### PR TITLE
make sure tlsSecret exists before setting it on DomainMapping

### DIFF
--- a/test/e2e_tests/helper.go
+++ b/test/e2e_tests/helper.go
@@ -5,6 +5,7 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	nfspvcv1alpha1 "github.com/dana-team/nfspvc-operator/api/v1alpha1"
 	dnsv1alpha1 "github.com/dana-team/provider-dns/apis/recordset/v1alpha1"
+	"github.com/go-logr/logr"
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -18,6 +19,7 @@ var (
 	k8sClient       client.Client
 	targetAutoScale map[string]string
 	scheme          = runtime.NewScheme()
+	logger          logr.Logger
 )
 
 func newScheme() *runtime.Scheme {

--- a/test/e2e_tests/knative_e2e_test.go
+++ b/test/e2e_tests/knative_e2e_test.go
@@ -14,7 +14,6 @@ import (
 
 // updateCapp updates the given Capp object and ensures the readiness of the latest revision
 // if shouldRevisionBeReady is true. It also checks and asserts the state of the LatestReadyRevision.
-
 func updateCapp(capp *cappv1alpha1.Capp, shouldRevisionBeReady bool) {
 	latestReadyRevisionBeforeUpdate := capp.Status.KnativeObjectStatus.ConfigurationStatusFields.LatestReadyRevisionName
 	nextRevisionName := utilst.GetNextRevisionName(latestReadyRevisionBeforeUpdate)


### PR DESCRIPTION
At times it can take a few seconds for the Certificate to become available and for the TLS Secret to actually exist. We don't want to set the TLS Secret on the DomainMapping before the secret actually exists since it emits redundant errors.