### PR TITLE
Add tls secret to Capp spec.

### DIFF
--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -57,6 +57,10 @@ type RouteSpec struct {
 	// +optional
 	TlsEnabled bool `json:"tlsEnabled,omitempty"`
 
+	// TlsSecret defines the name of the secret which holds the tls certification.
+	// +optional
+	TlsSecret string `json:"tlsSecret,omitempty"`
+
 	// TrafficTarget holds a single entry of the routing table for the Capp route.
 	// +optional
 	TrafficTarget knativev1.TrafficTarget `json:"trafficTarget,omitempty"`

--- a/config/crd/bases/rcs.dana.io_capps.yaml
+++ b/config/crd/bases/rcs.dana.io_capps.yaml
@@ -7983,6 +7983,10 @@ spec:
                     description: TlsEnabled determines whether to enable TLS for the
                       Capp route.
                     type: boolean
+                  tlsSecret:
+                    description: TlsSecret defines the name of the secret which holds
+                      the tls certification.
+                    type: string
                   trafficTarget:
                     description: TrafficTarget holds a single entry of the routing
                       table for the Capp route.

--- a/internals/utils/secure/secure.go
+++ b/internals/utils/secure/secure.go
@@ -12,22 +12,20 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-const TlsSecretPrefix = "secure-knativedm-"
-
 // SetHttpsKnativeDomainMapping takes a Capp, Knative Domain Mapping and a ResourceBaseManager Client and sets the Knative Domain Mapping Tls based on the Capp's Https field.
 func SetHttpsKnativeDomainMapping(capp rcsv1alpha1.Capp, knativeDomainMapping *knativev1alphav1.DomainMapping, resourceManager rclient.ResourceBaseManager) {
 	isHttps := capp.Spec.RouteSpec.TlsEnabled
 	if isHttps {
 		tlsSecret := corev1.Secret{}
-		if err := resourceManager.K8sclient.Get(resourceManager.Ctx, types.NamespacedName{Name: TlsSecretPrefix + capp.Name, Namespace: capp.Namespace}, &tlsSecret); err != nil {
+		if err := resourceManager.K8sclient.Get(resourceManager.Ctx, types.NamespacedName{Name: capp.Spec.RouteSpec.TlsSecret, Namespace: capp.Namespace}, &tlsSecret); err != nil {
 			if errors.IsNotFound(err) {
-				resourceManager.Log.Error(err, fmt.Sprintf("the tls secret %s for DomainMapping does not exist", TlsSecretPrefix+capp.Name))
+				resourceManager.Log.Error(err, fmt.Sprintf("the tls secret %s for DomainMapping does not exist", capp.Spec.RouteSpec.TlsSecret))
 				return
 			}
-			resourceManager.Log.Error(err, fmt.Sprintf("unable to get tls secret %s for DomainMapping", TlsSecretPrefix+capp.Name))
+			resourceManager.Log.Error(err, fmt.Sprintf("unable to get tls secret %s for DomainMapping", capp.Spec.RouteSpec.TlsSecret))
 		} else {
 			knativeDomainMapping.Spec.TLS = &knativev1alphav1.SecretTLS{
-				SecretName: TlsSecretPrefix + capp.Name,
+				SecretName: capp.Spec.RouteSpec.TlsSecret,
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #49.
With this PR, we can mention the tls secret's name in the capp spec.