### PR TITLE
capp: remove redundant spec.site field

### DIFF
--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -41,12 +41,6 @@ type CappSpec struct {
 	// +kubebuilder:default:="concurrency"
 	// +kubebuilder:validation:Enum=cpu;memory;rps;concurrency
 	ScaleMetric string `json:"scaleMetric,omitempty"`
-
-	// Site defines where to deploy the Capp.
-	// It can be a specific cluster or a placement name.
-	// +optional
-	Site string `json:"site,omitempty"`
-
 	// State defines the state of capp
 	// Possible values examples: "enabled", "disabled".
 	// +optional

--- a/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
@@ -8845,11 +8845,6 @@ spec:
                             - rps
                             - concurrency
                           type: string
-                        site:
-                          description: |-
-                            Site defines where to deploy the Capp.
-                            It can be a specific cluster or a placement name.
-                          type: string
                         sources:
                           description: Sources define the configuration and status of
                             event sources

--- a/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
@@ -8658,11 +8658,6 @@ spec:
                     - rps
                     - concurrency
                   type: string
-                site:
-                  description: |-
-                    Site defines where to deploy the Capp.
-                    It can be a specific cluster or a placement name.
-                  type: string
                 sources:
                   description: Sources define the configuration and status of event
                     sources

--- a/config/crd/bases/rcs.dana.io_capprevisions.yaml
+++ b/config/crd/bases/rcs.dana.io_capprevisions.yaml
@@ -8845,11 +8845,6 @@ spec:
                         - rps
                         - concurrency
                         type: string
-                      site:
-                        description: |-
-                          Site defines where to deploy the Capp.
-                          It can be a specific cluster or a placement name.
-                        type: string
                       sources:
                         description: Sources define the configuration and status of
                           event sources

--- a/config/crd/bases/rcs.dana.io_capps.yaml
+++ b/config/crd/bases/rcs.dana.io_capps.yaml
@@ -8658,11 +8658,6 @@ spec:
                 - rps
                 - concurrency
                 type: string
-              site:
-                description: |-
-                  Site defines where to deploy the Capp.
-                  It can be a specific cluster or a placement name.
-                type: string
               sources:
                 description: Sources define the configuration and status of event
                   sources


### PR DESCRIPTION
Drop spec.site from CappSpec since it is unused and redundant with status. Regenerate CRDs and Helm chart CRDs.