### PR TITLE
added https feature

### DIFF
--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -34,7 +34,7 @@ type CappSpec struct {
 
 type RouteSpec struct {
 	Hostname string `json:"hostname,omitempty"`
-	HTTPS    bool   `json:"protocol,omitempty"`
+	Https    bool   `json:"https,omitempty"`
 	//TrafficTarget knativev1.TrafficTarget `json:"trafficTarget,omitempty"`
 }
 

--- a/config/crd/bases/rcs.dana.io_capps.yaml
+++ b/config/crd/bases/rcs.dana.io_capps.yaml
@@ -7828,7 +7828,7 @@ spec:
                 properties:
                   hostname:
                     type: string
-                  protocol:
+                  https:
                     type: boolean
                 type: object
               scaleMetric:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: sahar2339/capp-operator
-  newTag: v0.0.2
+  newName: controller
+  newTag: latest

--- a/internals/resource-managers/knative_domain_mapping.go
+++ b/internals/resource-managers/knative_domain_mapping.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	rcsv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	secure_utils "github.com/dana-team/container-app-operator/internals/utils/secure"
 	rclient "github.com/dana-team/container-app-operator/internals/wrappers"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -45,6 +46,8 @@ func (k KnativeDomainMappingManager) prepareResource(capp rcsv1alpha1.Capp) knat
 			},
 		},
 	}
+	resourceManager := rclient.ResourceBaseManager{Ctx: k.Ctx, K8sclient: k.K8sclient, Log: k.Log}
+	secure_utils.SetHttpsKnativeDomainMapping(capp, knativeDomainMapping, resourceManager)
 	return *knativeDomainMapping
 }
 
@@ -77,7 +80,7 @@ func (k KnativeDomainMappingManager) CreateOrUpdateObject(capp rcsv1alpha1.Capp)
 		}
 		return nil
 	}
-	if reflect.DeepEqual(knativeDomainMapping.Spec, knativeDomainMappingFromCapp.Spec) {
+	if !reflect.DeepEqual(knativeDomainMapping.Spec, knativeDomainMappingFromCapp.Spec) {
 		knativeDomainMapping.Spec = knativeDomainMappingFromCapp.Spec
 		if err := resourceManager.UpdateResource(&knativeDomainMapping); err != nil {
 			return err

--- a/internals/utils/secure/secure.go
+++ b/internals/utils/secure/secure.go
@@ -1,0 +1,30 @@
+package secure
+
+import (
+	rcsv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rclient "github.com/dana-team/container-app-operator/internals/wrappers"
+	knativev1alphav1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const TlsSecretPrefix = "secure-knativedm-"
+
+//  This function takes a Capp, Knative Domain Mapping and a ResourceBaseManager Client and sets the Knative Domain Mapping Tls based on the Capp's Https field.
+func SetHttpsKnativeDomainMapping(capp rcsv1alpha1.Capp, knativeDomainMapping *knativev1alphav1.DomainMapping, resourceManager rclient.ResourceBaseManager) {
+	isHttps := capp.Spec.RouteSpec.Https
+	if isHttps {
+		tlsSecret := corev1.Secret{}
+		if err := resourceManager.K8sclient.Get(resourceManager.Ctx, types.NamespacedName{Name: TlsSecretPrefix + capp.Name, Namespace: capp.Namespace}, &tlsSecret); err != nil {
+			if !errors.IsNotFound(err) {
+				resourceManager.Log.Error(err, "unable to get resource")
+			}
+		} else {
+			knativeDomainMapping.Spec.TLS = &knativev1alphav1.SecretTLS{
+				SecretName: TlsSecretPrefix + capp.Name,
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4. With this PR, We can support https for the shortened hostname. 
By adding Https:true to the RouteSpec the controller should inject secret to the tls option in the DomainMapping resource.