### PR TITLE
Updated EventType handling

### DIFF
--- a/internals/resource-managers/flow.go
+++ b/internals/resource-managers/flow.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -103,11 +104,11 @@ func (f FlowManager) CreateOrUpdateObject(capp rcsv1alpha1.Capp) error {
 			logger.Info("didn't find flow")
 
 			if err := resourceManager.CreateResource(&generatedFlow); err != nil {
-				f.EventRecorder.Event(&capp, eventTypeError, eventCappFlowCreationFailed, fmt.Sprintf("Failed to create flow %s for Capp %s", flowName, capp.Name))
+				f.EventRecorder.Event(&capp, corev1.EventTypeWarning, eventCappFlowCreationFailed, fmt.Sprintf("Failed to create flow %s for Capp %s", flowName, capp.Name))
 				return fmt.Errorf("failed to create flow %s: %s", flowName, err.Error())
 			}
 			logger.Info("Created flow successfully")
-			f.EventRecorder.Event(&capp, eventTypeNormal, eventCappFlowCreated, fmt.Sprintf("Created flow %s for Capp %s", flowName, capp.Name))
+			f.EventRecorder.Event(&capp, corev1.EventTypeNormal, eventCappFlowCreated, fmt.Sprintf("Created flow %s for Capp %s", flowName, capp.Name))
 		case err != nil:
 			return fmt.Errorf("failed to fetch existing flow %s: %s", flowName, err.Error())
 		}

--- a/internals/resource-managers/knative_domain_mapping.go
+++ b/internals/resource-managers/knative_domain_mapping.go
@@ -3,23 +3,22 @@ package resourceprepares
 import (
 	"context"
 	"fmt"
-	"reflect"
-
 	rcsv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	secureutils "github.com/dana-team/container-app-operator/internals/utils/secure"
 	rclient "github.com/dana-team/container-app-operator/internals/wrappers"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/client-go/tools/record"
 )
 
 const CappResourceKey = "rcs.dana.io/parent-capp"
@@ -89,7 +88,7 @@ func (k KnativeDomainMappingManager) CreateOrUpdateObject(capp rcsv1alpha1.Capp)
 		if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Spec.RouteSpec.Hostname}, &knativeDomainMapping); err != nil {
 			if errors.IsNotFound(err) {
 				if err := resourceManager.CreateResource(&cappDomainMapping); err != nil {
-					k.EventRecorder.Event(&capp, eventTypeError, eventCappDomainMappingCreationFailed, fmt.Sprintf("Failed to create DomainMapping %s for Capp %s", capp.Spec.RouteSpec.Hostname, capp.Name))
+					k.EventRecorder.Event(&capp, corev1.EventTypeWarning, eventCappDomainMappingCreationFailed, fmt.Sprintf("Failed to create DomainMapping %s for Capp %s", capp.Spec.RouteSpec.Hostname, capp.Name))
 					return fmt.Errorf("unable to create DomainMapping: %s", err.Error())
 				}
 			} else {

--- a/internals/resource-managers/knative_service.go
+++ b/internals/resource-managers/knative_service.go
@@ -3,21 +3,19 @@ package resourceprepares
 import (
 	"context"
 	"fmt"
-	"reflect"
-
 	rcsv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/internals/utils"
-	autoscale_utils "github.com/dana-team/container-app-operator/internals/utils/autoscale"
+	autoscaleutils "github.com/dana-team/container-app-operator/internals/utils/autoscale"
 	rclient "github.com/dana-team/container-app-operator/internals/wrappers"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
-
 	"k8s.io/client-go/tools/record"
+	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -62,7 +60,7 @@ func (k KnativeServiceManager) prepareResource(capp rcsv1alpha1.Capp, ctx contex
 
 	knativeService.Spec.ConfigurationSpec.Template.Spec.TimeoutSeconds = capp.Spec.RouteSpec.RouteTimeoutSeconds
 	knativeService.Spec.Template.ObjectMeta.Annotations = utils.MergeMaps(knativeServiceAnnotations,
-		autoscale_utils.SetAutoScaler(capp))
+		autoscaleutils.SetAutoScaler(capp))
 	knativeService.Spec.Template.ObjectMeta.Labels = knativeServiceLabels
 	return knativeService
 }
@@ -103,7 +101,7 @@ func (k KnativeServiceManager) CreateOrUpdateObject(capp rcsv1alpha1.Capp) error
 	resourceManager := rclient.ResourceBaseManagerClient{Ctx: k.Ctx, K8sclient: k.K8sclient, Log: k.Log}
 	if !k.isRequired(capp) {
 		k.Log.Info("halting Capp")
-		k.EventRecorder.Event(&capp, eventTypeNormal, eventCappDisabled,
+		k.EventRecorder.Event(&capp, corev1.EventTypeNormal, eventCappDisabled,
 			fmt.Sprintf("Capp %s state changed to disabled", capp.Name))
 		return k.CleanUp(capp)
 	} else {
@@ -111,14 +109,14 @@ func (k KnativeServiceManager) CreateOrUpdateObject(capp rcsv1alpha1.Capp) error
 			&knativeService); err != nil {
 			if errors.IsNotFound(err) {
 				if err := resourceManager.CreateResource(&knativeServiceFromCapp); err != nil {
-					k.EventRecorder.Event(&capp, eventTypeError, eventCappKnativeServiceCreationFailed,
+					k.EventRecorder.Event(&capp, corev1.EventTypeWarning, eventCappKnativeServiceCreationFailed,
 						fmt.Sprintf("Failed to create KnativeService %s for Capp %s",
 							knativeService.Name, capp.Name))
 					return fmt.Errorf("unable to create KnativeService for Capp: %s", err.Error())
 				}
 				if k.isResumed(capp) {
 					k.Log.Info("Capp resumed")
-					k.EventRecorder.Event(&capp, eventTypeNormal, eventCappEnabled,
+					k.EventRecorder.Event(&capp, corev1.EventTypeNormal, eventCappEnabled,
 						fmt.Sprintf("Capp %s state changed to enabled", capp.Name))
 				}
 			} else {

--- a/internals/resource-managers/output.go
+++ b/internals/resource-managers/output.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,8 +56,8 @@ func createElasticsearchOutput(logSpec rcsv1alpha1.LogSpec) loggingv1beta1.Outpu
 			User:       logSpec.UserName,
 			Password: &secret.Secret{
 				ValueFrom: &secret.ValueFrom{
-					SecretKeyRef: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{Name: logSpec.PasswordSecretName},
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: logSpec.PasswordSecretName},
 						Key:                  "elastic",
 					},
 				},
@@ -88,8 +88,8 @@ func createSplunkHecOutput(logSpec rcsv1alpha1.LogSpec) loggingv1beta1.OutputSpe
 			InsecureSSL: &insecureSSL,
 			HecToken: &secret.Secret{
 				ValueFrom: &secret.ValueFrom{
-					SecretKeyRef: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{Name: logSpec.HecTokenSecretName},
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: logSpec.HecTokenSecretName},
 						Key:                  "SplunkHecToken",
 					},
 				},
@@ -169,11 +169,11 @@ func (o OutputManager) CreateOrUpdateObject(capp rcsv1alpha1.Capp) error {
 			logger.Error(err, "didn't find existing output")
 			if err := resourceManager.CreateResource(&generatedOutput); err != nil {
 				logger.Error(err, "failed to create output")
-				o.EventRecorder.Event(&capp, eventTypeError, eventCappOutputCreationFailed, fmt.Sprintf("Failed to create output %s for Capp %s", outputName, capp.Name))
+				o.EventRecorder.Event(&capp, corev1.EventTypeWarning, eventCappOutputCreationFailed, fmt.Sprintf("Failed to create output %s for Capp %s", outputName, capp.Name))
 				return err
 			}
 			logger.Info("Created output successfully")
-			o.EventRecorder.Event(&capp, eventTypeNormal, eventCappOutputCreated, fmt.Sprintf("Created output %s for Capp %s", outputName, capp.Name))
+			o.EventRecorder.Event(&capp, corev1.EventTypeNormal, eventCappOutputCreated, fmt.Sprintf("Created output %s for Capp %s", outputName, capp.Name))
 		case err != nil:
 			logger.Error(err, "failed to fetch existing output")
 			return err

--- a/internals/resource-managers/resource_prepare_interface.go
+++ b/internals/resource-managers/resource_prepare_interface.go
@@ -11,8 +11,6 @@ type ResourceManager interface {
 }
 
 const (
-	eventTypeNormal                       = "Normal"
-	eventTypeError                        = "Error"
 	eventCappFlowCreationFailed           = "FlowCreationFailed"
 	eventCappFlowCreated                  = "FlowCreated"
 	eventCappDomainMappingCreationFailed  = "DomainMappingCreationFailed"

--- a/internals/utils/secure/secure.go
+++ b/internals/utils/secure/secure.go
@@ -2,19 +2,16 @@ package secure
 
 import (
 	"fmt"
-
 	rcsv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	rclient "github.com/dana-team/container-app-operator/internals/wrappers"
-	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 const (
-	eventTypeWarning        = "Warning"
 	eventCappSecretNotFound = "SecretNotFound"
 )
 
@@ -26,7 +23,7 @@ func SetHttpsKnativeDomainMapping(capp rcsv1alpha1.Capp, knativeDomainMapping *k
 		if err := resourceManager.K8sclient.Get(resourceManager.Ctx, types.NamespacedName{Name: capp.Spec.RouteSpec.TlsSecret, Namespace: capp.Namespace}, &tlsSecret); err != nil {
 			if errors.IsNotFound(err) {
 				resourceManager.Log.Error(err, fmt.Sprintf("the tls secret %s for DomainMapping does not exist", capp.Spec.RouteSpec.TlsSecret))
-				eventRecorder.Event(&capp, eventTypeWarning, eventCappSecretNotFound, fmt.Sprintf("Secret %s for DomainMapping %s does not exist", capp.Spec.RouteSpec.TlsSecret, knativeDomainMapping.Name))
+				eventRecorder.Event(&capp, corev1.EventTypeWarning, eventCappSecretNotFound, fmt.Sprintf("Secret %s for DomainMapping %s does not exist", capp.Spec.RouteSpec.TlsSecret, knativeDomainMapping.Name))
 				return
 			}
 			resourceManager.Log.Error(err, fmt.Sprintf("unable to get tls secret %s for DomainMapping", capp.Spec.RouteSpec.TlsSecret))

--- a/internals/utils/utils_unit_test.go
+++ b/internals/utils/utils_unit_test.go
@@ -2,8 +2,6 @@ package utils_test
 
 import (
 	"context"
-	"testing"
-
 	rcsv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/internals/utils"
 	autoscaleutils "github.com/dana-team/container-app-operator/internals/utils/autoscale"
@@ -11,21 +9,20 @@ import (
 	"github.com/dana-team/container-app-operator/internals/utils/secure"
 	rclient "github.com/dana-team/container-app-operator/internals/wrappers"
 	networkingv1 "github.com/openshift/api/network/v1"
-	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/scale/scheme"
-	"k8s.io/client-go/tools/record"
-
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/scale/scheme"
+	"k8s.io/client-go/tools/record"
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
+	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
 )
 
 func newScheme() *runtime.Scheme {
@@ -46,7 +43,7 @@ func newFakeClient() client.Client {
 }
 
 func TestSetAutoScaler(t *testing.T) {
-	example_capp := rcsv1alpha1.Capp{
+	exampleCapp := rcsv1alpha1.Capp{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
@@ -55,22 +52,22 @@ func TestSetAutoScaler(t *testing.T) {
 			ScaleMetric: "cpu",
 		},
 	}
-	example_capp_cpu_expected := map[string]string{
+	exampleCappCpuExpected := map[string]string{
 		"autoscaling.knative.dev/class":  "hpa.autoscaling.knative.dev",
 		"autoscaling.knative.dev/metric": "cpu",
 		"autoscaling.knative.dev/target": "80",
 	}
-	annotations_cpu := autoscaleutils.SetAutoScaler(example_capp)
-	assert.Equal(t, example_capp_cpu_expected, annotations_cpu)
+	annotationsCpu := autoscaleutils.SetAutoScaler(exampleCapp)
+	assert.Equal(t, exampleCappCpuExpected, annotationsCpu)
 
-	example_capp.Spec.ScaleMetric = "rps"
-	example_capp_rps_expected := map[string]string{
+	exampleCapp.Spec.ScaleMetric = "rps"
+	exampleCappRpsExpected := map[string]string{
 		"autoscaling.knative.dev/class":  "kpa.autoscaling.knative.dev",
 		"autoscaling.knative.dev/metric": "rps",
 		"autoscaling.knative.dev/target": "200",
 	}
-	annotations_rps := autoscaleutils.SetAutoScaler(example_capp)
-	assert.Equal(t, example_capp_rps_expected, annotations_rps)
+	annotationsRps := autoscaleutils.SetAutoScaler(exampleCapp)
+	assert.Equal(t, exampleCappRpsExpected, annotationsRps)
 
 }
 

--- a/test/k8s_tests/utils/resources_adpater.go
+++ b/test/k8s_tests/utils/resources_adpater.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 	"math/rand"
@@ -64,7 +64,7 @@ func GetDomainMapping(k8sClient client.Client, name string, namespace string) *k
 }
 
 // CreateSecret creates a new secret.
-func CreateSecret(k8sClient client.Client, secret *v1.Secret) {
+func CreateSecret(k8sClient client.Client, secret *corev1.Secret) {
 	Expect(k8sClient.Create(context.Background(), secret)).To(Succeed())
 }
 
@@ -81,6 +81,6 @@ func GenerateSecretName() string {
 }
 
 // UpdateSecret updates an existing Secret instance.
-func UpdateSecret(k8sClient client.Client, secret *v1.Secret) {
+func UpdateSecret(k8sClient client.Client, secret *corev1.Secret) {
 	Expect(k8sClient.Update(context.Background(), secret)).To(Succeed())
 }

--- a/test/unit/utils_unit_test.go
+++ b/test/unit/utils_unit_test.go
@@ -2,15 +2,11 @@ package utils_test
 
 import (
 	"context"
-	"testing"
-
 	rcsv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/internals/utils"
 	autoscaleutils "github.com/dana-team/container-app-operator/internals/utils/autoscale"
 	"github.com/dana-team/container-app-operator/internals/utils/finalizer"
 	networkingv1 "github.com/openshift/api/network/v1"
-	knativev1alphav1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
-
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -19,9 +15,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/scale/scheme"
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
+	knativev1alphav1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
 )
 
 func newScheme() *runtime.Scheme {


### PR DESCRIPTION
Fixes #101.

- Changed every Error EventType to Warning as EventType can only be Normal or Warning.
- Replaced our EventType constants with corev1.EventTypeNormal and corev1.EventTypeWarning.
- Updated all instances of 'corev1' named 'v1' to 'corev1' for improved consistency in variable names.
- Converted snake_case variable names to camelCase.