### PR TITLE
feat: add DomainMapping and Certificate watch predicates for status changes

### DIFF
--- a/internal/kinds/capp/controllers/controller.go
+++ b/internal/kinds/capp/controllers/controller.go
@@ -15,6 +15,7 @@ import (
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 
 	"k8s.io/apimachinery/pkg/types"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -93,12 +94,12 @@ func (r *CappReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&knativev1beta1.DomainMapping{},
 			handler.EnqueueRequestsFromMapFunc(r.findCappFromHostname),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+			builder.WithPredicates(domainMappingWatchPredicate()),
 		).
 		Watches(
 			&cmapi.Certificate{},
 			handler.EnqueueRequestsFromMapFunc(r.findCappFromHostname),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+			builder.WithPredicates(certificateWatchPredicate()),
 		).
 		Watches(
 			&dnsrecordv1alpha1.CNAMERecord{},
@@ -160,6 +161,84 @@ func cnameRecordConditionChanged(
 	oldCond := oldObj.Status.GetCondition(conditionType)
 	newCond := newObj.Status.GetCondition(conditionType)
 	return oldCond.Status != newCond.Status
+}
+
+// conditionStatusChanged reports whether the status value of condType differs
+// between oldConds and newConds. Both type and status are compared as strings
+// so this works across knative, cert-manager, and any other condition schema.
+func conditionStatusChanged(oldConds, newConds []conditionPair, condType string) bool {
+	find := func(conds []conditionPair) string {
+		for _, c := range conds {
+			if c.condType == condType {
+				return c.status
+			}
+		}
+		return ""
+	}
+	return find(oldConds) != find(newConds)
+}
+
+type conditionPair struct {
+	condType string
+	status   string
+}
+
+// domainMappingWatchPredicate triggers on spec changes (generation) or Ready condition status changes.
+func domainMappingWatchPredicate() predicate.Predicate {
+	return predicate.Or(
+		predicate.GenerationChangedPredicate{},
+		predicate.TypedFuncs[client.Object]{
+			UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
+				oldObj, okOld := e.ObjectOld.(*knativev1beta1.DomainMapping)
+				newObj, okNew := e.ObjectNew.(*knativev1beta1.DomainMapping)
+				if !okOld || !okNew {
+					return false
+				}
+				return conditionStatusChanged(
+					knativeConditions(oldObj.Status.Conditions),
+					knativeConditions(newObj.Status.Conditions),
+					string(knativev1beta1.DomainMappingConditionReady),
+				)
+			},
+		},
+	)
+}
+
+func knativeConditions(conds duckv1.Conditions) []conditionPair {
+	out := make([]conditionPair, len(conds))
+	for i, c := range conds {
+		out[i] = conditionPair{condType: string(c.Type), status: string(c.Status)}
+	}
+	return out
+}
+
+// certificateWatchPredicate triggers on spec changes (generation) or Ready condition status changes.
+func certificateWatchPredicate() predicate.Predicate {
+	return predicate.Or(
+		predicate.GenerationChangedPredicate{},
+		predicate.TypedFuncs[client.Object]{
+			UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
+				oldObj, okOld := e.ObjectOld.(*cmapi.Certificate)
+				newObj, okNew := e.ObjectNew.(*cmapi.Certificate)
+				if !okOld || !okNew {
+					return false
+				}
+				return conditionStatusChanged(
+					certificateConditions(oldObj.Status.Conditions),
+					certificateConditions(newObj.Status.Conditions),
+					string(cmapi.CertificateConditionReady),
+				)
+			},
+		},
+	)
+}
+
+func certificateConditions(conds []cmapi.CertificateCondition) []conditionPair {
+	out := make([]conditionPair, len(conds))
+	for i, c := range conds {
+		out[i] = conditionPair{condType: string(c.Type), status: string(c.Status)}
+	}
+	return out
 }
 
 // findCappFromKnative maps reconciliation requests to Capp reconciliation requests.

--- a/internal/kinds/capp/controllers/controller_test.go
+++ b/internal/kinds/capp/controllers/controller_test.go
@@ -1,0 +1,230 @@
+package controllers
+
+import (
+	"testing"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	knativeapis "knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
+)
+
+func TestConditionStatusChanged(t *testing.T) {
+	tests := []struct {
+		name     string
+		oldConds []conditionPair
+		newConds []conditionPair
+		condType string
+		expected bool
+	}{
+		{
+			name:     "no change when both have same status",
+			oldConds: []conditionPair{{condType: "Ready", status: "True"}},
+			newConds: []conditionPair{{condType: "Ready", status: "True"}},
+			condType: "Ready",
+			expected: false,
+		},
+		{
+			name:     "no change when neither has the condition",
+			oldConds: []conditionPair{},
+			newConds: []conditionPair{},
+			condType: "Ready",
+			expected: false,
+		},
+		{
+			name:     "changed when status transitions",
+			oldConds: []conditionPair{{condType: "Ready", status: "False"}},
+			newConds: []conditionPair{{condType: "Ready", status: "True"}},
+			condType: "Ready",
+			expected: true,
+		},
+		{
+			name:     "changed when condition appears",
+			oldConds: []conditionPair{},
+			newConds: []conditionPair{{condType: "Ready", status: "True"}},
+			condType: "Ready",
+			expected: true,
+		},
+		{
+			name:     "changed when condition disappears",
+			oldConds: []conditionPair{{condType: "Ready", status: "True"}},
+			newConds: []conditionPair{},
+			condType: "Ready",
+			expected: true,
+		},
+		{
+			name:     "ignores other condition types",
+			oldConds: []conditionPair{{condType: "Ready", status: "True"}, {condType: "Synced", status: "False"}},
+			newConds: []conditionPair{{condType: "Ready", status: "True"}, {condType: "Synced", status: "True"}},
+			condType: "Ready",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, conditionStatusChanged(tt.oldConds, tt.newConds, tt.condType))
+		})
+	}
+}
+
+func TestKnativeConditions(t *testing.T) {
+	conds := duckv1.Conditions{
+		{Type: knativev1beta1.DomainMappingConditionReady, Status: corev1.ConditionTrue},
+		{Type: knativev1beta1.DomainMappingConditionIngressReady, Status: corev1.ConditionFalse},
+	}
+	pairs := knativeConditions(conds)
+	assert.Equal(t, []conditionPair{
+		{condType: "Ready", status: "True"},
+		{condType: "IngressReady", status: "False"},
+	}, pairs)
+}
+
+func TestCertificateConditions(t *testing.T) {
+	conds := []cmapi.CertificateCondition{
+		{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue},
+		{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionFalse},
+	}
+	pairs := certificateConditions(conds)
+	assert.Equal(t, []conditionPair{
+		{condType: "Ready", status: "True"},
+		{condType: "Issuing", status: "False"},
+	}, pairs)
+}
+
+func TestDomainMappingWatchPredicateIntegration(t *testing.T) {
+	makeDM := func(condStatus corev1.ConditionStatus) *knativev1beta1.DomainMapping {
+		dm := &knativev1beta1.DomainMapping{}
+		if condStatus != "" {
+			dm.Status.Conditions = duckv1.Conditions{
+				{Type: knativev1beta1.DomainMappingConditionReady, Status: condStatus},
+			}
+		}
+		return dm
+	}
+
+	tests := []struct {
+		name     string
+		oldObj   *knativev1beta1.DomainMapping
+		newObj   *knativev1beta1.DomainMapping
+		expected bool
+	}{
+		{
+			name:     "no change when both Ready=True",
+			oldObj:   makeDM(corev1.ConditionTrue),
+			newObj:   makeDM(corev1.ConditionTrue),
+			expected: false,
+		},
+		{
+			name:     "changed when Ready transitions False to True",
+			oldObj:   makeDM(corev1.ConditionFalse),
+			newObj:   makeDM(corev1.ConditionTrue),
+			expected: true,
+		},
+		{
+			name:     "changed when Ready condition appears",
+			oldObj:   makeDM(""),
+			newObj:   makeDM(corev1.ConditionTrue),
+			expected: true,
+		},
+		{
+			name: "ignores non-Ready condition changes",
+			oldObj: func() *knativev1beta1.DomainMapping {
+				dm := makeDM(corev1.ConditionTrue)
+				dm.Status.Conditions = append(dm.Status.Conditions, knativeapis.Condition{
+					Type: knativev1beta1.DomainMappingConditionIngressReady, Status: corev1.ConditionFalse,
+				})
+				return dm
+			}(),
+			newObj: func() *knativev1beta1.DomainMapping {
+				dm := makeDM(corev1.ConditionTrue)
+				dm.Status.Conditions = append(dm.Status.Conditions, knativeapis.Condition{
+					Type: knativev1beta1.DomainMappingConditionIngressReady, Status: corev1.ConditionTrue,
+				})
+				return dm
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := conditionStatusChanged(
+				knativeConditions(tt.oldObj.Status.Conditions),
+				knativeConditions(tt.newObj.Status.Conditions),
+				string(knativev1beta1.DomainMappingConditionReady),
+			)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCertificateWatchPredicateIntegration(t *testing.T) {
+	makeCert := func(condStatus cmmeta.ConditionStatus) *cmapi.Certificate {
+		cert := &cmapi.Certificate{}
+		if condStatus != "" {
+			cert.Status.Conditions = []cmapi.CertificateCondition{
+				{Type: cmapi.CertificateConditionReady, Status: condStatus},
+			}
+		}
+		return cert
+	}
+
+	tests := []struct {
+		name     string
+		oldObj   *cmapi.Certificate
+		newObj   *cmapi.Certificate
+		expected bool
+	}{
+		{
+			name:     "no change when both Ready=True",
+			oldObj:   makeCert(cmmeta.ConditionTrue),
+			newObj:   makeCert(cmmeta.ConditionTrue),
+			expected: false,
+		},
+		{
+			name:     "changed when Ready transitions False to True",
+			oldObj:   makeCert(cmmeta.ConditionFalse),
+			newObj:   makeCert(cmmeta.ConditionTrue),
+			expected: true,
+		},
+		{
+			name:     "changed when Ready condition appears",
+			oldObj:   makeCert(""),
+			newObj:   makeCert(cmmeta.ConditionTrue),
+			expected: true,
+		},
+		{
+			name: "ignores non-Ready condition changes",
+			oldObj: func() *cmapi.Certificate {
+				cert := makeCert(cmmeta.ConditionTrue)
+				cert.Status.Conditions = append(cert.Status.Conditions, cmapi.CertificateCondition{
+					Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionTrue,
+				})
+				return cert
+			}(),
+			newObj: func() *cmapi.Certificate {
+				cert := makeCert(cmmeta.ConditionTrue)
+				cert.Status.Conditions = append(cert.Status.Conditions, cmapi.CertificateCondition{
+					Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionFalse,
+				})
+				return cert
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := conditionStatusChanged(
+				certificateConditions(tt.oldObj.Status.Conditions),
+				certificateConditions(tt.newObj.Status.Conditions),
+				string(cmapi.CertificateConditionReady),
+			)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
DomainMapping and Certificate watches used only GenerationChangedPredicate, which misses status-only updates. This caused Capp status to remain stale (e.g. showing NotReady) even after the Certificate was issued or DomainMapping URL became available.

Add domainMappingWatchPredicate and certificateWatchPredicate that combine GenerationChangedPredicate with Ready condition status change detection, following the same pattern as knativeServiceWatchPredicate.

Resolves #524