### PR TITLE
fix(domainmapping): return immediately after creating DomainMapping

### DIFF
--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -157,9 +157,7 @@ func (k KnativeDomainMappingManager) createOrUpdate(capp cappv1alpha1.Capp) erro
 
 	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: domainMappingFromCapp.Name}, &domainMapping); err != nil {
 		if errors.IsNotFound(err) {
-			if err := k.createDomainMapping(capp, domainMappingFromCapp, resourceManager); err != nil {
-				return err
-			}
+			return k.createDomainMapping(capp, domainMappingFromCapp, resourceManager)
 		} else {
 			return fmt.Errorf("failed to get DomainMapping %q: %w", domainMappingFromCapp.Name, err)
 		}


### PR DESCRIPTION
Previously, createOrUpdate would continue execution after creating a DomainMapping, leading to an unnecessary call to updateDomainMapping in the same reconcile loop. Now returns immediately after successful creation.