### PR TITLE
test: reduce Consistently duration in e2e tests

### DIFF
--- a/test/e2e_tests/testconsts/testconsts.go
+++ b/test/e2e_tests/testconsts/testconsts.go
@@ -11,7 +11,7 @@ const (
 	TimeoutCapp                     = 90 * time.Second
 	Interval                        = 2 * time.Second
 	DefaultEventually               = 2 * time.Second
-	DefaultConsistently             = 30 * time.Second
+	DefaultConsistently             = 10 * time.Second
 	RetryOnConflictSteps            = 10
 	ClientListLimit                 = 100
 	CappKey                         = "capp"


### PR DESCRIPTION
Lower DefaultConsistently from 30s to 10s.
Affects negative/stability checks in certificate and knative e2e tests. Cuts those specs from ~30–32s to ~10s each without weakening coverage.