### PR TITLE
fix(capp): correct DNSRecord cleanup error wrap text

### DIFF
--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -140,7 +140,7 @@ func (r DNSRecordManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 
 	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
 		if err := r.handlePreviousDNSRecords(capp, resourceManager, dnsRecordFromCapp.Name); err != nil {
-			return fmt.Errorf("failed to delete previous Certificates: %w", err)
+			return fmt.Errorf("failed to delete previous DNSRecords: %w", err)
 		}
 	}
 


### PR DESCRIPTION
The handlePreviousDNSRecords failure path incorrectly mentioned Certificates; it deletes DNS records for the Capp route.