### PR TITLE
ci: skip workflows on docs-only changes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,13 @@ on:
     branches:
       - main
     types: [opened, reopened, synchronize]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'images/**'
+      - 'LICENSE'
+      - 'OWNERS'
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -3,6 +3,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'images/**'
+      - 'LICENSE'
+      - 'OWNERS'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,6 +4,13 @@ on:
     branches:
       - main
     types: [opened, reopened, synchronize]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'images/**'
+      - 'LICENSE'
+      - 'OWNERS'
 
 jobs:
   unit-test:


### PR DESCRIPTION
Avoid running PR tests/lint and post-merge image builds when a change only touches documentation, examples, images, or metadata. This reduces unnecessary CI load while keeping code changes fully covered.