### PR TITLE
fixed buggy behavior on CappRevision creation

### DIFF
--- a/api/v1alpha1/capprevision_types.go
+++ b/api/v1alpha1/capprevision_types.go
@@ -44,7 +44,7 @@ type CappTemplate struct {
 
 	// Annotations is a map of string keys and values which are the actual annotations of the related Capp
 	// +optional
-	Annotations map[string]string `json:"Annotations,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/rcs.dana.io_capprevisions.yaml
+++ b/config/crd/bases/rcs.dana.io_capprevisions.yaml
@@ -43,7 +43,7 @@ spec:
                 description: CappTemplate holds the manifest of a specific Capp corresponding
                   to a particular RevisionNumber
                 properties:
-                  Annotations:
+                  annotations:
                     additionalProperties:
                       type: string
                     description: Annotations is a map of string keys and values which


### PR DESCRIPTION
With this PR, the controller which creates CappRevisions is changed to not use predicate functions. Instead, the predicate logic has been moved to functions inside the controller. This was needed because unneeded CappRevisions where created on controller retarts, that's because controller-runtime generates a CREATE event on restart (when it puts the resource in the cache); this CREATE event is not the same as a CREATE event on the kube-apiserver (i.e. a new resource in the etcd). For more information, refer here - https://kubernetes.slack.com/archives/CAR30FCJZ/p1622991965433600?thread_ts=1622989881.429400&cid=CAR30FCJZ