### PR TITLE
feat(api)!: remove tlsSecret api field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ spec:
   routeSpec:
     hostname: capp.dev
     tlsEnabled: true
-    tlsSecret: cappTlsSecretName
   volumesSpec:
     nfsVolumes:
       - server: test

--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -92,10 +92,6 @@ type RouteSpec struct {
 	// +optional
 	TlsEnabled bool `json:"tlsEnabled,omitempty"`
 
-	// TlsSecret defines the name of the secret which holds the tls certification.
-	// +optional
-	TlsSecret string `json:"tlsSecret,omitempty"`
-
 	// TrafficTarget holds a single entry of the routing table for the Capp route.
 	// +optional
 	TrafficTarget knativev1.TrafficTarget `json:"trafficTarget,omitempty"`

--- a/config/crd/bases/rcs.dana.io_capprevisions.yaml
+++ b/config/crd/bases/rcs.dana.io_capprevisions.yaml
@@ -7872,10 +7872,6 @@ spec:
                             description: TlsEnabled determines whether to enable TLS
                               for the Capp route.
                             type: boolean
-                          tlsSecret:
-                            description: TlsSecret defines the name of the secret
-                              which holds the tls certification.
-                            type: string
                           trafficTarget:
                             description: TrafficTarget holds a single entry of the
                               routing table for the Capp route.

--- a/config/crd/bases/rcs.dana.io_capps.yaml
+++ b/config/crd/bases/rcs.dana.io_capps.yaml
@@ -7678,10 +7678,6 @@ spec:
                     description: TlsEnabled determines whether to enable TLS for the
                       Capp route.
                     type: boolean
-                  tlsSecret:
-                    description: TlsSecret defines the name of the secret which holds
-                      the tls certification.
-                    type: string
                   trafficTarget:
                     description: TrafficTarget holds a single entry of the routing
                       table for the Capp route.

--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -42,6 +42,7 @@ func (c CertificateManager) prepareResource(capp cappv1alpha1.Capp) (certv1alpha
 		return certv1alpha1.Certificate{}, err
 	}
 	resourceName := utils.GenerateResourceName(capp.Spec.RouteSpec.Hostname, zone)
+	secretName := utils.GenerateSecretName(capp)
 
 	certificate := certv1alpha1.Certificate{
 		TypeMeta: metav1.TypeMeta{},
@@ -62,7 +63,7 @@ func (c CertificateManager) prepareResource(capp cappv1alpha1.Capp) (certv1alpha
 				},
 				Form: certificateForm,
 			},
-			SecretName: capp.Spec.RouteSpec.TlsSecret,
+			SecretName: secretName,
 			ConfigRef: certv1alpha1.ConfigReference{
 				Name: certificateConfig,
 			},

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -47,6 +47,7 @@ func (k KnativeDomainMappingManager) prepareResource(capp cappv1alpha1.Capp) (kn
 		return knativev1beta1.DomainMapping{}, err
 	}
 	resourceName := utils.GenerateResourceName(capp.Spec.RouteSpec.Hostname, zone)
+	secretName := utils.GenerateSecretName(capp)
 
 	knativeDomainMapping := &knativev1beta1.DomainMapping{
 		TypeMeta: metav1.TypeMeta{},
@@ -67,7 +68,7 @@ func (k KnativeDomainMappingManager) prepareResource(capp cappv1alpha1.Capp) (kn
 	}
 
 	if tlsEnabled := capp.Spec.RouteSpec.TlsEnabled; tlsEnabled {
-		if err := k.setHTTPSKnativeDomainMapping(capp.Spec.RouteSpec.TlsSecret, capp.Namespace, knativeDomainMapping); err != nil {
+		if err := k.setHTTPSKnativeDomainMapping(secretName, capp.Namespace, knativeDomainMapping); err != nil {
 			if !errors.IsNotFound(err) {
 				return *knativeDomainMapping, err
 			}

--- a/internal/kinds/capp/utils/utils.go
+++ b/internal/kinds/capp/utils/utils.go
@@ -1,7 +1,10 @@
 package utils
 
 import (
+	"fmt"
 	"strings"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -66,4 +69,9 @@ func FilterMap(originalMap map[string]string, substring string) map[string]strin
 		}
 	}
 	return filteredMap
+}
+
+// GenerateSecretName generates TLS secret name for certificate and domain mapping.
+func GenerateSecretName(capp cappv1alpha1.Capp) string {
+	return fmt.Sprintf("%s-tls", capp.Name)
 }

--- a/test/e2e_tests/certificate_e2e_test.go
+++ b/test/e2e_tests/certificate_e2e_test.go
@@ -12,7 +12,7 @@ import (
 var _ = Describe("Validate Certificate functionality", func() {
 	It("Should create, update and delete Certificate when creating, updating and deleting a Capp instance", func() {
 		By("Creating an HTTPS Capp")
-		createdCapp, routeHostname, _ := utilst.CreateHTTPSCapp(k8sClient)
+		createdCapp, routeHostname := utilst.CreateHTTPSCapp(k8sClient)
 
 		By("Checking if the Certificate was created successfully")
 		certificateName := utilst.GenerateResourceName(routeHostname, mock.ZoneValue)
@@ -67,7 +67,7 @@ var _ = Describe("Validate Certificate functionality", func() {
 
 	It("Should cleanup Certificate when no longer required (tls)", func() {
 		By("Creating an HTTPS Capp")
-		createdCapp, routeHostname, _ := utilst.CreateHTTPSCapp(k8sClient)
+		createdCapp, routeHostname := utilst.CreateHTTPSCapp(k8sClient)
 
 		By("Checking if the Certificate was created successfully")
 		certificateName := utilst.GenerateResourceName(routeHostname, mock.ZoneValue)
@@ -79,7 +79,6 @@ var _ = Describe("Validate Certificate functionality", func() {
 		By("Removing the Certificate requirement from Capp Spec and checking cleanup", func() {
 			toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			toBeUpdatedCapp.Spec.RouteSpec.TlsEnabled = false
-			toBeUpdatedCapp.Spec.RouteSpec.TlsSecret = ""
 			utilst.UpdateCapp(k8sClient, toBeUpdatedCapp)
 
 			Eventually(func() bool {
@@ -90,7 +89,7 @@ var _ = Describe("Validate Certificate functionality", func() {
 
 	It("Should cleanup Certificate when no longer required (hostname)", func() {
 		By("Creating an HTTPS Capp")
-		createdCapp, routeHostname, _ := utilst.CreateHTTPSCapp(k8sClient)
+		createdCapp, routeHostname := utilst.CreateHTTPSCapp(k8sClient)
 
 		By("Checking if the Certificate was created successfully")
 		certificateName := utilst.GenerateResourceName(routeHostname, mock.ZoneValue)

--- a/test/e2e_tests/domain_mapping_e2e_test.go
+++ b/test/e2e_tests/domain_mapping_e2e_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 		createdCapp, routeHostname := utilst.CreateCappWithHTTPHostname(k8sClient)
 
 		By("Making sure the tls secret exists in advance")
-		secretName := utilst.GenerateSecretName()
+		secretName := utilst.GenerateCertSecretName(createdCapp.Name)
 		secretObject := mock.CreateSecretObject(secretName)
 		utilst.CreateSecret(k8sClient, secretObject)
 		Eventually(func() bool {
@@ -78,7 +78,6 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 		By("Changing Capp to be HTTPS")
 		assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 		assertionCapp.Spec.RouteSpec.TlsEnabled = true
-		assertionCapp.Spec.RouteSpec.TlsSecret = secretName
 		utilst.UpdateCapp(k8sClient, assertionCapp)
 
 		By("Checking if the secret reference exists at the domainMapping")

--- a/test/e2e_tests/utils/resources_adpater.go
+++ b/test/e2e_tests/utils/resources_adpater.go
@@ -83,6 +83,11 @@ func GenerateSecretName() string {
 	return generateName(routeTLSSecret)
 }
 
+// GenerateCertSecretName generates a capp cert secret name.
+func GenerateCertSecretName(cappName string) string {
+	return fmt.Sprintf("%s-tls", cappName)
+}
+
 // UpdateSecret updates an existing Secret instance.
 func UpdateSecret(k8sClient client.Client, secret *corev1.Secret) {
 	Expect(k8sClient.Update(context.Background(), secret)).To(Succeed())

--- a/test/e2e_tests/utils/route_adapter.go
+++ b/test/e2e_tests/utils/route_adapter.go
@@ -24,16 +24,14 @@ func CreateCappWithHTTPHostname(k8sClient client.Client) (*cappv1alpha1.Capp, st
 }
 
 // CreateHTTPSCapp creates a Capp with a Hostname, TLS Enabled and TLSSecret.
-func CreateHTTPSCapp(k8sClient client.Client) (*cappv1alpha1.Capp, string, string) {
+func CreateHTTPSCapp(k8sClient client.Client) (*cappv1alpha1.Capp, string) {
 	httpsCapp := mock.CreateBaseCapp()
 	hostname := GenerateRouteHostname()
-	secretName := GenerateSecretName()
 
 	httpsCapp.Spec.RouteSpec.Hostname = hostname
-	httpsCapp.Spec.RouteSpec.TlsSecret = secretName
 	httpsCapp.Spec.RouteSpec.TlsEnabled = true
 
-	return CreateCapp(k8sClient, httpsCapp), hostname, secretName
+	return CreateCapp(k8sClient, httpsCapp), hostname
 }
 
 // GetDomainMapping fetches and returns an existing instance of a DomainMapping.


### PR DESCRIPTION
BREAKING CHANGE: With this PR, the `TlsSecret` api field has been removed as it is no longer necessary. The name of the secret containing the TLS cert is now `<capp-name>-tls`.