### PR TITLE
test: speed up e2e teardown in CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
+      E2E_SKIP_CLEANUP: "true"
       E2E_GINKGO_PROCS: 8
       IMAGE_REGISTRY: kind-registry:5000
       KIND_VERSION: v0.25.0

--- a/test/e2e_tests/suite_test.go
+++ b/test/e2e_tests/suite_test.go
@@ -2,6 +2,7 @@ package e2e_tests
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +39,11 @@ var _ = SynchronizedBeforeSuite(func() {
 var _ = SynchronizedAfterSuite(func() {}, func() {
 	utilst.DeleteTestUser(k8sClient, testconsts.NSName)
 	utilst.DeleteExcludedServiceAccount(k8sClient)
+
+	if os.Getenv("E2E_SKIP_CLEANUP") == "true" {
+		return
+	}
+
 	cleanUp()
 })
 


### PR DESCRIPTION
Skip namespace cleanup in SynchronizedAfterSuite when E2E_SKIP_CLEANUP=true and enable this env var in the PR e2e workflow.
This reduces the e2e job runtime by about 2 minutes.