### PR TITLE
test(e2e): drop CRD-only validation cases

### DIFF
--- a/test/e2e_tests/capp_e2e_test.go
+++ b/test/e2e_tests/capp_e2e_test.go
@@ -1,8 +1,6 @@
 package e2e_tests
 
 import (
-	"context"
-
 	"github.com/dana-team/container-app-operator/test/e2e_tests/mocks"
 	"github.com/dana-team/container-app-operator/test/e2e_tests/testconsts"
 	utilst "github.com/dana-team/container-app-operator/test/e2e_tests/utils"
@@ -14,15 +12,11 @@ import (
 )
 
 var _ = Describe("Validate capp creation", func() {
-	It("Should validate capp spec", func() {
+	It("Should default scale metric when unset", func() {
 		baseCapp := mocks.CreateBaseCapp()
 		By("Creating Capp with no scale metric")
 		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
 		Expect(desiredCapp.Spec.ScaleMetric).ShouldNot(BeNil())
-
-		By("Creating Capp with unsupported scale metric")
-		baseCapp.Spec.ScaleMetric = testconsts.UnsupportedScaleMetric
-		Expect(k8sClient.Create(context.Background(), baseCapp)).ShouldNot(Succeed())
 	})
 
 	It("Should succeed all adapter functions", func() {

--- a/test/e2e_tests/testconsts/testconsts.go
+++ b/test/e2e_tests/testconsts/testconsts.go
@@ -17,7 +17,6 @@ const (
 	CappKey                         = "capp"
 	Charset                         = "abcdefghijklmnopqrstuvwxyz0123456789"
 	RandStrLength                   = 10
-	UnsupportedScaleMetric          = "storage"
 	EnabledState                    = "enabled"
 	DisabledState                   = "disabled"
 	KnativeMetricAnnotation         = "autoscaling.knative.dev/metric"

--- a/test/e2e_tests/validating_e2e_test.go
+++ b/test/e2e_tests/validating_e2e_test.go
@@ -19,7 +19,6 @@ const (
 	clusterLocalHostname = "invalid.svc.cluster.local"
 	invalidHostName      = "invalid_domain!"
 	existingHostname     = "google.com"
-	unsupportedLogType   = "unsupported"
 	elasticLogType       = "elastic"
 	elasticUser          = "user"
 	elasticHostExample   = "https://elasticsearch.dana.com/_bulk"
@@ -87,13 +86,6 @@ var _ = Describe("Validate the validating webhook", func() {
 			return k8sClient.Update(context.Background(), &cappInCluster)
 		})
 		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("Should deny the use of an invalid log type", func() {
-		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Name = utilst.GenerateUniqueCappName(baseCapp.Name)
-		baseCapp.Spec.LogSpec.Type = unsupportedLogType
-		Expect(k8sClient.Create(context.Background(), baseCapp)).ShouldNot(Succeed())
 	})
 
 	It("Should deny the use of an incomplete log spec", func() {


### PR DESCRIPTION
Remove e2e creates that expect failure for values already rejected by the Capp CRD. Rely on schema for those invariants. keep default scale-metric and webhook log-spec tests.

Fixes #447