### PR TITLE
fix(status): tolerate NotFound when syncing child resource status

### DIFF
--- a/internal/kinds/capp/status/knative.go
+++ b/internal/kinds/capp/status/knative.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,6 +57,9 @@ func buildKnativeStatus(ctx context.Context, kubeClient client.Client, capp capp
 	if isRequired {
 		kservice := &knativev1.Service{}
 		if err := kubeClient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, kservice); err != nil {
+			if apierrors.IsNotFound(err) {
+				return knativeObjectStatus, revisionInfo, nil
+			}
 			return knativeObjectStatus, revisionInfo, err
 		}
 

--- a/internal/kinds/capp/status/logging.go
+++ b/internal/kinds/capp/status/logging.go
@@ -7,6 +7,7 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,12 +34,18 @@ func buildLoggingStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Lo
 	logger.Info("Building logger status")
 
 	if err := r.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, syslogNGFlow); err != nil {
+		if apierrors.IsNotFound(err) {
+			return loggingStatus, nil
+		}
 		logger.Error(err, "Failed to fetch SyslogNGFlow")
 		return loggingStatus, err
 	}
 
 	syslogNGOutput := &loggingv1beta1.SyslogNGOutput{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, syslogNGOutput); err != nil {
+		if apierrors.IsNotFound(err) {
+			return loggingStatus, nil
+		}
 		logger.Error(err, "Failed to fetch SyslogNGOutput")
 		return loggingStatus, err
 	}

--- a/internal/kinds/capp/status/route.go
+++ b/internal/kinds/capp/status/route.go
@@ -10,6 +10,7 @@ import (
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,6 +63,9 @@ func buildDomainMappingStatus(ctx context.Context, kubeClient client.Client, cap
 	domainMapping := &knativev1beta1.DomainMapping{}
 	domainMappingName := utils.GenerateResourceName(capp.Spec.RouteSpec.Hostname, zone)
 	if err := kubeClient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: domainMappingName}, domainMapping); err != nil {
+		if apierrors.IsNotFound(err) {
+			return knativev1beta1.DomainMappingStatus{}, nil
+		}
 		return knativev1beta1.DomainMappingStatus{}, err
 	}
 
@@ -79,6 +83,9 @@ func buildCertificateStatus(ctx context.Context, kubeClient client.Client, capp 
 	certificateName := utils.GenerateResourceName(capp.Spec.RouteSpec.Hostname, zone)
 
 	if err := kubeClient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: certificateName}, certificate); err != nil {
+		if apierrors.IsNotFound(err) {
+			return cmapi.CertificateStatus{}, nil
+		}
 		return cmapi.CertificateStatus{}, err
 	}
 
@@ -109,6 +116,9 @@ func buildCNAMERecordStatus(ctx context.Context, kubeClient client.Client, capp 
 	cnameRecord := &dnsrecordv1alpha1.CNAMERecord{}
 	cnameRecordName := utils.GenerateResourceName(capp.Spec.RouteSpec.Hostname, zone)
 	if err := kubeClient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: cnameRecordName}, cnameRecord); err != nil {
+		if apierrors.IsNotFound(err) {
+			return dnsrecordv1alpha1.CNAMERecordStatus{}, nil
+		}
 		return dnsrecordv1alpha1.CNAMERecordStatus{}, err
 	}
 

--- a/internal/kinds/capp/status/volumes.go
+++ b/internal/kinds/capp/status/volumes.go
@@ -5,6 +5,7 @@ import (
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	nfspvcv1alpha1 "github.com/dana-team/nfspvc-operator/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,6 +22,13 @@ func buildVolumesStatus(ctx context.Context, kubeClient client.Client, capp capp
 	for _, NFSPVC := range capp.Spec.VolumesSpec.NFSVolumes {
 		NFSPVCObj := nfspvcv1alpha1.NfsPvc{}
 		if err := kubeClient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: NFSPVC.Name}, &NFSPVCObj); err != nil {
+			if apierrors.IsNotFound(err) {
+				volumesStatus.NFSVolumesStatus = append(volumesStatus.NFSVolumesStatus, cappv1alpha1.NFSVolumeStatus{
+					VolumeName:   NFSPVC.Name,
+					NFSPVCStatus: nfspvcv1alpha1.NfsPvcStatus{},
+				})
+				continue
+			}
 			return volumesStatus, err
 		}
 


### PR DESCRIPTION
Status sync read Knative Service, route children, logging CRs, and NFS PVCs via the cached client. Right after create, Get could return NotFound before the informer saw the object, failing the reconcile. Return empty status on NotFound so the loop succeeds and a later reconcile fills status.

Fixes #416