### PR TITLE
ci: add prereq-ci target and speed up e2e prereqs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -88,7 +88,7 @@ jobs:
         run: kind load docker-image container-app-operator:${IMAGE_TAG} --name hub
 
       - name: Setup prerequisites
-        run: make prereq
+        run: make prereq-ci
 
       - name: Deploy controller to cluster
         run: make install deploy IMG=container-app-operator:${IMAGE_TAG}

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,11 @@ KNATIVE_HPA_URL ?= https://github.com/knative/serving/releases/download/knative-
 CROSSPLANE_SCC_CRB ?= hack/crossplane-scc-clusterrolebinding.yaml
 PREREQ_HELMFILE ?= charts/capp-prereq-helmfile.yaml
 
+.PHONY: prereq-ci
+prereq-ci:
+	$(MAKE) -j 3 install install-knative install-prereq-helmfile
+	$(MAKE) enable-nfs-knative
+
 .PHONY: prereq ## Install every prerequisite needed to develop and run the operator.
 prereq: install install-knative enable-nfs-knative install-prereq-helmfile
 


### PR DESCRIPTION
Add prereq-ci target that runs install, install-knative, and install-prereq-helmfile in parallel.
Update PR workflow to call prereq-ci for e2e tests.