### PR TITLE
ci: reorder e2e workflow to build before kind

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,6 +61,19 @@ jobs:
           go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build container-app image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: |
+            container-app-operator:${{ env.IMAGE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Start kind cluster
         uses: container-tools/kind-action@v2
@@ -70,19 +83,6 @@ jobs:
           node_image: kindest/node:${{env.K8S_VERSION}}
           kubectl_version: ${{env.K8S_VERSION}}
           registry: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and load container-app image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          load: true
-          tags: |
-            container-app-operator:${{ env.IMAGE_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Load image into kind cluster
         run: kind load docker-image container-app-operator:${IMAGE_TAG} --name hub


### PR DESCRIPTION
Run Docker Buildx setup and image build before creating the kind cluster in the e2e job. This makes the pipeline fail fast on image build errors before paying the cost of kind startup and prerequisites installation.