### PR TITLE
ci: run e2e ginkgo tests with 8 parallel processes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
+      E2E_GINKGO_PROCS: 8
       IMAGE_REGISTRY: kind-registry:5000
       KIND_VERSION: v0.25.0
       K8S_VERSION: v1.30.4


### PR DESCRIPTION
Set E2E_GINKGO_PROCS=8 in the GitHub Actions e2e-tests job so that `make test-e2e` runs Ginkgo with 8 parallel processes in CI.
This reduces the duration of the "Run e2e tests" step by about 50%.