### PR TITLE
fix: replace reflect.DeepEqual with Semantic.DeepEqual in reconciliation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ KNATIVE_VERSION ?= v1.17.0
 KNATIVE_URL ?= https://github.com/knative-extensions/kn-plugin-quickstart/releases/download/knative-$(KNATIVE_VERSION)/kn-quickstart-linux-amd64
 KNATIVE_HPA_URL ?= https://github.com/knative/serving/releases/download/knative-$(KNATIVE_VERSION)/serving-hpa.yaml
 CROSSPLANE_SCC_CRB ?= hack/crossplane-scc-clusterrolebinding.yaml
-PREREQ_HELMFILE ?= charts/capp-prereq-helmfile.yaml
+PREREQ_HELMFILE ?= charts/capp-prereq-helmfile.gotmpl
 
 .PHONY: prereq ## Install every prerequisite needed to develop and run the operator.
 prereq: install install-knative enable-nfs-knative install-prereq-helmfile
@@ -239,7 +239,7 @@ KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v2.7.2
-HELMFILE_VERSION ?= 0.167.1
+HELMFILE_VERSION ?= 1.4.3
 HELM_DOCS_VERSION ?= v1.14.2
 
 .PHONY: kustomize

--- a/charts/capp-prereq-helmfile.gotmpl
+++ b/charts/capp-prereq-helmfile.gotmpl
@@ -58,7 +58,7 @@ releases:
     namespace: nfspvc-operator-system
     createNamespace: true
     chart: oci://ghcr.io/dana-team/helm-charts/nfspvc-operator
-    version: v0.4.1
+    version: v0.5.2
     wait: true
     disableValidationOnInstall: true
     needs:
@@ -68,7 +68,7 @@ releases:
     namespace: cert-external-issuer-system
     createNamespace: true
     chart: oci://ghcr.io/dana-team/helm-charts/cert-external-issuer
-    version: v0.1.0
+    version: v0.2.1
     wait: true
     disableValidationOnInstall: true
     needs:

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -3,7 +3,6 @@ package resourcemanagers
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -165,8 +165,8 @@ func (r DNSRecordManager) createDNSRecord(capp cappv1alpha1.Capp, dnsRecordFromC
 
 // updateDNSRecord checks if an update to the DNSRecord is necessary and performs the update to match desired state.
 func (r DNSRecordManager) updateDNSRecord(dnsRecord, dnsRecordFromCapp dnsrecordv1alpha1.CNAMERecord, resourceManager rclient.ResourceManagerClient) error {
-	if !reflect.DeepEqual(dnsRecord.Spec.ForProvider, dnsRecordFromCapp.Spec.ForProvider) ||
-		!reflect.DeepEqual(dnsRecord.Spec.ProviderConfigReference, dnsRecordFromCapp.Spec.ProviderConfigReference) {
+	if !equality.Semantic.DeepEqual(dnsRecord.Spec.ForProvider, dnsRecordFromCapp.Spec.ForProvider) ||
+		!equality.Semantic.DeepEqual(dnsRecord.Spec.ProviderConfigReference, dnsRecordFromCapp.Spec.ProviderConfigReference) {
 		dnsRecord.Spec.ForProvider = dnsRecordFromCapp.Spec.ForProvider
 		dnsRecord.Spec.ProviderConfigReference = dnsRecordFromCapp.Spec.ProviderConfigReference
 		return resourceManager.UpdateResource(&dnsRecord)

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -3,7 +3,6 @@ package resourcemanagers
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 
@@ -12,6 +11,7 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -189,7 +189,7 @@ func (k KnativeDomainMappingManager) createDomainMapping(capp cappv1alpha1.Capp,
 
 // updateDomainMapping checks if an update to the DomainMapping is necessary and performs the update to match desired state.
 func (k KnativeDomainMappingManager) updateDomainMapping(knativeDomainMapping, domainMappingFromCapp knativev1beta1.DomainMapping, resourceManager rclient.ResourceManagerClient) error {
-	if !reflect.DeepEqual(knativeDomainMapping.Spec, domainMappingFromCapp.Spec) {
+	if !equality.Semantic.DeepEqual(knativeDomainMapping.Spec, domainMappingFromCapp.Spec) {
 		knativeDomainMapping.Spec = domainMappingFromCapp.Spec
 		return resourceManager.UpdateResource(&knativeDomainMapping)
 	}

--- a/internal/kinds/capp/resourcemanagers/kedasource.go
+++ b/internal/kinds/capp/resourcemanagers/kedasource.go
@@ -3,7 +3,6 @@ package resourcemanagers
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
@@ -14,6 +13,7 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -267,7 +267,7 @@ func (k KedaSourceManager) createTriggerAuth(capp *cappv1alpha1.Capp, triggerAut
 
 // updateTriggerAuth checks if an update to the scaled object is necessary and performs the update to match desired state.
 func (k KedaSourceManager) updateTriggerAuth(existingtriggerAuth, triggerAuth kedav1alpha1.TriggerAuthentication, resourceManager rclient.ResourceManagerClient) error {
-	if !reflect.DeepEqual(existingtriggerAuth.Spec, triggerAuth.Spec) {
+	if !equality.Semantic.DeepEqual(existingtriggerAuth.Spec, triggerAuth.Spec) {
 		existingtriggerAuth.Spec = triggerAuth.Spec
 		return resourceManager.UpdateResource(&existingtriggerAuth)
 	}
@@ -291,7 +291,7 @@ func (k KedaSourceManager) createScaledObject(capp *cappv1alpha1.Capp, scaledObj
 
 // updateKafkaSource checks if an update to the scaled object is necessary and performs the update to match desired state.
 func (k KedaSourceManager) updateScaledObject(existingScaledObject, scaledObject kedav1alpha1.ScaledObject, resourceManager rclient.ResourceManagerClient) error {
-	if !reflect.DeepEqual(existingScaledObject.Spec, scaledObject.Spec) {
+	if !equality.Semantic.DeepEqual(existingScaledObject.Spec, scaledObject.Spec) {
 		existingScaledObject.Spec = scaledObject.Spec
 		return resourceManager.UpdateResource(&existingScaledObject)
 	}

--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -3,7 +3,7 @@ package resourcemanagers
 import (
 	"context"
 	"fmt"
-	"reflect"
+	"maps"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/autoscale"
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
@@ -12,6 +12,7 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,7 +45,8 @@ func (k KnativeServiceManager) prepareResource(capp cappv1alpha1.Capp, ctx conte
 	knativeServiceLabels := map[string]string{}
 
 	if capp.Labels != nil {
-		knativeServiceLabels = capp.Labels
+		maps.Copy(knativeServiceLabels, capp.Labels)
+
 	}
 	knativeServiceLabels[utils.CappResourceKey] = capp.Name
 
@@ -186,7 +188,7 @@ func (k KnativeServiceManager) createKSVC(capp *cappv1alpha1.Capp, knativeServic
 
 // updateKSVC checks if an update to the KnativeService is necessary and performs the update to match desired state.
 func (k KnativeServiceManager) updateKSVC(knativeService, knativeServiceFromCapp *knativev1.Service, resourceManager rclient.ResourceManagerClient) error {
-	if !reflect.DeepEqual(knativeService.Spec, knativeServiceFromCapp.Spec) {
+	if !equality.Semantic.DeepEqual(knativeService.Spec, knativeServiceFromCapp.Spec) {
 		knativeService.Spec = knativeServiceFromCapp.Spec
 		return resourceManager.UpdateResource(knativeService)
 	}

--- a/internal/kinds/capp/resourcemanagers/nfspvc.go
+++ b/internal/kinds/capp/resourcemanagers/nfspvc.go
@@ -3,7 +3,6 @@ package resourcemanagers
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 
@@ -13,6 +12,7 @@ import (
 	nfspvcv1alpha1 "github.com/dana-team/nfspvc-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -158,7 +158,7 @@ func (n NFSPVCManager) createNFSPVC(capp *cappv1alpha1.Capp, nfspvc *nfspvcv1alp
 
 // updateNFSPVC checks if an update to the NFSPVC is necessary and performs the update to match desired state.
 func (n NFSPVCManager) updateNFSPVC(existingNFSPVC, nfspvc nfspvcv1alpha1.NfsPvc, resourceManager rclient.ResourceManagerClient) error {
-	if !reflect.DeepEqual(existingNFSPVC.Spec, nfspvc.Spec) {
+	if !equality.Semantic.DeepEqual(existingNFSPVC.Spec, nfspvc.Spec) {
 		existingNFSPVC.Spec = nfspvc.Spec
 		return resourceManager.UpdateResource(&existingNFSPVC)
 	}

--- a/internal/kinds/capp/resourcemanagers/syslogngflow.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngflow.go
@@ -3,7 +3,6 @@ package resourcemanagers
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 
@@ -13,6 +12,7 @@ import (
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/filter"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -126,7 +126,7 @@ func (f SyslogNGFlowManager) createSyslogNGFlow(syslogNGFlowFromCapp loggingv1be
 
 // updateSyslogNGFlow checks if an update to the SyslogNGFlow is necessary and performs the update to match desired state.
 func (f SyslogNGFlowManager) updateSyslogNGFlow(syslogNGFlow, syslogNGFlowFromCapp *loggingv1beta1.SyslogNGFlow, resourceManager rclient.ResourceManagerClient) error {
-	if !reflect.DeepEqual(syslogNGFlow.Spec, syslogNGFlowFromCapp.Spec) {
+	if !equality.Semantic.DeepEqual(syslogNGFlow.Spec, syslogNGFlowFromCapp.Spec) {
 		syslogNGFlow.Spec = syslogNGFlowFromCapp.Spec
 		return resourceManager.UpdateResource(syslogNGFlow)
 	}

--- a/internal/kinds/capp/resourcemanagers/syslogngoutput.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngoutput.go
@@ -3,7 +3,6 @@ package resourcemanagers
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/output"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -163,7 +163,7 @@ func (o SyslogNGOutputManager) createSyslogNGOutput(syslogNGOutputFromCapp loggi
 
 // updateSyslogNGOutput checks if an update to the SyslogNGOutput is necessary and performs the update to match desired state.
 func (o SyslogNGOutputManager) updateSyslogNGOutput(syslogNGOutput, syslogNGOutputFromCapp *loggingv1beta1.SyslogNGOutput, resourceManager rclient.ResourceManagerClient) error {
-	if !reflect.DeepEqual(syslogNGOutput.Spec, syslogNGOutputFromCapp.Spec) {
+	if !equality.Semantic.DeepEqual(syslogNGOutput.Spec, syslogNGOutputFromCapp.Spec) {
 		syslogNGOutput.Spec = syslogNGOutputFromCapp.Spec
 		return resourceManager.UpdateResource(syslogNGOutput)
 	}

--- a/internal/kinds/capprevision/actionmanagers/update.go
+++ b/internal/kinds/capprevision/actionmanagers/update.go
@@ -2,17 +2,21 @@ package actionmanagers
 
 import (
 	"context"
+	"maps"
 	"sort"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	"github.com/dana-team/container-app-operator/internal/kinds/capprevision/adapters"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const revisionsToKeep = 10
+
+var annotationToIgnore = utils.CappAPIGroup + "/last-updated-by"
 
 // splitRevisionsAtIndex splits a slice of CappRevisions into two slices:
 // one containing the elements before the specified index (exclusive),
@@ -41,8 +45,14 @@ func equalSpec(cappSpec, revisionCappSpec cappv1alpha1.CappSpec) bool {
 }
 
 // equalAnnotations returns a boolean indicating whether two annotation maps are equal.
-func equalAnnotations(cappAnnotations, revisionCappAnnotations map[string]string) bool {
-	return equality.Semantic.DeepEqual(cappAnnotations, revisionCappAnnotations)
+func equalAnnotations(cappAnnotations, revisionCappAnnotations map[string]string, toIgnoreKey string) bool {
+	filteredCappAnnotations := map[string]string{}
+	filteredRevisionAnnotations := map[string]string{}
+	maps.Copy(filteredCappAnnotations, cappAnnotations)
+	maps.Copy(filteredRevisionAnnotations, revisionCappAnnotations)
+	delete(filteredCappAnnotations, toIgnoreKey)
+	delete(filteredRevisionAnnotations, toIgnoreKey)
+	return equality.Semantic.DeepEqual(filteredCappAnnotations, filteredRevisionAnnotations)
 }
 
 // equalLabels returns a boolean indicating whether two label maps are equal.
@@ -54,7 +64,7 @@ func equalLabels(cappLabels, revisionCappLabels map[string]string) bool {
 // The comparison concerts the Capp Spec of the two instances, the Capp annotations and Capp labels.
 func isEqual(capp cappv1alpha1.Capp, revision cappv1alpha1.CappRevision) bool {
 	return equalSpec(capp.Spec, revision.Spec.CappTemplate.Spec) &&
-		equalAnnotations(capp.Annotations, revision.Spec.CappTemplate.Annotations) &&
+		equalAnnotations(capp.Annotations, revision.Spec.CappTemplate.Annotations, annotationToIgnore) &&
 		equalLabels(capp.Labels, revision.Spec.CappTemplate.Labels)
 }
 


### PR DESCRIPTION
## Summary
This PR replaces `reflect.DeepEqual` with `equality.Semantic.DeepEqual` across all resource managers to ensure proper comparison of Kubernetes API objects during reconciliation.

## Changes
- Replace `reflect.DeepEqual` with `equality.Semantic.DeepEqual` in:
  - DNSRecord manager
  - DomainMapping manager
  - KedaSource manager (TriggerAuth and ScaledObject)
  - KnativeService manager
  - NFSPVC manager
  - SyslogNGFlow manager
  - SyslogNGOutput manager
- Fix label map copying in KnativeService using `maps.Copy` instead of direct assignment
- Update CappRevision annotation comparison to ignore `last-updated-by` annotation

## Why
`equality.Semantic.DeepEqual` is the recommended approach for comparing Kubernetes API objects as it:
- Properly handles semantically equivalent but structurally different representations
- Ignores fields that should not affect equality (like timestamps, generation, etc.)
- Provides more accurate comparison for resource reconciliation

This improves the reliability of the reconciliation logic and prevents unnecessary updates.