### PR TITLE
fix(webhooks): apply default resources to Capp containers in-place

### DIFF
--- a/hack/manifests/cappconfig.yaml
+++ b/hack/manifests/cappconfig.yaml
@@ -18,11 +18,11 @@ spec:
     issuer: "cert-issuer"
   defaultResources:
     limits:
-      cpu: "1"
-      memory: "1Gi"
-    requests:
       cpu: "500m"
       memory: "512Mi"
+    requests:
+      cpu: "10m"
+      memory: "64Mi"
   allowedHostnamePatterns:
     - '.*\.allowed'
     - '.*\.com'

--- a/internal/webhook/rcs/v1alpha1/mutator.go
+++ b/internal/webhook/rcs/v1alpha1/mutator.go
@@ -74,7 +74,8 @@ func mutateAnnotations(capp *v1alpha2.Capp, username string) {
 func mutateResources(capp *v1alpha2.Capp, defaultResources corev1.ResourceRequirements) {
 	resources := []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory}
 
-	for _, container := range capp.Spec.ConfigurationSpec.Template.Spec.Containers {
+	for i := range capp.Spec.ConfigurationSpec.Template.Spec.Containers {
+		container := &capp.Spec.ConfigurationSpec.Template.Spec.Containers[i]
 		setResourceQuantity(&container.Resources.Requests, defaultResources.Requests, resources)
 		setResourceQuantity(&container.Resources.Limits, defaultResources.Limits, resources)
 	}


### PR DESCRIPTION
Range over []corev1.Container copies each element, so defaults were written to a temporary value and never persisted. Iterate by index and mutate Containers[i] via a pointer.

Fixes #413