### PR TITLE
feat(capprevision): align CappRevision create/delete logs with API writes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"go.elastic.co/ecszap"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -77,9 +78,9 @@ func initOpenshiftSchemes() {
 	utilruntime.Must(routev1.Install(scheme))
 }
 
-func initEcsLogger() {
+func initEcsLogger(level zapcore.Level) {
 	encoderConfig := ecszap.NewDefaultEncoderConfig()
-	core := ecszap.NewCore(encoderConfig, os.Stdout, zap.DebugLevel)
+	core := ecszap.NewCore(encoderConfig, os.Stdout, level)
 	logger := zap.New(core, zap.AddCaller())
 	logf.SetLogger(zapr.NewLogger(logger))
 }
@@ -89,6 +90,7 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var ecsLogging bool
+	var logVerbosity int
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
@@ -98,16 +100,22 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&ecsLogging, "ecs-logging", true, "Display controller logs in ecs format.")
+	flag.IntVar(&logVerbosity, "log-verbosity", 0,
+		"Log verbosity: 0 is default; values above 0 enable more detailed controller diagnostic logs.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.Parse()
 
+	lvl := zapcore.InfoLevel
+	if logVerbosity > 0 {
+		lvl = zapcore.DebugLevel
+	}
 	if ecsLogging {
-		initEcsLogger()
+		initEcsLogger(lvl)
 	} else {
-		ctrl.SetLogger(runtimezap.New())
+		ctrl.SetLogger(runtimezap.New(runtimezap.Level(lvl)))
 	}
 	metricsServerOptions := metricsserver.Options{
 		BindAddress:   metricsAddr,

--- a/internal/kinds/capp/finalizer/finalizer.go
+++ b/internal/kinds/capp/finalizer/finalizer.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	rmanagers "github.com/dana-team/container-app-operator/internal/kinds/capp/resourcemanagers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const CappCleanupFinalizer = "dana.io/capp-cleanup"
@@ -27,6 +29,7 @@ func HandleResourceDeletion(ctx context.Context, capp cappv1alpha1.Capp, r clien
 // RemoveFinalizer removes the finalizer from the Capp manifest.
 func RemoveFinalizer(ctx context.Context, capp cappv1alpha1.Capp, r client.Client) error {
 	controllerutil.RemoveFinalizer(&capp, CappCleanupFinalizer)
+	ctrllog.FromContext(ctx).Info("kubernetes API write update", rclient.ObjectIdentityKeyVals(&capp)...)
 	if err := r.Update(ctx, &capp); err != nil {
 		return err
 	}
@@ -47,6 +50,7 @@ func finalizeCapp(capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.
 func EnsureFinalizer(ctx context.Context, service cappv1alpha1.Capp, r client.Client) error {
 	if !controllerutil.ContainsFinalizer(&service, CappCleanupFinalizer) {
 		controllerutil.AddFinalizer(&service, CappCleanupFinalizer)
+		ctrllog.FromContext(ctx).Info("kubernetes API write update", rclient.ObjectIdentityKeyVals(&service)...)
 		if err := r.Update(ctx, &service); err != nil {
 			return err
 		}

--- a/internal/kinds/capp/resourceclient/resourceclient.go
+++ b/internal/kinds/capp/resourceclient/resourceclient.go
@@ -14,8 +14,8 @@ type ResourceManagerClient struct {
 	Log       logr.Logger
 }
 
-// objectIdentityKeyVals returns key/value pairs identifying obj for structured logs.
-func objectIdentityKeyVals(obj client.Object) []any {
+// ObjectIdentityKeyVals returns key/value pairs identifying obj for structured logs.
+func ObjectIdentityKeyVals(obj client.Object) []any {
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	kind := gvk.Kind
 	if kind == "" {
@@ -33,7 +33,7 @@ func objectIdentityKeyVals(obj client.Object) []any {
 
 // CreateResource creates a resource.
 func (r ResourceManagerClient) CreateResource(resource client.Object) error {
-	r.Log.Info("kubernetes API write create", objectIdentityKeyVals(resource)...)
+	r.Log.Info("kubernetes API write create", ObjectIdentityKeyVals(resource)...)
 	if err := r.K8sclient.Create(r.Ctx, resource); err != nil {
 		return fmt.Errorf("failed to create resource %s %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName(), err)
 	}
@@ -42,7 +42,7 @@ func (r ResourceManagerClient) CreateResource(resource client.Object) error {
 
 // UpdateResource updates a resource.
 func (r ResourceManagerClient) UpdateResource(resource client.Object) error {
-	r.Log.Info("kubernetes API write update", objectIdentityKeyVals(resource)...)
+	r.Log.Info("kubernetes API write update", ObjectIdentityKeyVals(resource)...)
 	if err := r.K8sclient.Update(r.Ctx, resource); err != nil {
 		return fmt.Errorf("failed to update %s %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName(), err)
 	}
@@ -51,7 +51,7 @@ func (r ResourceManagerClient) UpdateResource(resource client.Object) error {
 
 // DeleteResource deletes a resource.
 func (r ResourceManagerClient) DeleteResource(resource client.Object) error {
-	r.Log.Info("kubernetes API write delete", objectIdentityKeyVals(resource)...)
+	r.Log.Info("kubernetes API write delete", ObjectIdentityKeyVals(resource)...)
 	if err := r.K8sclient.Delete(r.Ctx, resource); err != nil {
 		return fmt.Errorf("failed to delete %s %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName(), err)
 	}

--- a/internal/kinds/capp/resourceclient/resourceclient.go
+++ b/internal/kinds/capp/resourceclient/resourceclient.go
@@ -14,32 +14,46 @@ type ResourceManagerClient struct {
 	Log       logr.Logger
 }
 
+// objectIdentityKeyVals returns key/value pairs identifying obj for structured logs.
+func objectIdentityKeyVals(obj client.Object) []any {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	kind := gvk.Kind
+	if kind == "" {
+		kind = "Unknown"
+	}
+	return []any{
+		"kind", kind,
+		"group", gvk.Group,
+		"version", gvk.Version,
+		"namespace", obj.GetNamespace(),
+		"name", obj.GetName(),
+		"resourceVersion", obj.GetResourceVersion(),
+	}
+}
+
 // CreateResource creates a resource.
 func (r ResourceManagerClient) CreateResource(resource client.Object) error {
+	r.Log.Info("kubernetes API write create", objectIdentityKeyVals(resource)...)
 	if err := r.K8sclient.Create(r.Ctx, resource); err != nil {
 		return fmt.Errorf("failed to create resource %s %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName(), err)
 	}
-
-	r.Log.Info(fmt.Sprintf("successfully created %s %s", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName()))
 	return nil
 }
 
 // UpdateResource updates a resource.
 func (r ResourceManagerClient) UpdateResource(resource client.Object) error {
+	r.Log.Info("kubernetes API write update", objectIdentityKeyVals(resource)...)
 	if err := r.K8sclient.Update(r.Ctx, resource); err != nil {
 		return fmt.Errorf("failed to update %s %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName(), err)
 	}
-
-	r.Log.Info(fmt.Sprintf("successfully updated %s %s", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName()))
 	return nil
 }
 
 // DeleteResource deletes a resource.
 func (r ResourceManagerClient) DeleteResource(resource client.Object) error {
+	r.Log.Info("kubernetes API write delete", objectIdentityKeyVals(resource)...)
 	if err := r.K8sclient.Delete(r.Ctx, resource); err != nil {
 		return fmt.Errorf("failed to delete %s %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName(), err)
 	}
-
-	r.Log.Info(fmt.Sprintf("successfully deleted %s %s", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName()))
 	return nil
 }

--- a/internal/kinds/capp/status/capp.go
+++ b/internal/kinds/capp/status/capp.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	rmanagers "github.com/dana-team/container-app-operator/internal/kinds/capp/resourcemanagers"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
@@ -78,6 +79,7 @@ func SyncStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Logger, r 
 		return nil
 	}
 
+	log.Info("kubernetes API write status update", rclient.ObjectIdentityKeyVals(&cappObject)...)
 	if err := r.Status().Update(ctx, &cappObject); err != nil {
 		log.Error(err, "failed to update Capp status")
 		return err

--- a/internal/kinds/capprevision/adapters/capprevision_adapter.go
+++ b/internal/kinds/capprevision/adapters/capprevision_adapter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -67,23 +68,20 @@ func CreateCappRevision(ctx context.Context, k8sClient client.Client, logger log
 		return err
 	}
 
-	logger.Info(fmt.Sprintf("Trying to create CappRevision: %q.", cappRevision.Name))
+	logger.Info("kubernetes API write create", rclient.ObjectIdentityKeyVals(&cappRevision)...)
 	if err := k8sClient.Create(ctx, &cappRevision); err != nil {
-		logger.Error(err, fmt.Sprintf("Failed to create CappRevision %q.", cappRevision.Name))
+		logger.Error(err, "failed to create CappRevision", rclient.ObjectIdentityKeyVals(&cappRevision)...)
 		return err
 	}
-
-	logger.Info(fmt.Sprintf("Successfully created CappRevision %q", cappRevision.Name))
 	return nil
 }
 
 // DeleteCappRevision deletes a specified CappRevision and returning an error on failure.
 func DeleteCappRevision(ctx context.Context, k8sClient client.Client, logger logr.Logger, cappRevision *cappv1alpha1.CappRevision) error {
-	logger.Info(fmt.Sprintf("Trying to delete CappRevision: %q", cappRevision.Name))
+	logger.Info("kubernetes API write delete", rclient.ObjectIdentityKeyVals(cappRevision)...)
 	if err := k8sClient.Delete(ctx, cappRevision); err != nil {
-		logger.Error(err, fmt.Sprintf("Failed to delete CappRevision %q.", cappRevision.Name))
+		logger.Error(err, "failed to delete CappRevision", rclient.ObjectIdentityKeyVals(cappRevision)...)
 		return err
 	}
-
 	return nil
 }


### PR DESCRIPTION
Log kubernetes API write create/delete with structured identity fields
before client calls; use structured errors on failure and drop the old
sprintf success and "trying" messages.