### PR TITLE
feat: improve CappRevision naming

### DIFF
--- a/internal/kinds/capprevision/controllers/controller.go
+++ b/internal/kinds/capprevision/controllers/controller.go
@@ -57,7 +57,7 @@ func (r *CappRevisionReconciler) Reconcile(ctx context.Context, req reconcile.Re
 		return ctrl.Result{}, nil
 	}
 	if err := syncCappRevision(ctx, r.Client, capp, logger); err != nil {
-		if errors.IsConflict(err) {
+		if errors.IsConflict(err) || errors.IsAlreadyExists(err) {
 			logger.Info(fmt.Sprintf("Conflict detected requeuing: %s", err.Error()))
 			return ctrl.Result{RequeueAfter: RequeueTime}, nil
 		}

--- a/test/e2e_tests/utils/capp_revision_adapter.go
+++ b/test/e2e_tests/utils/capp_revision_adapter.go
@@ -37,3 +37,10 @@ func GetCappRevisions(ctx context.Context, k8sClient client.Client, capp cappv1a
 	err = k8sClient.List(ctx, &cappRevisions, &listOptions)
 	return cappRevisions.Items, err
 }
+
+// GetCappRevision retrieves a CappRevision by name.
+func GetCappRevision(k8sClient client.Client, cappRevisionName, namespace string) *cappv1alpha1.CappRevision {
+	cappRevision := &cappv1alpha1.CappRevision{}
+	GetResource(k8sClient, cappRevision, cappRevisionName, namespace)
+	return cappRevision
+}


### PR DESCRIPTION
This pull request addresses the current `CappRevision` naming convention, which uses a random string. 

The format for `CappRevision` names has been updated to a fixed format similar to `Knative` Revisions: `cappName-number`. 
For example, names will now follow the format `test-00001`, `test-00002`, etc.