### PR TITLE
fix(webhook): skip Capp mutation on status subresource

### DIFF
--- a/internal/webhook/rcs/v1alpha1/mutator.go
+++ b/internal/webhook/rcs/v1alpha1/mutator.go
@@ -31,6 +31,10 @@ var (
 func (c *CappMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	logger := log.FromContext(ctx).WithValues("mutation webhook", "capp mutation Webhook", "Name", req.Name)
 
+	if req.SubResource == "status" {
+		return admission.Allowed("")
+	}
+
 	capp := v1alpha2.Capp{}
 	if err := c.Decoder.DecodeRaw(req.Object, &capp); err != nil {
 		logger.Error(err, "could not decode capp object")


### PR DESCRIPTION
Avoid applying last-updated-by and default resources on status writes so controller updates do not adds annotations or risk partial-spec defaults.