### PR TITLE
fix: remove e2e tests that assert Knative readiness for invalid image/secret

### DIFF
--- a/test/e2e_tests/capp_e2e_test.go
+++ b/test/e2e_tests/capp_e2e_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Validate capp creation", func() {
 
 		By("Checking if the revision is ready")
 		revisionName := createdCapp.Name + testconsts.FirstRevisionSuffix
-		checkRevisionReadiness(revisionName, true)
+		checkRevisionReadiness(revisionName)
 
 		By("Updating the capp status to be disabled")
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -115,7 +115,7 @@ var _ = Describe("Validate capp creation", func() {
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking if the revision is ready")
-		checkRevisionReadiness(revisionName, true)
+		checkRevisionReadiness(revisionName)
 	})
 
 	It("Should create a Capp with a Kafka source", func() {

--- a/test/e2e_tests/testconsts/testconsts.go
+++ b/test/e2e_tests/testconsts/testconsts.go
@@ -21,7 +21,6 @@ const (
 	DisabledState                   = "disabled"
 	KnativeMetricAnnotation         = "autoscaling.knative.dev/metric"
 	ImageExample                    = "danateam/autoscale-go"
-	NonExistingImageExample         = "example-python-app:v1"
 	ExampleAppName                  = "new-app-name"
 	NewSecretKey                    = "username"
 	ExampleDanaAnnotation           = "rcs.dana.io/app-name"


### PR DESCRIPTION
fix: remove e2e tests that assert Knative readiness for invalid image/secret
    
    Remove the following e2e tests from knative_e2e_test.go:
    
    - "Should create not ready revision when attempting to update to non existing image"
    - "Should create not ready revision when attempting to update to non existing secret"
    
    These tests only assert that the Knative Revision created for an invalid image/secret never becomes Ready
    (checkRevisionReadiness(..., false) → IsReady() must stay false). This behavior is entirely owned by
    Knative and depends on its version and cluster configuration.
    
    Because these specs are effectively testing Knative internals rather than a stable Capp contract, and
    are already broken on our current Knative, we remove them from the operator e2e suite.