### PR TITLE
feat(chart): add metrics Service and ServiceMonitor

### DIFF
--- a/charts/container-app-operator/Chart.yaml
+++ b/charts/container-app-operator/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/container-app-operator/README.md
+++ b/charts/container-app-operator/README.md
@@ -1,6 +1,6 @@
 # container-app-operator
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -40,6 +40,18 @@ A Helm chart for Kubernetes
 | controllerManager.replicas | int | `1` | Number of replicas for the controller manager Deployment. |
 | controllerManager.serviceAccount.annotations | object | `{}` | Annotations to add to the service account used by the controller manager. |
 | kubernetesClusterDomain | string | `"cluster.local"` | Domain name of the Kubernetes cluster. |
+| metricsService.annotations | object | `{}` | Optional annotations on the metrics Service. |
+| metricsService.enabled | bool | `true` | If true, create a Service targeting the metrics port for scraping. |
+| metricsService.port | int | `8443` | Metrics listen port; must match --metrics-bind-address on the manager. |
+| metricsService.type | string | `"ClusterIP"` | Service type for the metrics endpoint. |
+| serviceMonitor.enabled | bool | `false` | If true, create a ServiceMonitor (requires monitoring.coreos.com CRDs). |
+| serviceMonitor.interval | string | `""` | Scrape interval (omit to use Prometheus default). |
+| serviceMonitor.labels | object | `{}` | Extra labels on the ServiceMonitor (e.g. for prometheus operator selectors). |
+| serviceMonitor.metricRelabelings | list | `[]` | Metric relabeling rules passed to the ServiceMonitor endpoint. |
+| serviceMonitor.relabelings | list | `[]` | Relabeling rules passed to the ServiceMonitor endpoint. |
+| serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout (omit to use Prometheus default). |
+| serviceMonitor.tls.caFile | string | `""` | Path to PEM CA file on the Prometheus pod; use with insecureSkipVerify false for verified TLS. |
+| serviceMonitor.tls.insecureSkipVerify | bool | `true` | If false, set caFile to the CA bundle on the Prometheus pod (e.g. OpenShift service CA). |
 | webhookService.ports | list | `[{"port":443,"protocol":"TCP","targetPort":9443}]` | List of ports exposed by the webhook service. |
 | webhookService.type | string | `"ClusterIP"` | Type of Kubernetes Service to expose the webhook (ClusterIP, NodePort, LoadBalancer). |
 

--- a/charts/container-app-operator/templates/deployment.yaml
+++ b/charts/container-app-operator/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        - containerPort: {{ .Values.metricsService.port }}
+          name: https
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz

--- a/charts/container-app-operator/templates/metrics-service.yaml
+++ b/charts/container-app-operator/templates/metrics-service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.metricsService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "container-app-operator.fullname" . }}-metrics-service
+  labels:
+    app.kubernetes.io/component: metrics
+    control-plane: controller-manager
+  {{- include "container-app-operator.labels" . | nindent 4 }}
+  {{- with .Values.metricsService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metricsService.type }}
+  selector:
+    control-plane: controller-manager
+    {{- include "container-app-operator.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: https
+      port: {{ .Values.metricsService.port }}
+      targetPort: https
+      protocol: TCP
+{{- end }}

--- a/charts/container-app-operator/templates/servicemonitor.yaml
+++ b/charts/container-app-operator/templates/servicemonitor.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.serviceMonitor.enabled .Values.metricsService.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "container-app-operator.fullname" . }}-metrics-monitor
+  labels:
+    app.kubernetes.io/component: metrics
+    control-plane: controller-manager
+  {{- include "container-app-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metrics
+      {{- include "container-app-operator.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: https
+      path: /metrics
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        {{- with .Values.serviceMonitor.tls.caFile }}
+        caFile: {{ . | quote }}
+        {{- end }}
+        insecureSkipVerify: {{ .Values.serviceMonitor.tls.insecureSkipVerify }}
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/container-app-operator/values.yaml
+++ b/charts/container-app-operator/values.yaml
@@ -60,6 +60,38 @@ webhookService:
   # -- Type of Kubernetes Service to expose the webhook (ClusterIP, NodePort, LoadBalancer).
   type: ClusterIP
 
+# -- Prometheus metrics (controller-runtime) on the manager pod.
+metricsService:
+  # -- If true, create a Service targeting the metrics port for scraping.
+  enabled: true
+  # -- Metrics listen port; must match --metrics-bind-address on the manager.
+  port: 8443
+  # -- Service type for the metrics endpoint.
+  type: ClusterIP
+  # -- Optional annotations on the metrics Service.
+  annotations: {}
+
+# -- kube-prometheus-stack / Prometheus Operator integration (optional).
+serviceMonitor:
+  # -- If true, create a ServiceMonitor (requires monitoring.coreos.com CRDs).
+  enabled: false
+  # -- Scrape interval (omit to use Prometheus default).
+  interval: ""
+  # -- Scrape timeout (omit to use Prometheus default).
+  scrapeTimeout: ""
+  # -- Extra labels on the ServiceMonitor (e.g. for prometheus operator selectors).
+  labels: {}
+  # -- Relabeling rules passed to the ServiceMonitor endpoint.
+  relabelings: []
+  # -- Metric relabeling rules passed to the ServiceMonitor endpoint.
+  metricRelabelings: []
+  # -- TLS options for HTTPS metrics scrape (default skips verify when the controller uses ephemeral certs).
+  tls:
+    # -- If false, set caFile to the CA bundle path on the Prometheus pod (e.g. OpenShift service CA).
+    insecureSkipVerify: true
+    # -- Path to PEM CA file on the Prometheus scraper pod; when set, typical pairing is insecureSkipVerify: false.
+    caFile: ""
+
 # -- Configuration for CappConfig CRD
 config:
   # -- Enable or disable creation of the CappConfig resource by Helm.


### PR DESCRIPTION
Add a ClusterIP metrics Service (port 8443, named https), optional ServiceMonitor for Prometheus Operator with configurable TLS (insecureSkipVerify and caFile), and the matching container port on the manager Deployment. Document new values in the chart README and bump chart version to 0.1.1.