### PR TITLE
feat: added minreplicas field to capp spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The `container-app-operator` project can work as a standalone solution, but is m
 ## Feature Highlights
 
 - [x] Support for autoscaler (`HPA` or `KPA`) according to the chosen `scaleMetric` (`concurrency`, `rps`, `cpu`, `memory`) with default settings.
+- [x] Support for setting minimum replicas per Capp (`minReplicas`) with a global maximum limit.
 - [x] Support for HTTP/HTTPS `DomainMapping` for accessing applications via `Ingress`/`Route`.
 - [x] Support for `DNS Records` lifecycle management based on the `hostname` API field (using a white-list approach for validation).
 - [x] Support for `Certificate` lifecycle management based on the `hostname` API field.
@@ -54,6 +55,8 @@ The `container-app-operator` project can work as a standalone solution, but is m
 5. `certificate-external-issuer` installed on the cluster (you can [use the `install.yaml`](https://github.com/dana-team/cert-external-issuer/releases)).
 
 6. `logging-operator` installed on the cluster (you can [use the Helm Chart](https://kube-logging.dev/docs/install/#deploy-logging-operator-with-helm)).
+
+7. `prometheus-operator` and `keda` installed on the cluster (optional, for Keda/Prometheus features).
 
 Everything can also be installed by running:
 
@@ -153,6 +156,7 @@ spec:
     memory: 70
     concurrency: 10
     activationScale: 3
+    globalMinScale: 10
   dnsConfig:
     zone: "capp-zone.com."
     cname: "ingress.capp-zone.com."
@@ -230,6 +234,7 @@ spec:
         - name: activemq-secret
           key: password
   scaleMetric: concurrency
+  minReplicas: 2
   state: enabled
   
 ```

--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -59,6 +59,12 @@ type CappSpec struct {
 	// +kubebuilder:validation:Enum=enabled;disabled
 	State string `json:"state,omitempty"`
 
+	// MinReplicas is the minimum number of replicas for the Capp.
+	// +kubebuilder:default:=0
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MinReplicas int `json:"minReplicas,omitempty"`
+
 	// ConfigurationSpec holds the desired state of the Configuration (from the client).
 	ConfigurationSpec knativev1.ConfigurationSpec `json:"configurationSpec"`
 

--- a/api/v1alpha1/cappconfig_types.go
+++ b/api/v1alpha1/cappconfig_types.go
@@ -45,6 +45,9 @@ type AutoscaleConfig struct {
 	Concurrency int `json:"concurrency"`
 	// ActivationScale is the default scale.
 	ActivationScale int `json:"activationScale"`
+	// MinReplicasLimit is the global minimum scale. (maximum allowed value for minReplicas).
+	// +kubebuilder:validation:Minimum=1
+	MinReplicasLimit int `json:"minReplicasLimit"`
 }
 
 // CappConfigStatus defines the observed state of CappConfig

--- a/charts/container-app-operator/README.md
+++ b/charts/container-app-operator/README.md
@@ -8,12 +8,13 @@ A Helm chart for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| config | object | `{"allowedHostnamePatterns":[".*"],"autoscaleConfig":{"activationScale":3,"concurrency":10,"cpu":80,"memory":70,"rps":200},"defaultResources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"100m","memory":"100Mi"}},"dnsConfig":{"cname":"ingress.capp-zone.com.","issuer":"cert-issuer","provider":"dns-default","zone":"capp-zone.com."},"enabled":true}` | Configuration for CappConfig CRD |
+| config | object | `{"allowedHostnamePatterns":[".*"],"autoscaleConfig":{"activationScale":3,"concurrency":10,"cpu":80,"memory":70,"minReplicasLimit":10,"rps":200},"defaultResources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"100m","memory":"100Mi"}},"dnsConfig":{"cname":"ingress.capp-zone.com.","issuer":"cert-issuer","provider":"dns-default","zone":"capp-zone.com."},"enabled":true}` | Configuration for CappConfig CRD |
 | config.allowedHostnamePatterns[0] | string | `".*"` | A list of regex patterns that hostnames of Capp workloads must match. If a Capp hostname matches one of these patterns, its creation will be allowed. |
 | config.autoscaleConfig.activationScale | int | `3` | The default activation scale (minimum replicas before scaling starts). |
 | config.autoscaleConfig.concurrency | int | `10` | The default concurrency limit for autoscaling. |
 | config.autoscaleConfig.cpu | int | `80` | The default CPU utilization percentage for autoscaling. |
 | config.autoscaleConfig.memory | int | `70` | The default memory utilization percentage for autoscaling. |
+| config.autoscaleConfig.minReplicasLimit | int | `10` | The global minimum scale (maximum allowed value for minReplicas). |
 | config.autoscaleConfig.rps | int | `200` | The default Requests Per Second (RPS) threshold for autoscaling. |
 | config.defaultResources.limits | object | `{"cpu":"200m","memory":"200Mi"}` | Default compute resource limits applied to all Capp workloads. |
 | config.defaultResources.limits.cpu | string | `"200m"` | Maximum requested CPU per Capp workload. |
@@ -30,7 +31,7 @@ A Helm chart for Kubernetes
 | controllerManager.manager.containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Linux capabilities to drop from the container for improved security. |
 | controllerManager.manager.image.imagePullPolicy | string | `"IfNotPresent"` | Controller manager container image pull policy. |
 | controllerManager.manager.image.repository | string | `"ghcr.io/dana-team/container-app-operator"` | Controller manager container image repository. |
-| controllerManager.manager.image.tag | string | `"main"` | Controller manager container image tag. |
+| controllerManager.manager.image.tag | string | `""` | Controller manager container image tag. |
 | controllerManager.manager.resources.limits.cpu | string | `"500m"` | Maximum CPU limit for the controller manager container. |
 | controllerManager.manager.resources.limits.memory | string | `"128Mi"` | Maximum memory limit for the controller manager container. |
 | controllerManager.manager.resources.requests.cpu | string | `"10m"` | Minimum CPU request for the controller manager container. |

--- a/charts/container-app-operator/crds/rcs.dana.io_cappconfigs.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_cappconfigs.yaml
@@ -62,6 +62,11 @@ spec:
                     description: Memory is the desired memory utilization to trigger
                       upscaling.
                     type: integer
+                  minReplicasLimit:
+                    description: MinReplicasLimit is the global minimum scale. (maximum
+                      allowed value for minReplicas).
+                    minimum: 1
+                    type: integer
                   rps:
                     description: RPS is the desired requests per second to trigger
                       upscaling.
@@ -71,6 +76,7 @@ spec:
                 - concurrency
                 - cpu
                 - memory
+                - minReplicasLimit
                 - rps
                 type: object
               defaultResources:

--- a/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
@@ -8823,6 +8823,12 @@ spec:
                             description: User defines a User for authentication.
                             type: string
                         type: object
+                      minReplicas:
+                        default: 0
+                        description: MinReplicas is the minimum number of replicas
+                          for the Capp.
+                        minimum: 0
+                        type: integer
                       routeSpec:
                         description: RouteSpec defines the route specification for
                           the Capp.

--- a/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
@@ -8640,6 +8640,12 @@ spec:
                     description: User defines a User for authentication.
                     type: string
                 type: object
+              minReplicas:
+                default: 0
+                description: MinReplicas is the minimum number of replicas for the
+                  Capp.
+                minimum: 0
+                type: integer
               routeSpec:
                 description: RouteSpec defines the route specification for the Capp.
                 properties:

--- a/charts/container-app-operator/templates/cappconfig.yaml
+++ b/charts/container-app-operator/templates/cappconfig.yaml
@@ -12,6 +12,7 @@ spec:
     memory: {{ .Values.config.autoscaleConfig.memory }}
     concurrency: {{ .Values.config.autoscaleConfig.concurrency }}
     activationScale: {{ .Values.config.autoscaleConfig.activationScale }}
+    minReplicasLimit: {{ .Values.config.autoscaleConfig.minReplicasLimit }}
   dnsConfig:
     zone: "{{ .Values.config.dnsConfig.zone }}"
     cname: "{{ .Values.config.dnsConfig.cname }}"

--- a/charts/container-app-operator/values.yaml
+++ b/charts/container-app-operator/values.yaml
@@ -86,6 +86,8 @@ config:
     concurrency: 10
     # -- The default activation scale (minimum replicas before scaling starts).
     activationScale: 3
+    # -- The global minimum scale (maximum allowed value for minReplicas).
+    minReplicasLimit: 10
 
   defaultResources:
     # -- Default compute resource limits applied to all Capp workloads.

--- a/config/crd/bases/rcs.dana.io_cappconfigs.yaml
+++ b/config/crd/bases/rcs.dana.io_cappconfigs.yaml
@@ -62,6 +62,11 @@ spec:
                     description: Memory is the desired memory utilization to trigger
                       upscaling.
                     type: integer
+                  minReplicasLimit:
+                    description: MinReplicasLimit is the global minimum scale. (maximum
+                      allowed value for minReplicas).
+                    minimum: 1
+                    type: integer
                   rps:
                     description: RPS is the desired requests per second to trigger
                       upscaling.
@@ -71,6 +76,7 @@ spec:
                 - concurrency
                 - cpu
                 - memory
+                - minReplicasLimit
                 - rps
                 type: object
               defaultResources:

--- a/config/crd/bases/rcs.dana.io_capprevisions.yaml
+++ b/config/crd/bases/rcs.dana.io_capprevisions.yaml
@@ -8823,6 +8823,12 @@ spec:
                             description: User defines a User for authentication.
                             type: string
                         type: object
+                      minReplicas:
+                        default: 0
+                        description: MinReplicas is the minimum number of replicas
+                          for the Capp.
+                        minimum: 0
+                        type: integer
                       routeSpec:
                         description: RouteSpec defines the route specification for
                           the Capp.

--- a/config/crd/bases/rcs.dana.io_capps.yaml
+++ b/config/crd/bases/rcs.dana.io_capps.yaml
@@ -8640,6 +8640,12 @@ spec:
                     description: User defines a User for authentication.
                     type: string
                 type: object
+              minReplicas:
+                default: 0
+                description: MinReplicas is the minimum number of replicas for the
+                  Capp.
+                minimum: 0
+                type: integer
               routeSpec:
                 description: RouteSpec defines the route specification for the Capp.
                 properties:

--- a/hack/manifests/cappconfig.yaml
+++ b/hack/manifests/cappconfig.yaml
@@ -10,6 +10,7 @@ spec:
     memory: 70
     concurrency: 10
     activationScale: 3
+    minReplicasLimit: 10
   dnsConfig:
     zone: "capp-zone.com."
     cname: "ingress.capp-zone.com."

--- a/internal/webhook/rcs/v1alpha1/validator.go
+++ b/internal/webhook/rcs/v1alpha1/validator.go
@@ -85,5 +85,8 @@ func (c *CappValidator) handle(ctx context.Context, capp cappv1alpha1.Capp, oldC
 		return admission.Denied("invalid scale metric 'external': must have at least one source defined")
 	}
 
+	if capp.Spec.MinReplicas > config.Spec.AutoscaleConfig.MinReplicasLimit {
+		return admission.Denied(fmt.Sprintf("invalid minReplicas %d: must be less than or equal to global min scale %d", capp.Spec.MinReplicas, config.Spec.AutoscaleConfig.MinReplicasLimit))
+	}
 	return admission.Allowed("")
 }

--- a/test/e2e_tests/knative_e2e_test.go
+++ b/test/e2e_tests/knative_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"k8s.io/client-go/util/retry"
+	"knative.dev/serving/pkg/apis/autoscaling"
 
 	"github.com/dana-team/container-app-operator/test/e2e_tests/testconsts"
 
@@ -271,7 +272,7 @@ var _ = Describe("Validate knative functionality", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
 		annotations := map[string]string{
-			testconsts.KnativeAutoscaleTargetKey: "666",
+			autoscaling.TargetAnnotationKey: "666",
 		}
 		testCapp.Spec.ConfigurationSpec.Template.Annotations = annotations
 		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
@@ -280,7 +281,7 @@ var _ = Describe("Validate knative functionality", func() {
 		By("Checking if the ksvc's defaults annotations were overridden")
 		Eventually(func() string {
 			ksvc := utilst.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return ksvc.Spec.ConfigurationSpec.Template.Annotations[testconsts.KnativeAutoscaleTargetKey]
+			return ksvc.Spec.ConfigurationSpec.Template.Annotations[autoscaling.TargetAnnotationKey]
 		}, testconsts.Timeout, testconsts.Interval).Should(Equal("666"))
 	})
 
@@ -324,8 +325,8 @@ var _ = Describe("Validate knative functionality", func() {
 		By("Checking if the ksvc's annotation is equal to the cappConfig's autoScale")
 		Eventually(func() bool {
 			ksvc := utilst.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return ksvc.Spec.ConfigurationSpec.Template.ObjectMeta.Annotations[testconsts.KnativeAutoscaleTargetKey] == fmt.Sprintf("%d", cappConfig.Spec.AutoscaleConfig.Concurrency) &&
-				ksvc.Spec.ConfigurationSpec.Template.ObjectMeta.Annotations[testconsts.KnativeActivationScaleKey] == fmt.Sprintf("%d", cappConfig.Spec.AutoscaleConfig.ActivationScale)
+			return ksvc.Spec.ConfigurationSpec.Template.ObjectMeta.Annotations[autoscaling.TargetAnnotationKey] == fmt.Sprintf("%d", cappConfig.Spec.AutoscaleConfig.Concurrency) &&
+				ksvc.Spec.ConfigurationSpec.Template.ObjectMeta.Annotations[autoscaling.ActivationScaleKey] == fmt.Sprintf("%d", cappConfig.Spec.AutoscaleConfig.ActivationScale)
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
 	})
 })

--- a/test/e2e_tests/testconsts/testconsts.go
+++ b/test/e2e_tests/testconsts/testconsts.go
@@ -28,8 +28,6 @@ const (
 	ExampleDanaAnnotation           = "rcs.dana.io/app-name"
 	TestContainerName               = "capp-test-container"
 	FirstRevisionSuffix             = "-00001"
-	KnativeAutoscaleTargetKey       = "autoscaling.knative.dev/target"
-	KnativeActivationScaleKey       = "autoscaling.knative.dev/activation-scale"
 	TestIndex                       = "test"
 	TestLabelKey                    = "e2e-test"
 	CappConfigName                  = "capp-config"


### PR DESCRIPTION
With this PR, and new field has been added to the capp.spec: minReplicas
This field controls the minimum number of available replicas of a CAPP,
by default it is set to 0 (scale-to-zero)
A `GlobalMinScale` field has been added to the CappConfig Spec to
provide an upper bound to the min-replicas field