### PR TITLE
ci(e2e): drop fixed Ginkgo procs in PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,7 +45,6 @@ jobs:
     timeout-minutes: 20
     env:
       E2E_SKIP_CLEANUP: "true"
-      E2E_GINKGO_PROCS: 8
       IMAGE_REGISTRY: kind-registry:5000
       KIND_VERSION: v0.31.0
       K8S_VERSION: v1.33.4


### PR DESCRIPTION
Let Ginkgo -p choose parallel node count from the runner instead of pinning eight processes, which can oversubscribe small VMs.