### PR TITLE
fixed capp revisions bug

### DIFF
--- a/internals/status/knative.go
+++ b/internals/status/knative.go
@@ -28,6 +28,7 @@ func buildRevisionsStatus(ctx context.Context, capp rcsv1alpha1.Capp, r client.C
 
 	labelSelector := labels.NewSelector().Add(*requirement)
 	listOptions := client.ListOptions{
+		Namespace:     capp.Namespace,
 		LabelSelector: labelSelector,
 		Limit:         ClientListLimit,
 	}


### PR DESCRIPTION
Prior to this PR, the revisions status of Capp was built wrongly, taking into account all revisions of a given name instead of limiting the scope of the specific Capp namespace