### PR TITLE
test(webhook): add ValidateLogSpec unit tests, trim e2e

### DIFF
--- a/internal/webhook/rcs/common/utils_test.go
+++ b/internal/webhook/rcs/common/utils_test.go
@@ -4,7 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateDomainName(t *testing.T) {
@@ -73,6 +75,47 @@ func TestValidateDomainName(t *testing.T) {
 				}
 			} else {
 				assert.Nil(t, errs)
+			}
+		})
+	}
+}
+
+func TestValidateLogSpec(t *testing.T) {
+	const elasticLogHost = "https://elasticsearch.dana.com/_bulk"
+
+	tests := []struct {
+		name    string
+		logSpec cappv1alpha1.LogSpec
+		wantErr bool
+	}{
+		{
+			name: "denies when elastic log configuration omits required fields",
+			logSpec: cappv1alpha1.LogSpec{
+				Type: cappv1alpha1.LogTypeElastic,
+				Host: elasticLogHost,
+			},
+			wantErr: true,
+		},
+		{
+			name: "accepts when elastic log configuration includes all required fields",
+			logSpec: cappv1alpha1.LogSpec{
+				Type:           cappv1alpha1.LogTypeElastic,
+				Host:           elasticLogHost,
+				Index:          "main",
+				User:           "user",
+				PasswordSecret: "elastic-secret",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateLogSpec(tt.logSpec)
+			if tt.wantErr {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
 			}
 		})
 	}

--- a/test/e2e_tests/validating_e2e_test.go
+++ b/test/e2e_tests/validating_e2e_test.go
@@ -19,11 +19,6 @@ const (
 	clusterLocalHostname = "invalid.svc.cluster.local"
 	invalidHostName      = "invalid_domain!"
 	existingHostname     = "google.com"
-	elasticLogType       = "elastic"
-	elasticUser          = "user"
-	elasticHostExample   = "https://elasticsearch.dana.com/_bulk"
-	index                = "main"
-	secretName           = "elastic-secret"
 )
 
 var _ = Describe("Validate the validating webhook", func() {
@@ -86,25 +81,6 @@ var _ = Describe("Validate the validating webhook", func() {
 			return k8sClient.Update(context.Background(), &cappInCluster)
 		})
 		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("Should deny the use of an incomplete log spec", func() {
-		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Name = utilst.GenerateUniqueCappName(baseCapp.Name)
-		baseCapp.Spec.LogSpec.Type = elasticLogType
-		baseCapp.Spec.LogSpec.Host = elasticHostExample
-		Expect(k8sClient.Create(context.Background(), baseCapp)).ShouldNot(Succeed())
-	})
-
-	It("Should allow the use of a complete and supported log spec", func() {
-		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Name = utilst.GenerateUniqueCappName(baseCapp.Name)
-		baseCapp.Spec.LogSpec.Type = elasticLogType
-		baseCapp.Spec.LogSpec.Host = elasticHostExample
-		baseCapp.Spec.LogSpec.Index = index
-		baseCapp.Spec.LogSpec.User = elasticUser
-		baseCapp.Spec.LogSpec.PasswordSecret = secretName
-		Expect(k8sClient.Create(context.Background(), baseCapp)).Should(Succeed())
 	})
 
 })


### PR DESCRIPTION
Cover incomplete vs complete elastic LogSpec in
internal/webhook/rcs/common; remove duplicate scenarios from validating_e2e_test.go.

LogSpec rules are enforced entirely in ValidateLogSpec with no cluster state, so e2e only re-ran the same logic through the API server. Unit tests own that contract; webhook e2e stays focused on integration cases that need a real cluster.