### PR TITLE
fix klusterlet-work-sa is missing permissions to list Capps.

### DIFF
--- a/config/rbac/klusterlet_work_sa_clusterrole.yaml
+++ b/config/rbac/klusterlet_work_sa_clusterrole.yaml
@@ -1,0 +1,37 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: klusterlet-work-sa-capp-target
+rules:
+  - verbs:
+      - create
+      - update
+      - patch
+      - delete
+      - get
+      - list
+      - watch
+    apiGroups:
+      - rcs.dana.io
+    resources:
+      - capps
+  - verbs:
+      - update
+    apiGroups:
+      - rcs.dana.io
+    resources:
+      - capps/finalizers
+  - verbs:
+      - get
+    apiGroups:
+      - rcs.dana.io
+    resources:
+      - capps/status
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - serving.knative.dev
+    resources:
+      - services

--- a/config/rbac/klusterlet_work_sa_clusterrole_binding.yaml
+++ b/config/rbac/klusterlet_work_sa_clusterrole_binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: klusterlet-work-sa-capp-target-binding
+subjects:
+  - kind: ServiceAccount
+    name: klusterlet-work-sa
+    namespace: open-cluster-management-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: klusterlet-work-sa-capp-target

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,5 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- klusterlet_work_sa_clusterrole.yaml
+- klusterlet_work_sa_clusterrole_binding.yaml


### PR DESCRIPTION
Fixes #14.
With this PR, now the klusterlet-work-sa  ServiceAccount has the permissions to list, watch and get Capps and Knative Services in the target cluster(managed).