### PR TITLE
fix(dnsrecord): remove duplicate provider lookup in prepareResource

### DIFF
--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -80,11 +80,6 @@ func (r DNSRecordManager) prepareResource(capp cappv1alpha1.Capp) (dnsrecordv1al
 		return dnsrecordv1alpha1.CNAMERecord{}, err
 	}
 
-	provider, err := utils.GetXPProviderFromConfig(dnsConfig)
-	if err != nil {
-		return dnsrecordv1alpha1.CNAMERecord{}, err
-	}
-
 	dnsRecord.Spec.ProviderConfigReference = &xpv1.ProviderConfigReference{
 		Name: provider,
 		Kind: ClusterProviderConfigKind,


### PR DESCRIPTION
Drop a duplicated GetXPProviderFromConfig block.