### PR TITLE
test(autoscale): improve SetAutoScaler tests and trim metric e2e

### DIFF
--- a/internal/kinds/capp/autoscale/autoscale_test.go
+++ b/internal/kinds/capp/autoscale/autoscale_test.go
@@ -6,37 +6,62 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kautoscaling "knative.dev/serving/pkg/apis/autoscaling"
 )
 
 func TestSetAutoScaler(t *testing.T) {
-	exampleCapp := cappv1alpha1.Capp{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
+	tests := []struct {
+		name     string
+		metric   string
+		expected map[string]string
+	}{
+		{
+			name:   "uses HPA class and default cpu target for cpu metric",
+			metric: kautoscaling.CPU,
+			expected: map[string]string{
+				kautoscaling.ClassAnnotationKey:  kautoscaling.HPA,
+				kautoscaling.MetricAnnotationKey: kautoscaling.CPU,
+				kautoscaling.TargetAnnotationKey: "80",
+				kautoscaling.ActivationScaleKey:  "3",
+			},
 		},
-		Spec: cappv1alpha1.CappSpec{
-			ScaleSpec: cappv1alpha1.ScaleSpec{
-
-				Metric: "cpu",
+		{
+			name:   "uses KPA class and default rps target for rps metric",
+			metric: kautoscaling.RPS,
+			expected: map[string]string{
+				kautoscaling.ClassAnnotationKey:  kautoscaling.KPA,
+				kautoscaling.MetricAnnotationKey: kautoscaling.RPS,
+				kautoscaling.TargetAnnotationKey: "200",
+				kautoscaling.ActivationScaleKey:  "3",
+			},
+		},
+		{
+			name:   "uses HPA class and default memory target for memory metric",
+			metric: kautoscaling.Memory,
+			expected: map[string]string{
+				kautoscaling.ClassAnnotationKey:  kautoscaling.HPA,
+				kautoscaling.MetricAnnotationKey: kautoscaling.Memory,
+				kautoscaling.TargetAnnotationKey: "70",
+				kautoscaling.ActivationScaleKey:  "3",
 			},
 		},
 	}
-	exampleCappCpuExpected := map[string]string{
-		"autoscaling.knative.dev/class":            "hpa.autoscaling.knative.dev",
-		"autoscaling.knative.dev/metric":           "cpu",
-		"autoscaling.knative.dev/target":           "80",
-		"autoscaling.knative.dev/activation-scale": "3",
-	}
-	annotationsCpu := SetAutoScaler(exampleCapp, cappv1alpha1.AutoscaleConfig{})
-	assert.Equal(t, exampleCappCpuExpected, annotationsCpu)
 
-	exampleCapp.Spec.ScaleSpec.Metric = "rps"
-	exampleCappRpsExpected := map[string]string{
-		"autoscaling.knative.dev/class":            "kpa.autoscaling.knative.dev",
-		"autoscaling.knative.dev/metric":           "rps",
-		"autoscaling.knative.dev/target":           "200",
-		"autoscaling.knative.dev/activation-scale": "3",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capp := cappv1alpha1.Capp{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: cappv1alpha1.CappSpec{
+					ScaleSpec: cappv1alpha1.ScaleSpec{
+						Metric: tt.metric,
+					},
+				},
+			}
+			annotations := SetAutoScaler(capp, cappv1alpha1.AutoscaleConfig{})
+			assert.Equal(t, tt.expected, annotations)
+		})
 	}
-	annotationsRps := SetAutoScaler(exampleCapp, cappv1alpha1.AutoscaleConfig{})
-	assert.Equal(t, exampleCappRpsExpected, annotationsRps)
 }

--- a/test/e2e/knative_test.go
+++ b/test/e2e/knative_test.go
@@ -38,31 +38,18 @@ func checkRevisionReadiness(revisionName string) {
 	}, consts.Timeout, consts.Interval).Should(BeTrue())
 }
 
-// testMetricAnnotation tests capp instance creation with a specified metric annotation.
-func testMetricAnnotation(metricType string) {
-	By("Creating a capp instance")
-	testCapp := mocks.CreateBaseCapp()
-	testCapp.Spec.ScaleSpec.Metric = metricType
-	createdCapp := utilst.CreateCapp(k8sClient, testCapp)
-
-	By(fmt.Sprintf("Checking if the ksvc was created with %s metric annotation successfully", metricType))
-	Eventually(func() string {
-		ksvc := utilst.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
-		return ksvc.Spec.Template.Annotations[consts.KnativeMetricAnnotation]
-	}, consts.Timeout, consts.Interval).Should(Equal(metricType))
-}
-
 var _ = Describe("Validate knative functionality", func() {
-	It("Should create a ksvc with cpu metric annotation when creating a capp with cpu scale metric", func() {
-		testMetricAnnotation(consts.CPUScaleMetric)
-	})
-
 	It("Should create a ksvc with memory metric annotation when creating a capp with memory scale metric", func() {
-		testMetricAnnotation("memory")
-	})
+		By("Creating a capp instance with memory scale metric")
+		testCapp := mocks.CreateBaseCapp()
+		testCapp.Spec.ScaleSpec.Metric = consts.MemoryScaleMetric
+		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
 
-	It("Should create a ksvc with rps metric annotation when creating a capp with rps scale metric", func() {
-		testMetricAnnotation("rps")
+		By("Checking if the ksvc was created with memory metric annotation successfully")
+		Eventually(func() string {
+			ksvc := utilst.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			return ksvc.Spec.Template.Annotations[consts.KnativeMetricAnnotation]
+		}, consts.Timeout, consts.Interval).Should(Equal(consts.MemoryScaleMetric))
 	})
 
 	It("Should create and delete a ksvc when creating and deleting a capp instance", func() {


### PR DESCRIPTION
Table-driven unit tests with Knative constants. single memory KSVC create smoke replaces duplicate cpu/rps/metric cases.