### PR TITLE
fix: normalize Kubebuilder scaffolding settings

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -2,10 +2,9 @@
 # This file is used to track the info used to scaffold your project
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
-domain: rcs.dana.io
+domain: dana.io
 layout:
 - go.kubebuilder.io/v4
-multigroup: true
 projectName: container-app-operator
 repo: github.com/dana-team/container-app-operator
 resources:
@@ -21,7 +20,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: rcs.dana.io
+  domain: dana.io
   kind: CappRevision
   path: github.com/dana-team/container-app-operator/api/v1alpha1
   version: v1alpha1
@@ -31,7 +30,7 @@ resources:
   domain: dana.io
   group: rcs
   kind: CappConfig
-  path: github.com/dana-team/container-app-operator/api/rcs/v1alpha1
+  path: github.com/dana-team/container-app-operator/api/v1alpha1
   version: v1alpha1
   webhooks:
     defaulting: true


### PR DESCRIPTION
Set project domain to dana.io to prevent duplicated API groups. Example: group rcs with domain rcs.dana.io produced rcs.rcs.dana.io Set multigroup false and align resource paths to api/v1alpha1 to keep future scaffolds in a single folder.