### PR TITLE
feat: add event URI to event sources

### DIFF
--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -91,6 +91,11 @@ type SourceConfiguration struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
+
+	// URI is the relative URI path that the source will send events to.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self == '' || self.startsWith('/')",message="path must start with '/' if specified"
+	URI string `json:"uri,omitempty"`
 }
 
 // VolumesSpec defines the volumes specification for the Capp.

--- a/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
@@ -8814,6 +8814,13 @@ spec:
                                     for this source within the Capp.
                                   minLength: 1
                                   type: string
+                                uri:
+                                  description: URI is the relative URI path that the
+                                    source will send events to.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: path must start with '/' if specified
+                                    rule: self == '' || self.startsWith('/')
                               required:
                               - name
                               type: object

--- a/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
@@ -8632,6 +8632,13 @@ spec:
                             source within the Capp.
                           minLength: 1
                           type: string
+                        uri:
+                          description: URI is the relative URI path that the source
+                            will send events to.
+                          type: string
+                          x-kubernetes-validations:
+                          - message: path must start with '/' if specified
+                            rule: self == '' || self.startsWith('/')
                       required:
                       - name
                       type: object

--- a/config/crd/bases/rcs.dana.io_capprevisions.yaml
+++ b/config/crd/bases/rcs.dana.io_capprevisions.yaml
@@ -8814,6 +8814,13 @@ spec:
                                     for this source within the Capp.
                                   minLength: 1
                                   type: string
+                                uri:
+                                  description: URI is the relative URI path that the
+                                    source will send events to.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: path must start with '/' if specified
+                                    rule: self == '' || self.startsWith('/')
                               required:
                               - name
                               type: object

--- a/config/crd/bases/rcs.dana.io_capps.yaml
+++ b/config/crd/bases/rcs.dana.io_capps.yaml
@@ -8632,6 +8632,13 @@ spec:
                             source within the Capp.
                           minLength: 1
                           type: string
+                        uri:
+                          description: URI is the relative URI path that the source
+                            will send events to.
+                          type: string
+                          x-kubernetes-validations:
+                          - message: path must start with '/' if specified
+                            rule: self == '' || self.startsWith('/')
                       required:
                       - name
                       type: object


### PR DESCRIPTION
Add uri field to SourceConfiguration and mutate it in webhook to ensure all event source URIs start with /, defaulting empty to "/".