### PR TITLE
fix: reconcile on Knative Service status updates

### DIFF
--- a/internal/kinds/capp/controllers/controller.go
+++ b/internal/kinds/capp/controllers/controller.go
@@ -78,7 +78,7 @@ func (r *CappReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&knativev1.Service{},
 			handler.EnqueueRequestsFromMapFunc(r.findCappFromEvent),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
 		Watches(
 			&knativev1beta1.DomainMapping{},


### PR DESCRIPTION
Knative Serving updates Service.status (including LatestReadyRevisionName) via the status subresource without incrementing metadata.generation. GenerationChangedPredicate skipped those events, so Capp status could stay stale and e2e timed out waiting for LatestReadyRevisionName.

Use ResourceVersionChangedPredicate for the Service watch so any update including status enqueues the Capp reconciler.