### PR TITLE
Handle non-existing resource in CleanUp method

### DIFF
--- a/internals/resource-managers/flow.go
+++ b/internals/resource-managers/flow.go
@@ -66,6 +66,12 @@ func (f FlowManager) CleanUp(capp rcsv1alpha1.Capp) error {
 	flowName := capp.GetName() + "-flow"
 	resourceManager := rclient.ResourceBaseManager{Ctx: f.Ctx, K8sclient: f.K8sclient, Log: f.Log}
 	flow := loggingv1beta1.Flow{}
+	if err := f.K8sclient.Get(f.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: flowName}, &flow); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
 	if err := resourceManager.DeleteResource(&flow, flowName, capp.Namespace); err != nil {
 		return err
 	}

--- a/internals/resource-managers/output.go
+++ b/internals/resource-managers/output.go
@@ -133,6 +133,12 @@ func (o OutputManager) CleanUp(capp rcsv1alpha1.Capp) error {
 	outputName := capp.GetName() + "-output"
 	resourceManager := rclient.ResourceBaseManager{Ctx: o.Ctx, K8sclient: o.K8sclient, Log: o.Log}
 	output := loggingv1beta1.Output{}
+	if err := o.K8sclient.Get(o.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: outputName}, &output); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
 	if err := resourceManager.DeleteResource(&output, outputName, capp.Namespace); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #46. Add a check to verify the existence of the flow or output resource before deletion in the CleanUp method. If the resource does not exist, the CleanUp method returns early without attempting to delete it.