### PR TITLE
fix(webhook): reject nfs volumes without matching mounts

### DIFF
--- a/internal/webhook/rcs/v1alpha1/validator.go
+++ b/internal/webhook/rcs/v1alpha1/validator.go
@@ -3,6 +3,9 @@ package webhooks
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 
 	"net/http"
 
@@ -77,8 +80,42 @@ func (c *CappValidator) handle(ctx context.Context, capp cappv1alpha1.Capp, oldC
 		}
 	}
 
+	if err := validateNFSVolumeMounts(capp); err != nil {
+		return admission.Denied(err.Error())
+	}
+
 	if capp.Spec.ScaleSpec.MinReplicas > config.Spec.AutoscaleConfig.MinReplicasLimit {
 		return admission.Denied(fmt.Sprintf("invalid minReplicas %d: must be less than or equal to global min scale %d", capp.Spec.ScaleSpec.MinReplicas, config.Spec.AutoscaleConfig.MinReplicasLimit))
 	}
 	return admission.Allowed("")
+}
+
+func validateNFSVolumeMounts(capp cappv1alpha1.Capp) error {
+	if len(capp.Spec.VolumesSpec.NFSVolumes) == 0 {
+		return nil
+	}
+
+	mountedVolumes := make(map[string]struct{})
+	for _, container := range capp.Spec.ConfigurationSpec.Template.Spec.Containers {
+		for _, volumeMount := range container.VolumeMounts {
+			mountedVolumes[volumeMount.Name] = struct{}{}
+		}
+	}
+
+	missingVolumes := make(map[string]struct{})
+	for _, nfsVolume := range capp.Spec.VolumesSpec.NFSVolumes {
+		if _, ok := mountedVolumes[nfsVolume.Name]; ok {
+			continue
+		}
+		missingVolumes[nfsVolume.Name] = struct{}{}
+	}
+
+	if len(missingVolumes) == 0 {
+		return nil
+	}
+
+	missingVolumeNames := slices.Collect(maps.Keys(missingVolumes))
+	slices.Sort(missingVolumeNames)
+
+	return fmt.Errorf("invalid nfsVolumes: volumes [%s] must be mounted by at least one container", strings.Join(missingVolumeNames, ", "))
 }

--- a/internal/webhook/rcs/v1alpha1/validator_test.go
+++ b/internal/webhook/rcs/v1alpha1/validator_test.go
@@ -8,7 +8,9 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -91,6 +93,104 @@ func TestCappValidator_Handle(t *testing.T) {
 			assert.Equal(t, tc.expectAllow, resp.Allowed, "Expected allowed: %v, got: %v. Result: %v", tc.expectAllow, resp.Allowed, resp.Result)
 			if !tc.expectAllow && tc.expectMsg != "" {
 				assert.Contains(t, resp.Result.Message, tc.expectMsg)
+			}
+		})
+	}
+}
+
+func TestValidateNFSVolumeMounts(t *testing.T) {
+	invalidNFSVolumesMsg := "invalid nfsVolumes"
+	mustBeMountedMsg := "must be mounted by at least one container"
+	nfsVolumeName := "shared-data"
+
+	tests := []struct {
+		name            string
+		nfsVolumes      []cappv1alpha1.NFSVolume
+		containers      []corev1.Container
+		wantErrContains []string
+	}{
+		{
+			name: "allows when no nfs volumes are defined",
+		},
+		{
+			name: "allows when all nfs volumes are mounted",
+			nfsVolumes: []cappv1alpha1.NFSVolume{
+				{Name: nfsVolumeName},
+			},
+			containers: []corev1.Container{
+				{
+					Name: "main",
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: nfsVolumeName, MountPath: "/mnt/shared-data"},
+					},
+				},
+			},
+		},
+		{
+			name: "reports missing mount when nfs volume is not mounted",
+			nfsVolumes: []cappv1alpha1.NFSVolume{
+				{Name: nfsVolumeName},
+			},
+			containers: []corev1.Container{
+				{
+					Name: "main",
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "other-volume", MountPath: "/mnt/other-volume"},
+					},
+				},
+			},
+			wantErrContains: []string{
+				invalidNFSVolumesMsg,
+				nfsVolumeName,
+				mustBeMountedMsg,
+			},
+		},
+		{
+			name: "reports missing volumes",
+			nfsVolumes: []cappv1alpha1.NFSVolume{
+				{Name: "mounted"},
+				{Name: "z-data"},
+				{Name: "a-data"},
+				{Name: "a-data"},
+			},
+			containers: []corev1.Container{
+				{
+					Name: "mounted",
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "mounted", MountPath: "/mnt/mounted"},
+					},
+				},
+			},
+			wantErrContains: []string{
+				invalidNFSVolumesMsg,
+				"a-data",
+				"z-data",
+				mustBeMountedMsg,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+
+		t.Run(tc.name, func(t *testing.T) {
+			capp := cappv1alpha1.Capp{
+				Spec: cappv1alpha1.CappSpec{
+					VolumesSpec: cappv1alpha1.VolumesSpec{
+						NFSVolumes: tc.nfsVolumes,
+					},
+				},
+			}
+			capp.Spec.ConfigurationSpec.Template.Spec.Containers = tc.containers
+
+			err := validateNFSVolumeMounts(capp)
+			if len(tc.wantErrContains) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			for _, expectedSubstring := range tc.wantErrContains {
+				require.Contains(t, err.Error(), expectedSubstring)
 			}
 		})
 	}


### PR DESCRIPTION
Add Capp validating webhook checks to ensure every declared nfsVolume is mounted by at least one container before admission.

Add dedicated unit tests for validateNFSVolumeMounts to cover allow and deny paths, including missing mount scenarios.