### PR TITLE
fix(resourcemanagers): use generated name in cleanup logic

### DIFF
--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -201,7 +201,7 @@ func (c CertificateManager) handlePreviousCertificates(capp cappv1alpha1.Capp, r
 		return err
 	}
 
-	return c.deletePreviousCertificates(certificates, resourceManager, capp.Spec.RouteSpec.Hostname)
+	return c.deletePreviousCertificates(certificates, resourceManager, name)
 }
 
 // getPreviousCertificates returns a list of all Certificate objects that are related to the given Capp.

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -192,7 +192,7 @@ func (r DNSRecordManager) handlePreviousDNSRecords(capp cappv1alpha1.Capp, resou
 		return err
 	}
 
-	return r.deletePreviousDNSRecords(dnsRecords, resourceManager, capp.Spec.RouteSpec.Hostname)
+	return r.deletePreviousDNSRecords(dnsRecords, resourceManager, name)
 }
 
 // getPreviousDNSRecords returns a list of all DNSRecord objects that are related to the given Capp.


### PR DESCRIPTION
Pass the generated resource name instead of raw hostname to deletePreviousCertificates and deletePreviousDNSRecords.

The raw hostname (e.g., "myapp") never matched the generated resource name (e.g., "myapp.example.com"), causing the current resource to be deleted on every reconcile. This created an infinite create-delete loop, resulting in thousands of CertificateRequests.