### PR TITLE
fix(capp): prevent duplicate Certificate create

### DIFF
--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -150,7 +150,7 @@ func (c CertificateManager) create(capp cappv1alpha1.Capp) error {
 				return err
 			}
 
-			return c.createCertificate(capp, certificateFromCapp, resourceManager)
+			return nil
 		} else {
 			return fmt.Errorf("failed to get Certificate %q: %w", certificateFromCapp.Name, err)
 		}


### PR DESCRIPTION
Remove the second create call on NotFound.
Add an e2e check that no CertificateCreationFailed event is emitted.