### PR TITLE
fix: reduce knative image update conflict flakiness

### DIFF
--- a/test/e2e_tests/knative_e2e_test.go
+++ b/test/e2e_tests/knative_e2e_test.go
@@ -159,7 +159,9 @@ var _ = Describe("Validate knative functionality", func() {
 
 		By("Updating capp's container image")
 		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		backoff := retry.DefaultRetry
+		backoff.Steps = 10
+		err := retry.RetryOnConflict(backoff, func() error {
 			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 


### PR DESCRIPTION
The knative e2e test updating a Capp container image sometimes failed with 409 conflict errors due to concurrent controller status updates. Increase RetryOnConflict steps from the default to 10 in this test, giving more chances to reapply the update without introducing significant delay.