### PR TITLE
fix(capp): correct Capp annotation filtering for Knative Service

### DIFF
--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -30,6 +30,8 @@ const (
 	eventCappKnativeServiceCreated        = "KnativeServiceCreated"
 	eventCappDisabled                     = "CappDisabled"
 	eventCappEnabled                      = "CappEnabled"
+
+	kubectlKubernetesIOAnnotationPrefix = "kubectl.kubernetes.io/"
 )
 
 type KnativeServiceManager struct {
@@ -41,7 +43,10 @@ type KnativeServiceManager struct {
 
 // prepareResource generates a Knative Service definition from a given Capp resource.
 func (k KnativeServiceManager) prepareResource(capp cappv1alpha1.Capp, ctx context.Context) knativev1.Service {
-	knativeServiceAnnotations := utils.FilterKeysWithoutPrefix(capp.Annotations, utils.CappAPIGroup)
+	knativeServiceAnnotations := utils.ExcludeKeysWithPrefix(
+		utils.ExcludeKeysWithPrefix(capp.Annotations, utils.CappAPIGroup),
+		kubectlKubernetesIOAnnotationPrefix,
+	)
 	knativeServiceLabels := map[string]string{}
 
 	if capp.Labels != nil {

--- a/internal/kinds/capp/utils/utils.go
+++ b/internal/kinds/capp/utils/utils.go
@@ -49,12 +49,12 @@ func IsOnOpenshift(config *rest.Config) (bool, error) {
 	return false, nil
 }
 
-// FilterKeysWithoutPrefix removes keys from a map if they don't start with a given prefix
-func FilterKeysWithoutPrefix(object map[string]string, prefix string) map[string]string {
+// ExcludeKeysWithPrefix returns a new map omitting entries whose keys start with prefix.
+func ExcludeKeysWithPrefix(object map[string]string, prefix string) map[string]string {
 	result := make(map[string]string)
 
 	for key, value := range object {
-		if strings.HasPrefix(key, prefix) {
+		if !strings.HasPrefix(key, prefix) {
 			result[key] = value
 		}
 	}

--- a/internal/kinds/capp/utils/utils_test.go
+++ b/internal/kinds/capp/utils/utils_test.go
@@ -5,20 +5,14 @@ import (
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestFilterKeysWithoutPrefix(t *testing.T) {
+func TestExcludeKeysWithPrefix(t *testing.T) {
 	object := map[string]string{
 		"prefix_key1": "value1",
 		"key2":        "value2",
 		"prefix_key3": "value3",
 	}
-	prefix := "prefix_"
-	expected := map[string]string{
-		"prefix_key1": "value1",
-		"prefix_key3": "value3",
-	}
-
-	assert.Equal(t, expected, utils.FilterKeysWithoutPrefix(object, prefix))
+	require.Equal(t, map[string]string{"key2": "value2"}, utils.ExcludeKeysWithPrefix(object, "prefix_"))
 }

--- a/test/e2e_tests/knative_e2e_test.go
+++ b/test/e2e_tests/knative_e2e_test.go
@@ -178,14 +178,16 @@ var _ = Describe("Validate knative functionality", func() {
 		}, testconsts.Timeout, testconsts.Interval).Should(Equal(testconsts.ImageExample))
 	})
 
-	It("Should update ksvc dana annotation when updating capp's dana annotation", func() {
+	It("Should update ksvc when updating a propagating Capp metadata annotation", func() {
+		const propagationAnnKey = "example.com/e2e-propagation"
+
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
 		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
 
-		By("Updating capp's dana annotation")
+		By("Updating capp metadata annotation that is copied to the Knative Service")
 		cappAnnotations := map[string]string{}
-		cappAnnotations[testconsts.ExampleDanaAnnotation] = testconsts.ExampleAppName
+		cappAnnotations[propagationAnnKey] = testconsts.ExampleAppName
 
 		var latestReadyRevisionBeforeUpdate string
 		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
@@ -199,10 +201,10 @@ var _ = Describe("Validate knative functionality", func() {
 
 		verifyLatestReadyRevision(createdCapp.Name, createdCapp.Namespace, latestReadyRevisionBeforeUpdate)
 
-		By("Checking if the ksvc's dana annotation was updated successfully")
+		By("Checking if the ksvc template annotation was updated successfully")
 		Eventually(func() string {
 			ksvc := utilst.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			return ksvc.Spec.Template.Annotations[testconsts.ExampleDanaAnnotation]
+			return ksvc.Spec.Template.Annotations[propagationAnnKey]
 		}, testconsts.Timeout, testconsts.Interval).Should(Equal(testconsts.ExampleAppName))
 	})
 

--- a/test/e2e_tests/testconsts/testconsts.go
+++ b/test/e2e_tests/testconsts/testconsts.go
@@ -23,7 +23,6 @@ const (
 	ImageExample                    = "danateam/autoscale-go"
 	ExampleAppName                  = "new-app-name"
 	NewSecretKey                    = "username"
-	ExampleDanaAnnotation           = "rcs.dana.io/app-name"
 	TestContainerName               = "capp-test-container"
 	FirstRevisionSuffix             = "-00001"
 	TestIndex                       = "test"


### PR DESCRIPTION
Rename FilterKeysWithoutPrefix to ExcludeKeysWithPrefix and keep only keys that do not start with the API group prefix. Also strip kubectl.kubernetes.io when building Knative Service annotations.

Fixes #440