### PR TITLE
fix(ksvc): deep copy Capp ConfigurationSpec for Knative Service

### DIFF
--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -67,7 +67,7 @@ func (k KnativeServiceManager) prepareResource(capp cappv1alpha1.Capp, ctx conte
 			Annotations: knativeServiceAnnotations,
 		},
 		Spec: knativev1.ServiceSpec{
-			ConfigurationSpec: capp.Spec.ConfigurationSpec,
+			ConfigurationSpec: *capp.Spec.ConfigurationSpec.DeepCopy(),
 		},
 	}
 


### PR DESCRIPTION
Avoid sharing nested slice data with the Capp when SetDefaults and volume appends mutate the built Service spec.