### PR TITLE
feat: add manager log verbosity and API write logging

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"go.elastic.co/ecszap"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -77,9 +78,9 @@ func initOpenshiftSchemes() {
 	utilruntime.Must(routev1.Install(scheme))
 }
 
-func initEcsLogger() {
+func initEcsLogger(level zapcore.Level) {
 	encoderConfig := ecszap.NewDefaultEncoderConfig()
-	core := ecszap.NewCore(encoderConfig, os.Stdout, zap.DebugLevel)
+	core := ecszap.NewCore(encoderConfig, os.Stdout, level)
 	logger := zap.New(core, zap.AddCaller())
 	logf.SetLogger(zapr.NewLogger(logger))
 }
@@ -89,6 +90,7 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var ecsLogging bool
+	var logVerbosity int
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
@@ -98,16 +100,22 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&ecsLogging, "ecs-logging", true, "Display controller logs in ecs format.")
+	flag.IntVar(&logVerbosity, "log-verbosity", 0,
+		"Log verbosity: 0 is default; values above 0 enable more detailed controller diagnostic logs.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.Parse()
 
+	lvl := zapcore.InfoLevel
+	if logVerbosity > 0 {
+		lvl = zapcore.DebugLevel
+	}
 	if ecsLogging {
-		initEcsLogger()
+		initEcsLogger(lvl)
 	} else {
-		ctrl.SetLogger(runtimezap.New())
+		ctrl.SetLogger(runtimezap.New(runtimezap.Level(lvl)))
 	}
 	metricsServerOptions := metricsserver.Options{
 		BindAddress:   metricsAddr,

--- a/internal/kinds/capp/resourceclient/resourceclient.go
+++ b/internal/kinds/capp/resourceclient/resourceclient.go
@@ -14,32 +14,46 @@ type ResourceManagerClient struct {
 	Log       logr.Logger
 }
 
+// objectIdentityKeyVals returns key/value pairs identifying obj for structured logs.
+func objectIdentityKeyVals(obj client.Object) []any {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	kind := gvk.Kind
+	if kind == "" {
+		kind = "Unknown"
+	}
+	return []any{
+		"kind", kind,
+		"group", gvk.Group,
+		"version", gvk.Version,
+		"namespace", obj.GetNamespace(),
+		"name", obj.GetName(),
+		"resourceVersion", obj.GetResourceVersion(),
+	}
+}
+
 // CreateResource creates a resource.
 func (r ResourceManagerClient) CreateResource(resource client.Object) error {
+	r.Log.Info("kubernetes API write create", objectIdentityKeyVals(resource)...)
 	if err := r.K8sclient.Create(r.Ctx, resource); err != nil {
 		return fmt.Errorf("failed to create resource %s %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName(), err)
 	}
-
-	r.Log.Info(fmt.Sprintf("successfully created %s %s", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName()))
 	return nil
 }
 
 // UpdateResource updates a resource.
 func (r ResourceManagerClient) UpdateResource(resource client.Object) error {
+	r.Log.Info("kubernetes API write update", objectIdentityKeyVals(resource)...)
 	if err := r.K8sclient.Update(r.Ctx, resource); err != nil {
 		return fmt.Errorf("failed to update %s %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName(), err)
 	}
-
-	r.Log.Info(fmt.Sprintf("successfully updated %s %s", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName()))
 	return nil
 }
 
 // DeleteResource deletes a resource.
 func (r ResourceManagerClient) DeleteResource(resource client.Object) error {
+	r.Log.Info("kubernetes API write delete", objectIdentityKeyVals(resource)...)
 	if err := r.K8sclient.Delete(r.Ctx, resource); err != nil {
 		return fmt.Errorf("failed to delete %s %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName(), err)
 	}
-
-	r.Log.Info(fmt.Sprintf("successfully deleted %s %s", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName()))
 	return nil
 }


### PR DESCRIPTION
feat: add --log-verbosity and structured pre-write API logs

Wire manager log level from --log-verbosity (0 -> Info, >0 -> Debug)
for both ECS and controller-runtime loggers so default deploys are
quieter than ECS hard-coded Debug.

Log each resourceclient Create/Update/Delete with a single structured
Info line before the API call (stable message + GVK, namespace, name,
resourceVersion) to make reconciliation-driven writes easy to grep.

Remove the old unconditional Info "successfully ..." lines after
successful writes; callers still surface failures via returned errors,
and attempt logs cover the hot path for diagnosing churn.

Upgrade note: with --ecs-logging=true (default), the ECS zap core
was previously always Debug; at --log-verbosity=0 it is now Info
(quieter). Pass --log-verbosity=1 for prior debug-style volume and
to show V(1) success logs.