### PR TITLE
Syncing labels and annotations from Capp to KSVC

### DIFF
--- a/internals/utils/common.go
+++ b/internals/utils/common.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
@@ -22,4 +24,17 @@ func IsOnOpenshift(config *rest.Config) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// FilterKeysWithoutPrefix removes keys from a map if they don't start with a given prefix
+func FilterKeysWithoutPrefix(object map[string]string, prefix string) map[string]string {
+	result := make(map[string]string)
+
+	for key, value := range object {
+		if strings.HasPrefix(key, prefix) {
+			result[key] = value
+		}
+	}
+
+	return result
 }

--- a/internals/utils/utils_unit_test.go
+++ b/internals/utils/utils_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	rcsv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/dana-team/container-app-operator/internals/utils"
 	autoscale_utils "github.com/dana-team/container-app-operator/internals/utils/autoscale"
 	"github.com/dana-team/container-app-operator/internals/utils/finalizer"
 	"github.com/dana-team/container-app-operator/internals/utils/secure"
@@ -189,4 +190,19 @@ func TestRemoveFinalizer(t *testing.T) {
 
 	// Check if there is no error after the finalizer removed.
 	assert.NoError(t, finalizer.RemoveFinalizer(ctx, *capp, ctrl.Log, fakeClient))
+}
+
+func TestFilterKeysWithoutPrefix(t *testing.T) {
+	object := map[string]string{
+		"prefix_key1": "value1",
+		"key2":        "value2",
+		"prefix_key3": "value3",
+	}
+	prefix := "prefix_"
+	expected := map[string]string{
+		"prefix_key1": "value1",
+		"prefix_key3": "value3",
+	}
+
+	assert.Equal(t, expected, utils.FilterKeysWithoutPrefix(object, prefix))
 }


### PR DESCRIPTION
With these changes, the controller copies the annotations and labels with a unique prefix from the `Capp` to the `knativeService`.
