### PR TITLE
refactor(capp): centralize ManagedResourceLabels helper

### DIFF
--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -64,10 +64,7 @@ func (c CertificateManager) prepareResource(capp cappv1alpha1.Capp) (cmapi.Certi
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resourceName,
 			Namespace: capp.Namespace,
-			Labels: map[string]string{
-				utils.CappResourceKey:   capp.Name,
-				utils.ManagedByLabelKey: utils.CappKey,
-			},
+			Labels:    utils.ManagedResourceLabels(capp.Name),
 		},
 		Spec: cmapi.CertificateSpec{
 			CommonName: utils.TruncateCommonName(resourceName),

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -62,11 +62,9 @@ func (r DNSRecordManager) prepareResource(capp cappv1alpha1.Capp) (dnsrecordv1al
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resourceName,
 			Namespace: capp.Namespace,
-			Labels: map[string]string{
-				utils.CappResourceKey:   capp.Name,
-				utils.CappNamespaceKey:  capp.Namespace,
-				utils.ManagedByLabelKey: utils.CappKey,
-			},
+			Labels: utils.MergeMaps(utils.ManagedResourceLabels(capp.Name), map[string]string{
+				utils.CappNamespaceKey: capp.Namespace,
+			}),
 		},
 		Spec: dnsrecordv1alpha1.CNAMERecordSpec{
 			ForProvider: dnsrecordv1alpha1.CNAMERecordParameters{

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -58,10 +58,7 @@ func (k KnativeDomainMappingManager) prepareResource(capp cappv1alpha1.Capp) (kn
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resourceName,
 			Namespace: capp.Namespace,
-			Labels: map[string]string{
-				utils.CappResourceKey:   capp.Name,
-				utils.ManagedByLabelKey: utils.CappKey,
-			},
+			Labels:    utils.ManagedResourceLabels(capp.Name),
 		},
 		Spec: knativev1beta1.DomainMappingSpec{
 			Ref: duckv1.KReference{

--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -58,12 +58,9 @@ func (k KnativeServiceManager) prepareResource(capp cappv1alpha1.Capp, ctx conte
 	knativeService := knativev1.Service{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      capp.Name,
-			Namespace: capp.Namespace,
-			Labels: map[string]string{
-				utils.CappResourceKey:   capp.Name,
-				utils.ManagedByLabelKey: utils.CappKey,
-			},
+			Name:        capp.Name,
+			Namespace:   capp.Namespace,
+			Labels:      utils.ManagedResourceLabels(capp.Name),
 			Annotations: knativeServiceAnnotations,
 		},
 		Spec: knativev1.ServiceSpec{

--- a/internal/kinds/capp/resourcemanagers/nfspvc.go
+++ b/internal/kinds/capp/resourcemanagers/nfspvc.go
@@ -44,10 +44,7 @@ func (n NFSPVCManager) prepareResource(capp cappv1alpha1.Capp) []nfspvcv1alpha1.
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nfsVolume.Name,
 				Namespace: capp.Namespace,
-				Labels: map[string]string{
-					utils.CappResourceKey:   capp.Name,
-					utils.ManagedByLabelKey: utils.CappKey,
-				},
+				Labels:    utils.ManagedResourceLabels(capp.Name),
 			},
 			Spec: nfspvcv1alpha1.NfsPvcSpec{
 				Server: nfsVolume.Server,

--- a/internal/kinds/capp/resourcemanagers/syslogngflow.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngflow.go
@@ -44,10 +44,7 @@ func (f SyslogNGFlowManager) prepareResource(capp cappv1alpha1.Capp) loggingv1be
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      syslogNGFlowName,
 			Namespace: capp.GetNamespace(),
-			Labels: map[string]string{
-				utils.CappResourceKey:   capp.Name,
-				utils.ManagedByLabelKey: utils.CappKey,
-			},
+			Labels:    utils.ManagedResourceLabels(capp.Name),
 		},
 		Spec: loggingv1beta1.SyslogNGFlowSpec{
 			Match: &loggingv1beta1.SyslogNGMatch{

--- a/internal/kinds/capp/resourcemanagers/syslogngoutput.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngoutput.go
@@ -116,10 +116,7 @@ func (o SyslogNGOutputManager) prepareResource(capp cappv1alpha1.Capp) loggingv1
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      syslogNGOutputName,
 				Namespace: capp.GetNamespace(),
-				Labels: map[string]string{
-					utils.CappResourceKey:   capp.Name,
-					utils.ManagedByLabelKey: utils.CappKey,
-				},
+				Labels:    utils.ManagedResourceLabels(capp.Name),
 			},
 			Spec: syslogNGOutputSpec,
 		}

--- a/internal/kinds/capp/utils/utils.go
+++ b/internal/kinds/capp/utils/utils.go
@@ -28,6 +28,14 @@ const (
 	CappKey        = "capp"
 )
 
+// ManagedResourceLabels returns labels used for child resources reconciled from a Capp.
+func ManagedResourceLabels(cappName string) map[string]string {
+	return map[string]string{
+		CappResourceKey:   cappName,
+		ManagedByLabelKey: CappKey,
+	}
+}
+
 // IsOnOpenshift returns true if the cluster has the openshift config group
 func IsOnOpenshift(config *rest.Config) (bool, error) {
 	dc, err := discovery.NewDiscoveryClientForConfig(config)

--- a/internal/kinds/capp/utils/utils_test.go
+++ b/internal/kinds/capp/utils/utils_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestManagedResourceLabels(t *testing.T) {
+	const cappName = "my-capp"
+	labels := utils.ManagedResourceLabels(cappName)
+	require.Equal(t, cappName, labels[utils.CappResourceKey])
+	require.Equal(t, utils.CappKey, labels[utils.ManagedByLabelKey])
+}
+
 func TestExcludeKeysWithPrefix(t *testing.T) {
 	object := map[string]string{
 		"prefix_key1": "value1",


### PR DESCRIPTION
Introduce utils.ManagedResourceLabels for parent-capp and managed-by labels on Capp-managed workloads. Replace duplicated literal maps in certificate, dnsrecord, domainmapping, knative service, nfs pvc, and syslog managers. DNS records keep an extra namespace label via MergeMaps. Add a unit test for the helper contract.