### PR TITLE
ci: simplify Go tools cache step names

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.1
 
-      - name: Cache Go tools (bin/)
+      - name: Cache Go tools
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6.0.1
 
-    - name: Cache Go tools (bin/)
+    - name: Cache Go tools
       uses: actions/cache@v4
       with:
         path: |
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.1
 
-      - name: Cache Go tools (bin/)
+      - name: Cache Go tools
         uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
Update cache step names from Cache Go tools (bin/) to Cache Go tools.