### PR TITLE
test: share retry backoff helper and fix e2e conflict flakiness

### DIFF
--- a/test/e2e_tests/capp_e2e_test.go
+++ b/test/e2e_tests/capp_e2e_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Validate capp creation", func() {
 		Expect(assertionCapp.Name).ShouldNot(Equal(baseCapp.Name))
 
 		By("Checks if Capp updated successfully")
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			assertionCapp := utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 			assertionCapp.Spec.ScaleMetric = testconsts.RPSScaleMetric
 
@@ -77,7 +77,7 @@ var _ = Describe("Validate capp creation", func() {
 		checkRevisionReadiness(revisionName)
 
 		By("Updating the capp status to be disabled")
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			assertionCapp.Spec.State = testconsts.DisabledState
 
@@ -101,7 +101,7 @@ var _ = Describe("Validate capp creation", func() {
 		}, testconsts.Timeout, testconsts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Updating the capp status to be enabled")
-		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err = retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			assertionCapp.Spec.State = testconsts.EnabledState
 

--- a/test/e2e_tests/capp_revision_e2e_test.go
+++ b/test/e2e_tests/capp_revision_e2e_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Validate CappRevision creation", func() {
 		utilst.GetCappRevision(k8sClient, cappRevisionName, desiredCapp.Namespace)
 
 		By("Updating Capp")
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			desiredCapp = utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 			desiredCapp.Annotations = make(map[string]string)
 			desiredCapp.Annotations["test"] = "test"
@@ -72,7 +72,7 @@ var _ = Describe("Validate CappRevision creation", func() {
 		By("Checking many updates to Capp")
 		for i := 1; i < moreThanRevisionsToKeep; i++ {
 			assertValue := fmt.Sprintf("test%s", strconv.Itoa(i))
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 				desiredCapp = utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 				desiredCapp.Annotations = make(map[string]string)
 				desiredCapp.Annotations["test"] = assertValue

--- a/test/e2e_tests/certificate_e2e_test.go
+++ b/test/e2e_tests/certificate_e2e_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Validate Certificate functionality", func() {
 		var toBeUpdatedCapp *cappv1alpha1.Capp
 		updatedRouteHostname := utilst.GenerateResourceName(utilst.GenerateRouteHostname(), testconsts.ZoneValue)
 
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp = utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			toBeUpdatedCapp.Spec.RouteSpec.Hostname = updatedRouteHostname
 
@@ -89,7 +89,7 @@ var _ = Describe("Validate Certificate functionality", func() {
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Removing the Certificate requirement from Capp Spec and checking cleanup", func() {
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 				toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 				toBeUpdatedCapp.Spec.RouteSpec.TlsEnabled = false
 
@@ -115,7 +115,7 @@ var _ = Describe("Validate Certificate functionality", func() {
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Removing the Certificate requirement from Capp Spec and checking cleanup", func() {
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 				toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 				toBeUpdatedCapp.Spec.RouteSpec.Hostname = ""
 

--- a/test/e2e_tests/dnsrecord_e2e_test.go
+++ b/test/e2e_tests/dnsrecord_e2e_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Validate DNSRecord functionality", func() {
 		By("checking if the DNSRecord object was updated after changing the Capp Route Hostname")
 		updatedRouteHostname := utilst.GenerateRouteHostname()
 
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			toBeUpdatedCapp.Spec.RouteSpec.Hostname = updatedRouteHostname
 
@@ -70,7 +70,7 @@ var _ = Describe("Validate DNSRecord functionality", func() {
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Removing the DNSRecord requirement from Capp Spec and checking cleanup", func() {
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 				toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 				toBeUpdatedCapp.Spec.RouteSpec.Hostname = ""
 

--- a/test/e2e_tests/domain_mapping_e2e_test.go
+++ b/test/e2e_tests/domain_mapping_e2e_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 
 		By("Updating the Capp Route hostname and checking the status")
 		updatedRouteHostname := utilst.GenerateResourceName(utilst.GenerateRouteHostname(), testconsts.ZoneValue)
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			toBeUpdatedCapp.Spec.RouteSpec.Hostname = updatedRouteHostname
 
@@ -87,7 +87,7 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Changing Capp to be HTTPS")
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			assertionCapp.Spec.RouteSpec.TlsEnabled = true
 
@@ -121,7 +121,7 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 		}, testconsts.Timeout, testconsts.Interval).Should(Equal(domainMappingName), "Should update Route Status of Capp")
 
 		By("Removing the Route from the Capp and check the status and resource clean up")
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			toBeUpdatedCapp.Spec.RouteSpec = cappv1alpha1.RouteSpec{}
 

--- a/test/e2e_tests/knative_e2e_test.go
+++ b/test/e2e_tests/knative_e2e_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Validate knative functionality", func() {
 
 		By("Updating the Capp scale metric")
 		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 
@@ -134,7 +134,7 @@ var _ = Describe("Validate knative functionality", func() {
 
 		By("Updating the a capp container name")
 		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 
@@ -159,9 +159,7 @@ var _ = Describe("Validate knative functionality", func() {
 
 		By("Updating capp's container image")
 		var latestReadyRevisionBeforeUpdate string
-		backoff := retry.DefaultRetry
-		backoff.Steps = 10
-		err := retry.RetryOnConflict(backoff, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 
@@ -189,7 +187,7 @@ var _ = Describe("Validate knative functionality", func() {
 		cappAnnotations[testconsts.ExampleDanaAnnotation] = testconsts.ExampleAppName
 
 		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 
@@ -214,7 +212,7 @@ var _ = Describe("Validate knative functionality", func() {
 
 		By("Updating capp's container environment variable")
 		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 
@@ -247,7 +245,7 @@ var _ = Describe("Validate knative functionality", func() {
 		checkRevisionReadiness(assertionCapp.Name + testconsts.FirstRevisionSuffix)
 
 		By("Updating the secret")
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			secretObject := utilst.GetSecret(k8sClient, secretObject.Name, secretObject.Namespace)
 			secretObject.Data = map[string][]byte{testconsts.NewSecretKey: []byte(testconsts.SecretValue)}
 
@@ -257,7 +255,7 @@ var _ = Describe("Validate knative functionality", func() {
 
 		By("Updating the capp secret environment variable")
 		var latestReadyRevisionBeforeUpdate string
-		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err = retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 

--- a/test/e2e_tests/logger_e2e_test.go
+++ b/test/e2e_tests/logger_e2e_test.go
@@ -82,7 +82,7 @@ func testCappWithLogger(logType string) {
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
 
 		By(fmt.Sprintf("Updating the capp %s logger index", logType))
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			toBeUpdatedCapp.Spec.LogSpec.Index = testconsts.TestIndex
 
@@ -130,7 +130,7 @@ func testCappWithLogger(logType string) {
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Removing the logging requirement from Capp Spec and checking cleanup")
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			toBeUpdatedCapp.Spec.LogSpec = cappv1alpha1.LogSpec{}
 

--- a/test/e2e_tests/mutating_e2e_test.go
+++ b/test/e2e_tests/mutating_e2e_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Validate the mutating webhook", func() {
 
 		utilst.SwitchUser(&k8sClient, cfg, testconsts.NSName, newScheme(), testconsts.ServiceAccountName)
 
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			capp = utilst.GetCapp(k8sClient, capp.Name, capp.Namespace)
 			if capp.ObjectMeta.Annotations == nil {
 				capp.ObjectMeta.Annotations = map[string]string{}

--- a/test/e2e_tests/testconsts/testconsts.go
+++ b/test/e2e_tests/testconsts/testconsts.go
@@ -12,6 +12,7 @@ const (
 	Interval                        = 2 * time.Second
 	DefaultEventually               = 2 * time.Second
 	DefaultConsistently             = 30 * time.Second
+	RetryOnConflictSteps            = 10
 	ClientListLimit                 = 100
 	CappKey                         = "capp"
 	Charset                         = "abcdefghijklmnopqrstuvwxyz0123456789"

--- a/test/e2e_tests/utils/resources_adpater.go
+++ b/test/e2e_tests/utils/resources_adpater.go
@@ -14,6 +14,8 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -103,4 +105,11 @@ func CreateSecret(k8sClient client.Client, secret *corev1.Secret) {
 func CreateCappConfig(k8sClient client.Client, cappConfig *cappv1alpha1.CappConfig) *cappv1alpha1.CappConfig {
 	Expect(k8sClient.Create(context.Background(), cappConfig)).To(Succeed())
 	return cappConfig
+}
+
+// NewRetryOnConflictBackoff returns a preconfigured backoff for RetryOnConflict.
+func NewRetryOnConflictBackoff() wait.Backoff {
+	b := retry.DefaultRetry
+	b.Steps = testconsts.RetryOnConflictSteps
+	return b
 }

--- a/test/e2e_tests/validating_e2e_test.go
+++ b/test/e2e_tests/validating_e2e_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Validate the validating webhook", func() {
 		baseCapp.Spec.RouteSpec.Hostname = validHostName
 		Expect(k8sClient.Create(context.Background(), baseCapp)).Should(Succeed())
 
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
 			cappInCluster := cappv1alpha1.Capp{}
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: baseCapp.Name, Namespace: baseCapp.Namespace}, &cappInCluster); err != nil {
 				return err


### PR DESCRIPTION
- Add RetryOnConflictSteps constant for e2e tests
- Introduce utilst.NewRetryOnConflictBackoff() to centralize RetryOnConflict backoff config
- Refactor all e2e tests to use the shared backoff helper instead of ad‑hoc setup