### PR TITLE
helm: set default operator image values

### DIFF
--- a/charts/container-app-operator/values.yaml
+++ b/charts/container-app-operator/values.yaml
@@ -19,9 +19,9 @@ controllerManager:
 
     image:
       # -- Controller manager container image repository.
-      repository: controller
+      repository: ghcr.io/dana-team/container-app-operator
       # -- Controller manager container image tag.
-      tag: latest
+      tag: main
       # -- Controller manager container image pull policy.
       imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
Provide a default container-app-operator image repository and tag in values.yaml so the Helm chart can be installed without explicitly setting image values, while still allowing overrides when needed.