### PR TITLE
ci: improve caching for tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,9 +16,20 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Cache Go tools (bin/)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./bin
+          key: ${{ runner.os }}-tools-${{ hashFiles('Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-tools-
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Run vet
         run: go vet ./...

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,10 +13,21 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4.2.2
 
+    - name: Cache Go tools (bin/)
+      uses: actions/cache@v4
+      with:
+        path: |
+          ./bin
+        key: ${{ runner.os }}-tools-${{ hashFiles('Makefile') }}
+        restore-keys: |
+          ${{ runner.os }}-tools-
+
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
+        cache: true
+        cache-dependency-path: go.sum
 
     - name: Run unit-tests
       run: make test
@@ -29,14 +40,26 @@ jobs:
       IMAGE_REGISTRY: kind-registry:5000
       KIND_VERSION: v0.25.0
       K8S_VERSION: v1.30.4
+      IMAGE_TAG: test-${{ github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
+
+      - name: Cache Go tools (bin/)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./bin
+          key: ${{ runner.os }}-tools-${{ hashFiles('Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-tools-
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Start kind cluster
         uses: container-tools/kind-action@v2
@@ -47,14 +70,27 @@ jobs:
           kubectl_version: ${{env.K8S_VERSION}}
           registry: true
 
-      - name: Build container-app image
-        run: make docker-build docker-push IMG=${IMAGE_REGISTRY}/container-app-operator:test-${GITHUB_REF##*/}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and load container-app image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: |
+            container-app-operator:${{ env.IMAGE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Load image into kind cluster
+        run: kind load docker-image container-app-operator:${IMAGE_TAG} --name hub
 
       - name: Setup prerequisites
         run: make prereq
 
       - name: Deploy controller to cluster
-        run: make install deploy IMG=${IMAGE_REGISTRY}/container-app-operator:test-${GITHUB_REF##*/}
+        run: make install deploy IMG=container-app-operator:${IMAGE_TAG}
 
       - name: Create CappConfig
         run: make create-cappConfig


### PR DESCRIPTION
Optimize CI workflows by adding and refining caching:

- Enable Go module and build cache via actions/setup-go
- Cache tool binaries in ./bin across jobs with actions/cache
- Use docker/build-push-action with GHA cache for the e2e image build
- Load the built e2e image directly into the kind cluster instead of pushing to a registry

These caching changes reduced overall PR workflow time by ~35–40%, unit-test duration by ~75%, and e2e-tests duration by ~35–40%.