### PR TITLE
docs(examples): add user-friendly CR examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Examples
+
+This folder contains **user-friendly** `Capp` custom resource examples. Each folder shows a small, focused setup (sometimes combining a couple of related fields):
+
+- **Route**: custom hostname + TLS
+- **Logs**: ship logs to Elasticsearch
+- **Volume**: NFS volume + scale metric
+
+

--- a/examples/logs/capp-logs-elastic.yaml
+++ b/examples/logs/capp-logs-elastic.yaml
@@ -1,0 +1,22 @@
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: hello-logs
+  namespace: capp-examples
+spec:
+  configurationSpec:
+    template:
+      spec:
+        containers:
+          - name: app
+            image: ghcr.io/dana-team/capp-gin-app:v0.2.0
+            env:
+              - name: APP_NAME
+                value: hello-logs
+
+  logSpec:
+    type: elastic
+    host: "https://elasticsearch.example.com:9200"
+    index: "capp-logs"
+    user: "elastic"
+    passwordSecret: "capp-elastic-credentials"

--- a/examples/logs/elasticsearch-secret.yaml
+++ b/examples/logs/elasticsearch-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capp-elastic-credentials
+  namespace: capp-examples
+type: Opaque
+stringData:
+  elastic: changeme

--- a/examples/route/capp-route.yaml
+++ b/examples/route/capp-route.yaml
@@ -1,0 +1,22 @@
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: hello-route
+  namespace: capp-examples
+spec:
+  configurationSpec:
+    template:
+      spec:
+        containers:
+          - name: app
+            image: ghcr.io/dana-team/capp-gin-app:v0.2.0
+            env:
+              - name: APP_NAME
+                value: hello-route
+
+  routeSpec:
+    hostname: hello-route.example.com
+    tlsEnabled: true
+    trafficTarget:
+      percent: 100
+      latestRevision: true

--- a/examples/volume-spec/capp-volume-spec.yaml
+++ b/examples/volume-spec/capp-volume-spec.yaml
@@ -1,0 +1,26 @@
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: hello-volume
+  namespace: capp-examples
+spec:
+  scaleMetric: rps
+  configurationSpec:
+    template:
+      spec:
+        containers:
+          - name: app
+            image: ghcr.io/dana-team/capp-gin-app:v0.2.0
+            env:
+              - name: APP_NAME
+                value: hello-volume
+            volumeMounts:
+              - name: shared-data
+                mountPath: /data
+  volumesSpec:
+    nfsVolumes:
+      - name: shared-data
+        server: nfs.example.com
+        path: /exports/shared-data
+        capacity:
+          storage: 1Gi


### PR DESCRIPTION
Add a new examples folder with simple Capp sample manifests for common features.