### PR TITLE
ci: gate chart readme sync in lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,6 +41,9 @@ jobs:
       - name: Run vet
         run: go vet ./...
 
+      - name: Verify chart README (helm-docs)
+        run: make verify-doc-chart
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,14 @@ uninstall-prereq-helmfile: helmfile helm helm-plugins
 doc-chart: helm-docs helm
 	$(HELM_DOCS) charts/
 
+.PHONY: verify-doc-chart
+verify-doc-chart: doc-chart ## Fail if chart README is out of sync with values.yaml
+	@if ! git diff --exit-code charts/container-app-operator/README.md; then \
+		echo >&2 'chart README out of date; run: make doc-chart, then git add charts/container-app-operator/README.md (and values.yaml if changed).'; \
+		exit 1; \
+	fi
+	@echo 'verify-doc-chart: OK (chart README matches helm-docs)'
+
 .PHONY: create-cappConfig
 create-cappConfig: ## Run the setup-cappConfig-deployer script
 	$(KUBECTL) apply -f $(shell pwd)/hack/manifests/cappconfig.yaml

--- a/charts/container-app-operator/README.md
+++ b/charts/container-app-operator/README.md
@@ -40,18 +40,20 @@ A Helm chart for Kubernetes
 | controllerManager.replicas | int | `1` | Number of replicas for the controller manager Deployment. |
 | controllerManager.serviceAccount.annotations | object | `{}` | Annotations to add to the service account used by the controller manager. |
 | kubernetesClusterDomain | string | `"cluster.local"` | Domain name of the Kubernetes cluster. |
+| metricsService | object | `{"annotations":{},"enabled":true,"port":8443,"type":"ClusterIP"}` | Metrics Service for the manager; `port` must match `--metrics-bind-address` in manager `args` (default 8443). |
 | metricsService.annotations | object | `{}` | Optional annotations on the metrics Service. |
 | metricsService.enabled | bool | `true` | If true, create a Service targeting the metrics port for scraping. |
-| metricsService.port | int | `8443` | Metrics listen port; must match --metrics-bind-address on the manager. |
 | metricsService.type | string | `"ClusterIP"` | Service type for the metrics endpoint. |
+| serviceMonitor | object | `{"enabled":false,"interval":"","labels":{},"metricRelabelings":[],"relabelings":[],"scrapeTimeout":"","tls":{"caFile":"","insecureSkipVerify":true}}` | kube-prometheus-stack / Prometheus Operator integration (optional). |
 | serviceMonitor.enabled | bool | `false` | If true, create a ServiceMonitor (requires monitoring.coreos.com CRDs). |
 | serviceMonitor.interval | string | `""` | Scrape interval (omit to use Prometheus default). |
 | serviceMonitor.labels | object | `{}` | Extra labels on the ServiceMonitor (e.g. for prometheus operator selectors). |
 | serviceMonitor.metricRelabelings | list | `[]` | Metric relabeling rules passed to the ServiceMonitor endpoint. |
 | serviceMonitor.relabelings | list | `[]` | Relabeling rules passed to the ServiceMonitor endpoint. |
 | serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout (omit to use Prometheus default). |
-| serviceMonitor.tls.caFile | string | `""` | Path to PEM CA file on the Prometheus pod; use with insecureSkipVerify false for verified TLS. |
-| serviceMonitor.tls.insecureSkipVerify | bool | `true` | If false, set caFile to the CA bundle on the Prometheus pod (e.g. OpenShift service CA). |
+| serviceMonitor.tls | object | `{"caFile":"","insecureSkipVerify":true}` | TLS options for HTTPS metrics scrape (default skips verify when the controller uses ephemeral certs). |
+| serviceMonitor.tls.caFile | string | `""` | Path to PEM CA file on the Prometheus scraper pod; when set, typical pairing is insecureSkipVerify: false. |
+| serviceMonitor.tls.insecureSkipVerify | bool | `true` | If false, set caFile to the CA bundle path on the Prometheus pod (e.g. OpenShift service CA). |
 | webhookService.ports | list | `[{"port":443,"protocol":"TCP","targetPort":9443}]` | List of ports exposed by the webhook service. |
 | webhookService.type | string | `"ClusterIP"` | Type of Kubernetes Service to expose the webhook (ClusterIP, NodePort, LoadBalancer). |
 

--- a/charts/container-app-operator/values.yaml
+++ b/charts/container-app-operator/values.yaml
@@ -60,7 +60,7 @@ webhookService:
   # -- Type of Kubernetes Service to expose the webhook (ClusterIP, NodePort, LoadBalancer).
   type: ClusterIP
 
-# -- Prometheus metrics (controller-runtime) on the manager pod.
+# -- Metrics Service for the manager; `port` must match `--metrics-bind-address` in manager `args` (default 8443).
 metricsService:
   # -- If true, create a Service targeting the metrics port for scraping.
   enabled: true


### PR DESCRIPTION
Add a Makefile recipe that runs chart doc generation then git diff on the chart README, with clear pass and fail messages. Run it in the lint workflow. Regenerate the Helm README from values and clarify the metricsService parent comment for the metrics bind port.