### PR TITLE
fix(domainmapping): scope TLS secret deletion to previous only

### DIFF
--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -245,9 +245,9 @@ func (k KnativeDomainMappingManager) deletePreviousDomainMappings(knativeDomainM
 			if err := resourceManager.DeleteResource(&dm); err != nil {
 				return err
 			}
-		}
-		if err := deleteTLSSecret(resourceManager.Ctx, resourceManager.K8sclient, utils.GenerateSecretName(domainMapping.Name), domainMapping.Namespace); err != nil {
-			return err
+			if err := deleteTLSSecret(resourceManager.Ctx, resourceManager.K8sclient, utils.GenerateSecretName(domainMapping.Name), domainMapping.Namespace); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
deleteTLSSecret was called outside the hostname guard in
deletePreviousDomainMappings, causing the current DomainMapping's
TLS secret to be deleted on every reconcile. This forced cert-manager
to re-issue repeatedly, spamming the cluster with CertificateRequests.