### PR TITLE
fix: stop waiting for Knative readiness in CreateCapp

### DIFF
--- a/test/e2e_tests/domain_mapping_e2e_test.go
+++ b/test/e2e_tests/domain_mapping_e2e_test.go
@@ -114,6 +114,9 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 		By("Checking if the RouteStatus of the Capp was updated successfully")
 		Eventually(func() string {
 			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			if capp.Status.RouteStatus.DomainMappingObjectStatus.URL == nil {
+				return ""
+			}
 			return capp.Status.RouteStatus.DomainMappingObjectStatus.URL.Host
 		}, testconsts.Timeout, testconsts.Interval).Should(Equal(domainMappingName), "Should update Route Status of Capp")
 

--- a/test/e2e_tests/knative_e2e_test.go
+++ b/test/e2e_tests/knative_e2e_test.go
@@ -294,6 +294,11 @@ var _ = Describe("Validate knative functionality", func() {
 		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
 		assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 
+		Eventually(func() string {
+			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			return capp.Status.KnativeObjectStatus.LatestReadyRevisionName
+		}, testconsts.Timeout, testconsts.Interval).ShouldNot(BeEmpty())
+
 		By("Updating capp's container image")
 		var latestReadyRevisionBeforeUpdate string
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/test/e2e_tests/logger_e2e_test.go
+++ b/test/e2e_tests/logger_e2e_test.go
@@ -45,6 +45,9 @@ func testCappWithLogger(logType string) {
 		syslogNGOutput := &loggingv1beta1.SyslogNGOutput{}
 		Eventually(func() bool {
 			syslogNGOutput = utilst.GetSyslogNGOutput(k8sClient, syslogNGOutputName, createdCapp.Namespace)
+			if syslogNGOutput.Status.Active == nil {
+				return false
+			}
 			return *syslogNGOutput.Status.Active
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
 
@@ -72,6 +75,9 @@ func testCappWithLogger(logType string) {
 
 		Eventually(func() bool {
 			syslogNGFlow := utilst.GetSyslogNGFlow(k8sClient, syslogNGFlowName, createdCapp.Namespace)
+			if syslogNGFlow.Status.Active == nil {
+				return false
+			}
 			return *syslogNGFlow.Status.Active
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
 

--- a/test/e2e_tests/utils/capp_adapter.go
+++ b/test/e2e_tests/utils/capp_adapter.go
@@ -16,10 +16,11 @@ func CreateCapp(k8sClient client.Client, capp *cappv1alpha1.Capp) *cappv1alpha1.
 	newCapp := capp.DeepCopy()
 	newCapp.Name = cappName
 	Expect(k8sClient.Create(context.Background(), newCapp)).To(Succeed())
-	Eventually(func() string {
-		result := GetCapp(k8sClient, newCapp.Name, newCapp.Namespace)
-		return result.Status.KnativeObjectStatus.ConfigurationStatusFields.LatestReadyRevisionName
-	}, testconsts.TimeoutCapp, testconsts.Interval).ShouldNot(Equal(""), "Should fetch capp")
+
+	Eventually(func() bool {
+		return DoesResourceExist(k8sClient, newCapp)
+	}, testconsts.Timeout, testconsts.Interval).Should(BeTrue(), "Capp should exist")
+
 	return newCapp
 }
 


### PR DESCRIPTION
Remove the readiness wait from CreateCapp so it only ensures the Capp resource exists. Tests that need Knative/revision readiness already have their own Eventually checks, so the shared wait was redundant and flaky.

After removing the global readiness wait, some e2e tests started running earlier in the reconciliation cycle and hit legitimate nil status fields which caused panics on direct dereference. Update those tests to handle the intermediate nil state while still asserting the same eventual behavior.

Also fix the "non existing image" knative e2e test: after removing the readiness wait from CreateCapp it captured an empty LatestReadyRevisionName as the "before" value, so the assertion that the ready revision does not move started failing. The test now explicitly waits for a non-empty LatestReadyRevisionName before taking that snapshot.