### PR TITLE
fix: use CappConfig DNS provider instead of hardcoded  "default" for DNSRecord

### DIFF
--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -76,8 +76,13 @@ func (r DNSRecordManager) prepareResource(capp cappv1alpha1.Capp) (dnsrecordv1al
 		},
 	}
 
+	provider, err := utils.GetXPProviderFromConfig(dnsConfig)
+	if err != nil {
+		return dnsrecordv1alpha1.CNAMERecord{}, err
+	}
+
 	dnsRecord.Spec.ProviderConfigReference = &xpv1.ProviderConfigReference{
-		Name: "default",
+		Name: provider,
 		Kind: ClusterProviderConfigKind,
 	}
 


### PR DESCRIPTION
Resolves #521