### PR TITLE
ci: use minimal buildx cache export to speed up first runs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -73,7 +73,7 @@ jobs:
           tags: |
             container-app-operator:${{ env.IMAGE_TAG }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: Start kind cluster
         uses: container-tools/kind-action@v2


### PR DESCRIPTION
Switch cache-to from mode=max to mode=min so we export a much