### PR TITLE
fix(capprevision): deep-copy Capp template into CappRevision

### DIFF
--- a/internal/kinds/capprevision/adapters/capprevision_adapter.go
+++ b/internal/kinds/capprevision/adapters/capprevision_adapter.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
@@ -56,9 +57,9 @@ func CreateCappRevision(ctx context.Context, k8sClient client.Client, logger log
 		},
 		Spec: cappv1alpha1.CappRevisionSpec{
 			CappTemplate: cappv1alpha1.CappTemplate{
-				Labels:      capp.Labels,
-				Annotations: capp.Annotations,
-				Spec:        capp.Spec,
+				Labels:      maps.Clone(capp.Labels),
+				Annotations: maps.Clone(capp.Annotations),
+				Spec:        *capp.Spec.DeepCopy(),
 			},
 			RevisionNumber: revisionNumber,
 		},


### PR DESCRIPTION
Snapshot Labels, Annotations, and Spec when creating a revision so the CappRevision does not share underlying maps or nested spec state with the live Capp (avoids accidental aliasing and stale mutations).