### PR TITLE
fix(controller): remove unconditional 30s requeue on success

### DIFF
--- a/internal/kinds/capp/controllers/controller.go
+++ b/internal/kinds/capp/controllers/controller.go
@@ -40,7 +40,6 @@ import (
 const (
 	cappControllerName = "CappController"
 	RequeueTime        = 5 * time.Second
-	SyncPeriod         = 30 * time.Second
 )
 
 // CappReconciler reconciles a Capp object
@@ -173,7 +172,7 @@ func (r *CappReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to sync Capp: %s", err.Error())
 	}
-	return ctrl.Result{RequeueAfter: SyncPeriod}, nil
+	return ctrl.Result{}, nil
 }
 
 // SyncApplication manages the lifecycle of Capp.


### PR DESCRIPTION
The reconciler already watches all child resources via SetupWithManager, so the periodic SyncPeriod requeue was unnecessary polling that amplified reconcile noise.