### PR TITLE
fix(capp): filter primary Capp watch on spec and metadata

### DIFF
--- a/internal/kinds/capp/controllers/controller.go
+++ b/internal/kinds/capp/controllers/controller.go
@@ -73,7 +73,15 @@ type CappReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *CappReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&cappv1alpha1.Capp{}).
+		For(&cappv1alpha1.Capp{},
+			builder.WithPredicates(
+				predicate.Or(
+					predicate.GenerationChangedPredicate{},
+					predicate.AnnotationChangedPredicate{},
+					predicate.LabelChangedPredicate{},
+				),
+			),
+		).
 		Named(cappControllerName).
 		Watches(
 			&knativev1.Service{},


### PR DESCRIPTION
Ignore status-only informer updates on the main Capp source while still reconciling on spec generation and Capp label/annotation changes propagated to Knative.

Fixes #438