### PR TITLE
Temporarily disable SSL verification

### DIFF
--- a/internals/resource-managers/output.go
+++ b/internals/resource-managers/output.go
@@ -13,15 +13,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"k8s.io/client-go/tools/record"
 )
 
 type OutputManager struct {
-	Ctx       context.Context
-	K8sclient client.Client
-	Log       logr.Logger
+	Ctx           context.Context
+	K8sclient     client.Client
+	Log           logr.Logger
 	EventRecorder record.EventRecorder
 }
 
@@ -42,6 +42,7 @@ const (
 // It constructs the Elasticsearch output which is returned as an OutputSpec.
 func createElasticsearchOutput(logSpec rcsv1alpha1.LogSpec) loggingv1beta1.OutputSpec {
 	protocol := "http"
+	falseVar := false
 	if logSpec.SSLVerify {
 		protocol = "https"
 	}
@@ -50,7 +51,7 @@ func createElasticsearchOutput(logSpec rcsv1alpha1.LogSpec) loggingv1beta1.Outpu
 			Host:       logSpec.Host,
 			Port:       ElasticPort,
 			Scheme:     protocol,
-			SslVerify:  &logSpec.SSLVerify,
+			SslVerify:  &falseVar,
 			SslVersion: ElasticSSLVersion,
 			User:       logSpec.UserName,
 			Password: &secret.Secret{

--- a/test/e2e/capp-Logging/00-deploy-capp-with-elastic-logs.yaml
+++ b/test/e2e/capp-Logging/00-deploy-capp-with-elastic-logs.yaml
@@ -40,19 +40,8 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: splunk-single-standalone-secrets
+  name: quickstart-es-elastic-user
   namespace: capp-tests
 data:
-  hec_token: ODVhZTc2YmYtYjYyMS00MDk5LWIyYzMtOGI5OTk3NTA0OTgy
-  password: QWExMjM0NTYh
-  username: bGFiZXI=
-type: Opaque
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: splunk-token
-  namespace: capp-tests
-data:
-  SplunkHecToken: ODVhZTc2YmYtYjYyMS00MDk5LWIyYzMtOGI5OTk3NTA0OTgy
+  elastic: K0ZZY0w2RjdEaWxMSEx0ZWpfRm0=
 type: Opaque

--- a/test/e2e/capp-Logging/01-deploy-capp-with-splunk-logs.yaml
+++ b/test/e2e/capp-Logging/01-deploy-capp-with-splunk-logs.yaml
@@ -39,8 +39,19 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: quickstart-es-elastic-user
+  name: splunk-single-standalone-secrets
   namespace: capp-tests
 data:
-  elastic: K0ZZY0w2RjdEaWxMSEx0ZWpfRm0=
+  hec_token: ODVhZTc2YmYtYjYyMS00MDk5LWIyYzMtOGI5OTk3NTA0OTgy
+  password: QWExMjM0NTYh
+  username: bGFiZXI=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: splunk-token
+  namespace: capp-tests
+data:
+  SplunkHecToken: ODVhZTc2YmYtYjYyMS00MDk5LWIyYzMtOGI5OTk3NTA0OTgy
 type: Opaque


### PR DESCRIPTION
This change temporarily disables SSL verification in the createElasticsearchOutput function. We are experiencing SSL verification issues while working within our network, and this adjustment will allow us to continue working until a proper SSL solution is implemented.

In addition, I also replaced the Elasticsearch and Splunk secrets. Previously, there was a mix-up where Splunk secrets were mistakenly created in the Elastic test environment, and Elastic secrets were mistakenly created in the Splunk test environment. This change fixes the issue by properly separating the creation of Elasticsearch and Splunk secrets, ensuring that they are in their respective environments.