### PR TITLE
feat: rename tls Secret

### DIFF
--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -56,7 +56,7 @@ func (c CertificateManager) prepareResource(capp cappv1alpha1.Capp) (cmapi.Certi
 	}
 
 	resourceName := utils.GenerateResourceName(capp.Spec.RouteSpec.Hostname, zone)
-	secretName := utils.GenerateSecretName(capp)
+	secretName := utils.GenerateSecretName(resourceName)
 
 	certificate := cmapi.Certificate{
 		TypeMeta: metav1.TypeMeta{},

--- a/internal/kinds/capp/utils/utils.go
+++ b/internal/kinds/capp/utils/utils.go
@@ -85,8 +85,8 @@ func FilterMap(originalMap map[string]string, substring string) map[string]strin
 }
 
 // GenerateSecretName generates TLS secret name for certificate and domain mapping.
-func GenerateSecretName(capp cappv1alpha1.Capp) string {
-	return fmt.Sprintf("%s-tls", capp.Name)
+func GenerateSecretName(resourceName string) string {
+	return fmt.Sprintf("%s-tls", resourceName)
 }
 
 // GetListOptions returns a list option object from a given Set.

--- a/test/e2e_tests/domain_mapping_e2e_test.go
+++ b/test/e2e_tests/domain_mapping_e2e_test.go
@@ -78,7 +78,8 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 		createdCapp, routeHostname := utilst.CreateCappWithHTTPHostname(k8sClient)
 
 		By("Making sure the tls secret exists in advance")
-		secretName := utilst.GenerateCertSecretName(createdCapp.Name)
+		resourceName := utilst.GenerateResourceName(routeHostname, mocks.ZoneValue)
+		secretName := utilst.GenerateCertSecretName(resourceName)
 		secretObject := mocks.CreateSecretObject(secretName)
 		utilst.CreateSecret(k8sClient, secretObject)
 		Eventually(func() bool {

--- a/test/e2e_tests/utils/resources_adpater.go
+++ b/test/e2e_tests/utils/resources_adpater.go
@@ -91,8 +91,8 @@ func GenerateSecretName() string {
 }
 
 // GenerateCertSecretName generates a capp cert secret name.
-func GenerateCertSecretName(cappName string) string {
-	return fmt.Sprintf("%s-tls", cappName)
+func GenerateCertSecretName(hostname string) string {
+	return fmt.Sprintf("%s-tls", hostname)
 }
 
 // UpdateResource updates an existing resource.


### PR DESCRIPTION
the TLS secret for a capp will now be `<hostname>-tls` instead of `<capp>-tls`