### PR TITLE
chore(e2e): rename utilst import alias to utils

### DIFF
--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -80,11 +80,6 @@ func (r DNSRecordManager) prepareResource(capp cappv1alpha1.Capp) (dnsrecordv1al
 		return dnsrecordv1alpha1.CNAMERecord{}, err
 	}
 
-	provider, err := utils.GetXPProviderFromConfig(dnsConfig)
-	if err != nil {
-		return dnsrecordv1alpha1.CNAMERecord{}, err
-	}
-
 	dnsRecord.Spec.ProviderConfigReference = &xpv1.ProviderConfigReference{
 		Name: provider,
 		Kind: ClusterProviderConfigKind,

--- a/test/e2e/capp_revision_test.go
+++ b/test/e2e/capp_revision_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 	"github.com/dana-team/container-app-operator/test/e2e/mocks"
-	utilst "github.com/dana-team/container-app-operator/test/e2e/utils"
+	"github.com/dana-team/container-app-operator/test/e2e/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -24,38 +24,38 @@ var _ = Describe("Validate CappRevision creation", func() {
 	It("Should validate CappRevison lifecycle based on Capp lifecycle", func() {
 		baseCapp := mocks.CreateBaseCapp()
 		By("Creating regular Capp")
-		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
+		desiredCapp := utils.CreateCapp(k8sClient, baseCapp)
 
 		Eventually(func() int {
-			cappRevisons, _ := utilst.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
+			cappRevisons, _ := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
 			return len(cappRevisons)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeZero(), "Should create CappRevisions")
 
 		cappRevisionName := kmeta.ChildName(desiredCapp.Name, fmt.Sprintf("-%05d", 1))
-		utilst.GetCappRevision(k8sClient, cappRevisionName, desiredCapp.Namespace)
+		utils.GetCappRevision(k8sClient, cappRevisionName, desiredCapp.Namespace)
 
 		By("Updating Capp")
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			desiredCapp = utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			desiredCapp = utils.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 			desiredCapp.Annotations = make(map[string]string)
 			desiredCapp.Annotations["test"] = "test"
 
-			return utilst.UpdateResource(k8sClient, desiredCapp)
+			return utils.UpdateResource(k8sClient, desiredCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() bool {
-			cappRevisions, _ := utilst.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
+			cappRevisions, _ := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
 			return len(cappRevisions) > 1
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should create new CappRevision")
 
 		cappRevisionName = kmeta.ChildName(desiredCapp.Name, fmt.Sprintf("-%05d", 2))
-		utilst.GetCappRevision(k8sClient, cappRevisionName, desiredCapp.Namespace)
+		utils.GetCappRevision(k8sClient, cappRevisionName, desiredCapp.Namespace)
 
 		By("Deleting Capp")
-		utilst.DeleteCapp(k8sClient, desiredCapp)
+		utils.DeleteCapp(k8sClient, desiredCapp)
 		Eventually(func() int {
-			cappRevisons, _ := utilst.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
+			cappRevisons, _ := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
 			return len(cappRevisons)
 		}, consts.Timeout, consts.Interval).Should(BeZero(), "Should delete all CappRevisions")
 
@@ -65,31 +65,31 @@ var _ = Describe("Validate CappRevision creation", func() {
 		baseCapp := mocks.CreateBaseCapp()
 
 		By("Creating Capp")
-		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
-		desiredCapp = utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
+		desiredCapp := utils.CreateCapp(k8sClient, baseCapp)
+		desiredCapp = utils.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 		desiredCapp.Annotations = make(map[string]string)
 
 		By("Checking many updates to Capp")
 		for i := 1; i < moreThanRevisionsToKeep; i++ {
 			assertValue := fmt.Sprintf("test%s", strconv.Itoa(i))
-			err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-				desiredCapp = utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
+			err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+				desiredCapp = utils.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 				desiredCapp.Annotations = make(map[string]string)
 				desiredCapp.Annotations["test"] = assertValue
 
-				return utilst.UpdateResource(k8sClient, desiredCapp)
+				return utils.UpdateResource(k8sClient, desiredCapp)
 			})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() string {
-				return utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace).Annotations["test"]
+				return utils.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace).Annotations["test"]
 			}, consts.Timeout, consts.Interval).Should(Equal(assertValue), "Should be equal to the updated value")
 
-			desiredCapp = utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
+			desiredCapp = utils.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 		}
 
 		Eventually(func() int {
-			cappRevisions, _ := utilst.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
+			cappRevisions, _ := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
 			return len(cappRevisions)
 		}, consts.Timeout, consts.Interval).Should(BeNumerically("<=", revisionsToKeep),
 			fmt.Sprintf("Should limit to at most %s CappRevision", strconv.Itoa(revisionsToKeep)))

--- a/test/e2e/capp_test.go
+++ b/test/e2e/capp_test.go
@@ -3,7 +3,7 @@ package e2e
 import (
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 	"github.com/dana-team/container-app-operator/test/e2e/mocks"
-	utilst "github.com/dana-team/container-app-operator/test/e2e/utils"
+	"github.com/dana-team/container-app-operator/test/e2e/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/util/retry"
@@ -15,54 +15,54 @@ var _ = Describe("Validate capp creation", func() {
 	It("Should default scale metric when unset", func() {
 		baseCapp := mocks.CreateBaseCapp()
 		By("Creating Capp with no scale metric")
-		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
+		desiredCapp := utils.CreateCapp(k8sClient, baseCapp)
 		Expect(desiredCapp.Spec.ScaleSpec.Metric).ShouldNot(BeNil())
 	})
 
 	It("Should succeed all adapter functions", func() {
 		baseCapp := mocks.CreateBaseCapp()
-		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
+		desiredCapp := utils.CreateCapp(k8sClient, baseCapp)
 
 		By("Checks unique creation of Capp")
-		assertionCapp := utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
+		assertionCapp := utils.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 		Expect(assertionCapp.Name).ShouldNot(Equal(baseCapp.Name))
 
 		By("Checks if Capp updated successfully")
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			assertionCapp := utils.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 			assertionCapp.Spec.ScaleSpec.Metric = consts.RPSScaleMetric
 
-			return utilst.UpdateResource(k8sClient, assertionCapp)
+			return utils.UpdateResource(k8sClient, assertionCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() string {
-			assertionCapp = utilst.GetCapp(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
+			assertionCapp = utils.GetCapp(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
 			return assertionCapp.Spec.ScaleSpec.Metric
 		}, consts.Timeout, consts.Interval).Should(Equal(consts.RPSScaleMetric), "Should fetch capp.")
 
 		By("Checks if deleted successfully")
-		utilst.DeleteCapp(k8sClient, assertionCapp)
+		utils.DeleteCapp(k8sClient, assertionCapp)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, assertionCapp)
+			return utils.DoesResourceExist(k8sClient, assertionCapp)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
 	It("Validate state functionality", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
-		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(k8sClient, testCapp)
 
 		By("Checking if the capp state is enabled")
 		Eventually(func() string {
-			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			return capp.Status.StateStatus.State
 		}, consts.Timeout, consts.Interval).Should(Equal(consts.EnabledState))
 
 		By("Checking if the ksvc was created successfully")
 		ksvcObject := mocks.CreateKnativeServiceObject(createdCapp.Name)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, ksvcObject)
+			return utils.DoesResourceExist(k8sClient, ksvcObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking if the revision is ready")
@@ -70,41 +70,41 @@ var _ = Describe("Validate capp creation", func() {
 		checkRevisionReadiness(revisionName)
 
 		By("Updating the capp status to be disabled")
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			assertionCapp.Spec.State = consts.DisabledState
 
-			return utilst.UpdateResource(k8sClient, assertionCapp)
+			return utils.UpdateResource(k8sClient, assertionCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Checking if the capp state is disabled")
 		Eventually(func() string {
-			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			return capp.Status.StateStatus.State
 		}, consts.Timeout, consts.Interval).Should(Equal(consts.DisabledState))
 
 		By("Checking if the ksvc and the revision were deleted successfully")
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, ksvcObject)
+			return utils.DoesResourceExist(k8sClient, ksvcObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 		Eventually(func() bool {
 			revision := mocks.CreateRevisionObject(revisionName)
-			return utilst.DoesResourceExist(k8sClient, revision)
+			return utils.DoesResourceExist(k8sClient, revision)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Updating the capp status to be enabled")
-		err = retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err = retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			assertionCapp.Spec.State = consts.EnabledState
 
-			return utilst.UpdateResource(k8sClient, assertionCapp)
+			return utils.UpdateResource(k8sClient, assertionCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Checking if the ksvc was recreated successfully")
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, ksvcObject)
+			return utils.DoesResourceExist(k8sClient, ksvcObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking if the revision is ready")
@@ -112,19 +112,19 @@ var _ = Describe("Validate capp creation", func() {
 	})
 	It("Should validate minReplicas defaulting and validation", func() {
 		baseCapp := mocks.CreateBaseCapp()
-		baseCapp.Name = utilst.GenerateCappName()
+		baseCapp.Name = utils.GenerateCappName()
 
 		By("Creating Capp with no minReplicas (should default to 0)")
-		createdCapp := utilst.CreateCapp(k8sClient, baseCapp)
+		createdCapp := utils.CreateCapp(k8sClient, baseCapp)
 		Eventually(func() int {
-			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			return capp.Spec.ScaleSpec.MinReplicas
 		}, consts.Timeout, consts.Interval).Should(Equal(0))
 
 		By("Verifying KSVC annotation for default minReplicas")
 		Eventually(func() bool {
 			ksvc := &knativev1.Service{}
-			utilst.GetResource(k8sClient, ksvc, createdCapp.Name, createdCapp.Namespace)
+			utils.GetResource(k8sClient, ksvc, createdCapp.Name, createdCapp.Namespace)
 			minReplicas, found := ksvc.Spec.Template.Annotations[autoscaling.MinScaleAnnotationKey]
 			if !found {
 				return true
@@ -133,37 +133,37 @@ var _ = Describe("Validate capp creation", func() {
 		}, consts.Timeout, consts.Interval).Should(BeTrue())
 
 		By("Updating Capp with valid minReplicas")
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			capp.Spec.ScaleSpec.MinReplicas = 3
-			return utilst.UpdateResource(k8sClient, capp)
+			return utils.UpdateResource(k8sClient, capp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verifying Capp has minReplicas=3")
 		Eventually(func() int {
-			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			return capp.Spec.ScaleSpec.MinReplicas
 		}, consts.Timeout, consts.Interval).Should(Equal(3))
 
 		By("Verifying KSVC annotation for minReplicas=3")
 		Eventually(func() string {
 			ksvc := &knativev1.Service{}
-			utilst.GetResource(k8sClient, ksvc, createdCapp.Name, createdCapp.Namespace)
+			utils.GetResource(k8sClient, ksvc, createdCapp.Name, createdCapp.Namespace)
 			return ksvc.Spec.Template.Annotations[autoscaling.MinScaleAnnotationKey]
 		}, consts.Timeout, consts.Interval).Should(Equal("3"))
 
 		By("Updating Capp with invalid minReplicas (> GlobalMinScale)")
 
-		err = retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err = retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			capp.Spec.ScaleSpec.MinReplicas = 20
-			return utilst.UpdateResource(k8sClient, capp)
+			return utils.UpdateResource(k8sClient, capp)
 		})
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("must be less than or equal to global min scale"))
 
 		By("Cleaning up")
-		utilst.DeleteCapp(k8sClient, createdCapp)
+		utils.DeleteCapp(k8sClient, createdCapp)
 	})
 })

--- a/test/e2e/certificate_test.go
+++ b/test/e2e/certificate_test.go
@@ -6,7 +6,7 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 	"github.com/dana-team/container-app-operator/test/e2e/mocks"
-	utilst "github.com/dana-team/container-app-operator/test/e2e/utils"
+	"github.com/dana-team/container-app-operator/test/e2e/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -17,17 +17,17 @@ import (
 var _ = Describe("Validate Certificate functionality", func() {
 	It("Should create, update and delete Certificate when creating, updating and deleting a Capp instance", func() {
 		By("Creating an HTTPS Capp")
-		createdCapp, routeHostname := utilst.CreateHTTPSCapp(k8sClient)
+		createdCapp, routeHostname := utils.CreateHTTPSCapp(k8sClient)
 
 		By("Checking if the Certificate was created successfully")
-		certificateName := utilst.GenerateResourceName(routeHostname, consts.ZoneValue)
+		certificateName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		certificateObject := mocks.CreateCertificateObject(certificateName)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, certificateObject)
+			return utils.DoesResourceExist(k8sClient, certificateObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking the Certificate has the needed labels")
-		certificateObject = utilst.GetCertificate(k8sClient, certificateName, consts.NSName)
+		certificateObject = utils.GetCertificate(k8sClient, certificateName, consts.NSName)
 		Expect(certificateObject.Labels[consts.CappResourceKey]).Should(Equal(createdCapp.Name))
 		Expect(certificateObject.Labels[consts.ManagedByLabelKey]).Should(Equal(consts.CappKey))
 
@@ -48,18 +48,18 @@ var _ = Describe("Validate Certificate functionality", func() {
 
 		By("Updating the Capp Route hostname and checking the status")
 		var toBeUpdatedCapp *cappv1alpha1.Capp
-		updatedRouteHostname := utilst.GenerateResourceName(utilst.GenerateRouteHostname(), consts.ZoneValue)
+		updatedRouteHostname := utils.GenerateResourceName(utils.GenerateRouteHostname(), consts.ZoneValue)
 
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			toBeUpdatedCapp = utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			toBeUpdatedCapp = utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			toBeUpdatedCapp.Spec.RouteSpec.Hostname = updatedRouteHostname
 
-			return utilst.UpdateResource(k8sClient, toBeUpdatedCapp)
+			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() string {
-			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			if capp.Status.RouteStatus.DomainMappingObjectStatus.URL == nil {
 				return ""
 			}
@@ -69,81 +69,81 @@ var _ = Describe("Validate Certificate functionality", func() {
 		By("checking if the Certificate object was updated after changing the Capp Route Hostname")
 		updatedCertificateObject := mocks.CreateCertificateObject(updatedRouteHostname)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, updatedCertificateObject)
+			return utils.DoesResourceExist(k8sClient, updatedCertificateObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		Eventually(func() []string {
-			updatedCertificateObject = utilst.GetCertificate(k8sClient, updatedRouteHostname, toBeUpdatedCapp.Namespace)
+			updatedCertificateObject = utils.GetCertificate(k8sClient, updatedRouteHostname, toBeUpdatedCapp.Namespace)
 			return updatedCertificateObject.Spec.DNSNames
 		}, consts.Timeout, consts.Interval).Should(Equal([]string{updatedRouteHostname}))
 
 		By("Deleting the Capp instance and checking if the Certificate was deleted successfully")
-		utilst.DeleteCapp(k8sClient, createdCapp)
+		utils.DeleteCapp(k8sClient, createdCapp)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, updatedCertificateObject)
+			return utils.DoesResourceExist(k8sClient, updatedCertificateObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
 	It("Should not create Certificate when creating a non-HTTPS Capp instance", func() {
 		By("Creating a Capp with a route")
-		_, routeHostname := utilst.CreateCappWithHTTPHostname(k8sClient)
+		_, routeHostname := utils.CreateCappWithHTTPHostname(k8sClient)
 
 		By("Checking if the Certificate was not created")
-		certificateName := utilst.GenerateResourceName(routeHostname, consts.ZoneValue)
+		certificateName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		certificateObject := mocks.CreateCertificateObject(certificateName)
 		Consistently(func() bool {
-			return utilst.DoesResourceExist(k8sClient, certificateObject)
+			return utils.DoesResourceExist(k8sClient, certificateObject)
 		}, consts.DefaultConsistently, consts.Interval).Should(BeFalse(), "Should not find a resource.")
 	})
 
 	It("Should cleanup Certificate when no longer required (tls)", func() {
 		By("Creating an HTTPS Capp")
-		createdCapp, routeHostname := utilst.CreateHTTPSCapp(k8sClient)
+		createdCapp, routeHostname := utils.CreateHTTPSCapp(k8sClient)
 
 		By("Checking if the Certificate was created successfully")
-		certificateName := utilst.GenerateResourceName(routeHostname, consts.ZoneValue)
+		certificateName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		certificateObject := mocks.CreateCertificateObject(certificateName)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, certificateObject)
+			return utils.DoesResourceExist(k8sClient, certificateObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Removing the Certificate requirement from Capp Spec and checking cleanup", func() {
-			err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-				toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+				toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 				toBeUpdatedCapp.Spec.RouteSpec.TlsEnabled = false
 
-				return utilst.UpdateResource(k8sClient, toBeUpdatedCapp)
+				return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 			})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
-				return utilst.DoesResourceExist(k8sClient, certificateObject)
+				return utils.DoesResourceExist(k8sClient, certificateObject)
 			}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should not find a resource.")
 		})
 	})
 
 	It("Should cleanup Certificate when no longer required (hostname)", func() {
 		By("Creating an HTTPS Capp")
-		createdCapp, routeHostname := utilst.CreateHTTPSCapp(k8sClient)
+		createdCapp, routeHostname := utils.CreateHTTPSCapp(k8sClient)
 
 		By("Checking if the Certificate was created successfully")
-		certificateName := utilst.GenerateResourceName(routeHostname, consts.ZoneValue)
+		certificateName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		certificateObject := mocks.CreateCertificateObject(certificateName)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, certificateObject)
+			return utils.DoesResourceExist(k8sClient, certificateObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Removing the Certificate requirement from Capp Spec and checking cleanup", func() {
-			err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-				toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+				toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 				toBeUpdatedCapp.Spec.RouteSpec.Hostname = ""
 
-				return utilst.UpdateResource(k8sClient, toBeUpdatedCapp)
+				return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 			})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
-				return utilst.DoesResourceExist(k8sClient, certificateObject)
+				return utils.DoesResourceExist(k8sClient, certificateObject)
 			}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should not find a resource.")
 		})
 	})

--- a/test/e2e/dnsrecord_test.go
+++ b/test/e2e/dnsrecord_test.go
@@ -4,7 +4,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 	"github.com/dana-team/container-app-operator/test/e2e/mocks"
-	utilst "github.com/dana-team/container-app-operator/test/e2e/utils"
+	"github.com/dana-team/container-app-operator/test/e2e/utils"
 	"k8s.io/client-go/util/retry"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,105 +14,105 @@ import (
 var _ = Describe("Validate DNSRecord functionality", func() {
 	It("Should create, update and delete DNSRecord when creating, updating and deleting a Capp instance", func() {
 		By("Creating a capp with a route")
-		createdCapp, _ := utilst.CreateCappWithHTTPHostname(k8sClient)
+		createdCapp, _ := utils.CreateCappWithHTTPHostname(k8sClient)
 
 		By("Checking if the DNSRecord was created successfully")
-		dnsRecordName := utilst.GenerateResourceName(createdCapp.Spec.RouteSpec.Hostname, consts.ZoneValue)
+		dnsRecordName := utils.GenerateResourceName(createdCapp.Spec.RouteSpec.Hostname, consts.ZoneValue)
 		dnsRecordObject := mocks.CreateDNSRecordObject(dnsRecordName)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, dnsRecordObject)
+			return utils.DoesResourceExist(k8sClient, dnsRecordObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking the DNSRecord has the needed labels")
-		dnsRecordObject = utilst.GetDNSRecord(k8sClient, dnsRecordName, createdCapp.Namespace)
+		dnsRecordObject = utils.GetDNSRecord(k8sClient, dnsRecordName, createdCapp.Namespace)
 		Expect(dnsRecordObject.Labels[consts.CappResourceKey]).Should(Equal(createdCapp.Name))
 		Expect(dnsRecordObject.Labels[consts.CappNamespaceKey]).Should(Equal(createdCapp.Namespace))
 		Expect(dnsRecordObject.Labels[consts.ManagedByLabelKey]).Should(Equal(consts.CappKey))
 
 		By("checking if the DNSRecord object was updated after changing the Capp Route Hostname")
-		updatedRouteHostname := utilst.GenerateRouteHostname()
+		updatedRouteHostname := utils.GenerateRouteHostname()
 
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			toBeUpdatedCapp.Spec.RouteSpec.Hostname = updatedRouteHostname
 
-			return utilst.UpdateResource(k8sClient, toBeUpdatedCapp)
+			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		updatedDNSRecord := dnsRecordObject
-		updatedDNSRecordName := utilst.GenerateResourceName(updatedRouteHostname, consts.ZoneValue)
+		updatedDNSRecordName := utils.GenerateResourceName(updatedRouteHostname, consts.ZoneValue)
 		Eventually(func() *string {
-			updatedDNSRecord = utilst.GetDNSRecord(k8sClient, updatedDNSRecordName, createdCapp.Namespace)
+			updatedDNSRecord = utils.GetDNSRecord(k8sClient, updatedDNSRecordName, createdCapp.Namespace)
 			return updatedDNSRecord.Spec.ForProvider.Name
 		}, consts.Timeout, consts.Interval).Should(Equal(&updatedRouteHostname))
 
 		By("Deleting the Capp instance")
-		utilst.DeleteCapp(k8sClient, createdCapp)
+		utils.DeleteCapp(k8sClient, createdCapp)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, createdCapp)
+			return utils.DoesResourceExist(k8sClient, createdCapp)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the DNSRecord was deleted successfully")
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, updatedDNSRecord)
+			return utils.DoesResourceExist(k8sClient, updatedDNSRecord)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
 	It("Should cleanup DNSRecord when no longer required", func() {
 		By("Creating a capp with a route")
-		createdCapp, _ := utilst.CreateCappWithHTTPHostname(k8sClient)
+		createdCapp, _ := utils.CreateCappWithHTTPHostname(k8sClient)
 
 		By("Checking if the DNSRecord was created successfully")
-		dnsRecordName := utilst.GenerateResourceName(createdCapp.Spec.RouteSpec.Hostname, consts.ZoneValue)
+		dnsRecordName := utils.GenerateResourceName(createdCapp.Spec.RouteSpec.Hostname, consts.ZoneValue)
 		dnsRecordObject := mocks.CreateDNSRecordObject(dnsRecordName)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, dnsRecordObject)
+			return utils.DoesResourceExist(k8sClient, dnsRecordObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Removing the DNSRecord requirement from Capp Spec and checking cleanup", func() {
-			err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-				toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+				toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 				toBeUpdatedCapp.Spec.RouteSpec.Hostname = ""
 
-				return utilst.UpdateResource(k8sClient, toBeUpdatedCapp)
+				return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 			})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
-				return utilst.DoesResourceExist(k8sClient, dnsRecordObject)
+				return utils.DoesResourceExist(k8sClient, dnsRecordObject)
 			}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should not find a resource.")
 		})
 	})
 
 	It("Should not update DNSRecord when only Capp metadata changes", func() {
 		By("Creating a capp with a route")
-		createdCapp, _ := utilst.CreateCappWithHTTPHostname(k8sClient)
+		createdCapp, _ := utils.CreateCappWithHTTPHostname(k8sClient)
 
 		By("Checking if the DNSRecord was created successfully")
-		dnsRecordName := utilst.GenerateResourceName(createdCapp.Spec.RouteSpec.Hostname, consts.ZoneValue)
+		dnsRecordName := utils.GenerateResourceName(createdCapp.Spec.RouteSpec.Hostname, consts.ZoneValue)
 		dnsRecordObject := mocks.CreateDNSRecordObject(dnsRecordName)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, dnsRecordObject)
+			return utils.DoesResourceExist(k8sClient, dnsRecordObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Simulating external mutation of DNSRecord spec")
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			dnsRecord := utilst.GetDNSRecord(k8sClient, dnsRecordName, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			dnsRecord := utils.GetDNSRecord(k8sClient, dnsRecordName, createdCapp.Namespace)
 			dnsRecord.Spec.ManagementPolicies = []xpv1.ManagementAction{"Create"}
-			return utilst.UpdateResource(k8sClient, dnsRecord)
+			return utils.UpdateResource(k8sClient, dnsRecord)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Confirming external mutation is persisted")
 		Eventually(func() []xpv1.ManagementAction {
-			currentDNSRecord := utilst.GetDNSRecord(k8sClient, dnsRecordName, createdCapp.Namespace)
+			currentDNSRecord := utils.GetDNSRecord(k8sClient, dnsRecordName, createdCapp.Namespace)
 			return currentDNSRecord.Spec.ManagementPolicies
 		}, consts.Timeout, consts.Interval).Should(Equal([]xpv1.ManagementAction{"Create"}))
 
 		By("Should preserve external DNSRecord spec fields on Capp metadata-only changes")
 		Consistently(func() []xpv1.ManagementAction {
-			currentDNSRecord := utilst.GetDNSRecord(k8sClient, dnsRecordName, createdCapp.Namespace)
+			currentDNSRecord := utils.GetDNSRecord(k8sClient, dnsRecordName, createdCapp.Namespace)
 			return currentDNSRecord.Spec.ManagementPolicies
 		}, consts.DefaultConsistently, consts.Interval).Should(Equal([]xpv1.ManagementAction{"Create"}))
 	})

--- a/test/e2e/domain_mapping_test.go
+++ b/test/e2e/domain_mapping_test.go
@@ -4,7 +4,7 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 	"github.com/dana-team/container-app-operator/test/e2e/mocks"
-	utilst "github.com/dana-team/container-app-operator/test/e2e/utils"
+	"github.com/dana-team/container-app-operator/test/e2e/utils"
 	"k8s.io/client-go/util/retry"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,23 +14,23 @@ import (
 var _ = Describe("Validate DomainMapping functionality", func() {
 	It("Should create, update and delete DomainMapping when creating, updating and deleting a Capp instance", func() {
 		By("Creating a capp with a route")
-		createdCapp, routeHostname := utilst.CreateCappWithHTTPHostname(k8sClient)
+		createdCapp, routeHostname := utils.CreateCappWithHTTPHostname(k8sClient)
 
 		By("Checking if the domainMapping was created successfully")
-		domainMappingName := utilst.GenerateResourceName(routeHostname, consts.ZoneValue)
+		domainMappingName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		domainMappingObject := mocks.CreateDomainMappingObject(domainMappingName)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, domainMappingObject)
+			return utils.DoesResourceExist(k8sClient, domainMappingObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking the domainMapping has the needed labels")
-		domainMappingObject = utilst.GetDomainMapping(k8sClient, domainMappingName, consts.NSName)
+		domainMappingObject = utils.GetDomainMapping(k8sClient, domainMappingName, consts.NSName)
 		Expect(domainMappingObject.Labels[consts.CappResourceKey]).Should(Equal(createdCapp.Name))
 		Expect(domainMappingObject.Labels[consts.ManagedByLabelKey]).Should(Equal(consts.CappKey))
 
 		By("Checking if the RouteStatus of the Capp was updated successfully")
 		Eventually(func() string {
-			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			if capp.Status.RouteStatus.DomainMappingObjectStatus.URL == nil {
 				return ""
 			}
@@ -38,17 +38,17 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 		}, consts.Timeout, consts.Interval).Should(Equal(domainMappingName), "Should update Route Status of Capp")
 
 		By("Updating the Capp Route hostname and checking the status")
-		updatedRouteHostname := utilst.GenerateResourceName(utilst.GenerateRouteHostname(), consts.ZoneValue)
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		updatedRouteHostname := utils.GenerateResourceName(utils.GenerateRouteHostname(), consts.ZoneValue)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			toBeUpdatedCapp.Spec.RouteSpec.Hostname = updatedRouteHostname
 
-			return utilst.UpdateResource(k8sClient, toBeUpdatedCapp)
+			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() string {
-			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			if capp.Status.RouteStatus.DomainMappingObjectStatus.URL == nil {
 				return ""
 			}
@@ -58,47 +58,47 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 		By("checking if the domainMapping was updated")
 		updatedDomainMappingObject := mocks.CreateDomainMappingObject(updatedRouteHostname)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, updatedDomainMappingObject)
+			return utils.DoesResourceExist(k8sClient, updatedDomainMappingObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Deleting the Capp instance")
-		utilst.DeleteCapp(k8sClient, createdCapp)
+		utils.DeleteCapp(k8sClient, createdCapp)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, createdCapp)
+			return utils.DoesResourceExist(k8sClient, createdCapp)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the domainMapping was deleted successfully")
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, updatedDomainMappingObject)
+			return utils.DoesResourceExist(k8sClient, updatedDomainMappingObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
 	It("Should create DomainMapping with secret when Creating an HTTPS Capp instance", func() {
 		By("Creating an HTTP Capp")
-		createdCapp, routeHostname := utilst.CreateCappWithHTTPHostname(k8sClient)
+		createdCapp, routeHostname := utils.CreateCappWithHTTPHostname(k8sClient)
 
 		By("Making sure the tls secret exists in advance")
-		resourceName := utilst.GenerateResourceName(routeHostname, consts.ZoneValue)
-		secretName := utilst.GenerateCertSecretName(resourceName)
+		resourceName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
+		secretName := utils.GenerateCertSecretName(resourceName)
 		secretObject := mocks.CreateSecretObject(secretName)
-		utilst.CreateSecret(k8sClient, secretObject)
+		utils.CreateSecret(k8sClient, secretObject)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, secretObject)
+			return utils.DoesResourceExist(k8sClient, secretObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Changing Capp to be HTTPS")
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			assertionCapp.Spec.RouteSpec.TlsEnabled = true
 
-			return utilst.UpdateResource(k8sClient, assertionCapp)
+			return utils.UpdateResource(k8sClient, assertionCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Checking if the secret reference exists at the domainMapping")
-		domainMappingName := utilst.GenerateResourceName(routeHostname, consts.ZoneValue)
+		domainMappingName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		Eventually(func() string {
-			domainMapping := utilst.GetDomainMapping(k8sClient, domainMappingName, createdCapp.Namespace)
+			domainMapping := utils.GetDomainMapping(k8sClient, domainMappingName, createdCapp.Namespace)
 			if domainMapping.Spec.TLS != nil {
 				return domainMapping.Spec.TLS.SecretName
 			}
@@ -108,12 +108,12 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 
 	It("Should update the RouteStatus of the Capp accordingly", func() {
 		By("Creating a capp with a route")
-		createdCapp, routeHostname := utilst.CreateCappWithHTTPHostname(k8sClient)
+		createdCapp, routeHostname := utils.CreateCappWithHTTPHostname(k8sClient)
 
-		domainMappingName := utilst.GenerateResourceName(routeHostname, consts.ZoneValue)
+		domainMappingName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		By("Checking if the RouteStatus of the Capp was updated successfully")
 		Eventually(func() string {
-			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			if capp.Status.RouteStatus.DomainMappingObjectStatus.URL == nil {
 				return ""
 			}
@@ -121,21 +121,21 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 		}, consts.Timeout, consts.Interval).Should(Equal(domainMappingName), "Should update Route Status of Capp")
 
 		By("Removing the Route from the Capp and check the status and resource clean up")
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			toBeUpdatedCapp.Spec.RouteSpec = cappv1alpha1.RouteSpec{}
 
-			return utilst.UpdateResource(k8sClient, toBeUpdatedCapp)
+			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		domainMappingObject := mocks.CreateDomainMappingObject(domainMappingName)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, domainMappingObject)
+			return utils.DoesResourceExist(k8sClient, domainMappingObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		Eventually(func() cappv1alpha1.RouteStatus {
-			capp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			return capp.Status.RouteStatus
 		}, consts.Timeout, consts.Interval).Should(Equal(cappv1alpha1.RouteStatus{}), "Should update Route Status of Capp")
 	})

--- a/test/e2e/knative_test.go
+++ b/test/e2e/knative_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 
 	"github.com/dana-team/container-app-operator/test/e2e/mocks"
-	utilst "github.com/dana-team/container-app-operator/test/e2e/utils"
+	"github.com/dana-team/container-app-operator/test/e2e/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -18,10 +18,10 @@ import (
 // and that LatestReadyRevisionName changes compared to the previous value.
 func verifyLatestReadyRevision(name, namespace, latestReadyRevisionBeforeUpdate string) {
 	Eventually(func() string {
-		return utilst.GetCapp(k8sClient, name, namespace).Status.KnativeObjectStatus.ConfigurationStatusFields.LatestReadyRevisionName
+		return utils.GetCapp(k8sClient, name, namespace).Status.KnativeObjectStatus.ConfigurationStatusFields.LatestReadyRevisionName
 	}, consts.Timeout, consts.Interval).ShouldNot(Equal(latestReadyRevisionBeforeUpdate))
 
-	actualNewRevision := utilst.GetCapp(k8sClient, name, namespace).Status.KnativeObjectStatus.ConfigurationStatusFields.LatestReadyRevisionName
+	actualNewRevision := utils.GetCapp(k8sClient, name, namespace).Status.KnativeObjectStatus.ConfigurationStatusFields.LatestReadyRevisionName
 	checkRevisionReadiness(actualNewRevision)
 }
 
@@ -30,11 +30,11 @@ func checkRevisionReadiness(revisionName string) {
 	By("Checking if the revision was created successfully")
 	revisionObject := mocks.CreateRevisionObject(revisionName)
 	Eventually(func() bool {
-		return utilst.DoesResourceExist(k8sClient, revisionObject)
+		return utils.DoesResourceExist(k8sClient, revisionObject)
 	}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 	By("Ensuring that the new revision is ready")
 	Eventually(func() bool {
-		return utilst.GetRevision(k8sClient, revisionObject.Name, revisionObject.Namespace).IsReady()
+		return utils.GetRevision(k8sClient, revisionObject.Name, revisionObject.Namespace).IsReady()
 	}, consts.Timeout, consts.Interval).Should(BeTrue())
 }
 
@@ -43,11 +43,11 @@ var _ = Describe("Validate knative functionality", func() {
 		By("Creating a capp instance with memory scale metric")
 		testCapp := mocks.CreateBaseCapp()
 		testCapp.Spec.ScaleSpec.Metric = consts.MemoryScaleMetric
-		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(k8sClient, testCapp)
 
 		By("Checking if the ksvc was created with memory metric annotation successfully")
 		Eventually(func() string {
-			ksvc := utilst.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			ksvc := utils.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			return ksvc.Spec.Template.Annotations[consts.KnativeMetricAnnotation]
 		}, consts.Timeout, consts.Interval).Should(Equal(consts.MemoryScaleMetric))
 	})
@@ -56,36 +56,36 @@ var _ = Describe("Validate knative functionality", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
 		testCapp.Spec.ScaleSpec.Metric = consts.CPUScaleMetric
-		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
-		assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		createdCapp := utils.CreateCapp(k8sClient, testCapp)
+		assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 
 		By("Checking if the ksvc was created successfully")
 		ksvcObject := mocks.CreateKnativeServiceObject(assertionCapp.Name)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, ksvcObject)
+			return utils.DoesResourceExist(k8sClient, ksvcObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 		checkRevisionReadiness(assertionCapp.Name + consts.FirstRevisionSuffix)
 
 		By("Checking the ksvc has the needed labels")
-		ksvcObject = utilst.GetKSVC(k8sClient, assertionCapp.Name, consts.NSName)
+		ksvcObject = utils.GetKSVC(k8sClient, assertionCapp.Name, consts.NSName)
 		Expect(ksvcObject.Labels[consts.CappResourceKey]).Should(Equal(assertionCapp.Name))
 		Expect(ksvcObject.Labels[consts.ManagedByLabelKey]).Should(Equal(consts.CappKey))
 
 		By("Deleting the capp instance")
-		utilst.DeleteCapp(k8sClient, assertionCapp)
+		utils.DeleteCapp(k8sClient, assertionCapp)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, assertionCapp)
+			return utils.DoesResourceExist(k8sClient, assertionCapp)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the ksvc exists")
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, ksvcObject)
+			return utils.DoesResourceExist(k8sClient, ksvcObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the revision exists")
 		revisionObject := mocks.CreateRevisionObject(assertionCapp.Name + consts.FirstRevisionSuffix)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, revisionObject)
+			return utils.DoesResourceExist(k8sClient, revisionObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
@@ -93,16 +93,16 @@ var _ = Describe("Validate knative functionality", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
 		testCapp.Spec.ScaleSpec.Metric = consts.CPUScaleMetric
-		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(k8sClient, testCapp)
 
 		By("Updating the Capp scale metric")
 		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 
 			assertionCapp.Spec.ScaleSpec.Metric = consts.MemoryScaleMetric
-			return utilst.UpdateResource(k8sClient, assertionCapp)
+			return utils.UpdateResource(k8sClient, assertionCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -110,7 +110,7 @@ var _ = Describe("Validate knative functionality", func() {
 
 		By("Checking if the ksvc was updated successfully")
 		Eventually(func() string {
-			ksvc := utilst.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			ksvc := utils.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			return ksvc.Spec.Template.Annotations[consts.KnativeMetricAnnotation]
 		}, consts.Timeout, consts.Interval).Should(Equal("memory"))
 	})
@@ -118,16 +118,16 @@ var _ = Describe("Validate knative functionality", func() {
 	It("Should update ksvc container name and create a new revision when updating a capp container name", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
-		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(k8sClient, testCapp)
 
 		By("Updating the a capp container name")
 		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 
 			assertionCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Name = consts.TestContainerName
-			return utilst.UpdateResource(k8sClient, assertionCapp)
+			return utils.UpdateResource(k8sClient, assertionCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -135,7 +135,7 @@ var _ = Describe("Validate knative functionality", func() {
 
 		By("Checking if the ksvc was updated successfully")
 		Eventually(func() string {
-			ksvc := utilst.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			ksvc := utils.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			return ksvc.Spec.ConfigurationSpec.Template.Spec.Containers[0].Name
 		}, consts.Timeout, consts.Interval).Should(Equal(consts.TestContainerName))
 	})
@@ -143,16 +143,16 @@ var _ = Describe("Validate knative functionality", func() {
 	It("Should update ksvc container image and create a new revision when updating a capp container image", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
-		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(k8sClient, testCapp)
 
 		By("Updating capp's container image")
 		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 
 			assertionCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Image = consts.ImageExample
-			return utilst.UpdateResource(k8sClient, assertionCapp)
+			return utils.UpdateResource(k8sClient, assertionCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -160,7 +160,7 @@ var _ = Describe("Validate knative functionality", func() {
 
 		By("Checking if the ksvc's container image was updated successfully")
 		Eventually(func() string {
-			ksvc := utilst.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			ksvc := utils.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			return ksvc.Spec.ConfigurationSpec.Template.Spec.Containers[0].Image
 		}, consts.Timeout, consts.Interval).Should(Equal(consts.ImageExample))
 	})
@@ -170,19 +170,19 @@ var _ = Describe("Validate knative functionality", func() {
 
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
-		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(k8sClient, testCapp)
 
 		By("Updating capp metadata annotation that is copied to the Knative Service")
 		cappAnnotations := map[string]string{}
 		cappAnnotations[propagationAnnKey] = consts.ExampleAppName
 
 		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 
 			assertionCapp.Annotations = cappAnnotations
-			return utilst.UpdateResource(k8sClient, assertionCapp)
+			return utils.UpdateResource(k8sClient, assertionCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -190,7 +190,7 @@ var _ = Describe("Validate knative functionality", func() {
 
 		By("Checking if the ksvc template annotation was updated successfully")
 		Eventually(func() string {
-			ksvc := utilst.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			ksvc := utils.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			return ksvc.Spec.Template.Annotations[propagationAnnKey]
 		}, consts.Timeout, consts.Interval).Should(Equal(consts.ExampleAppName))
 	})
@@ -198,16 +198,16 @@ var _ = Describe("Validate knative functionality", func() {
 	It("Should update ksvc environment variable and create a new revision when updating a capp container environment variable", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
-		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(k8sClient, testCapp)
 
 		By("Updating capp's container environment variable")
 		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 
 			assertionCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Env[0].Value = consts.ExampleAppName
-			return utilst.UpdateResource(k8sClient, assertionCapp)
+			return utils.UpdateResource(k8sClient, assertionCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -215,42 +215,42 @@ var _ = Describe("Validate knative functionality", func() {
 
 		By("Checking if the ksvc's container environment variable was updated successfully")
 		Eventually(func() string {
-			ksvc := utilst.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			ksvc := utils.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			return ksvc.Spec.ConfigurationSpec.Template.Spec.Containers[0].Env[0].Value
 		}, consts.Timeout, consts.Interval).Should(Equal(consts.ExampleAppName))
 	})
 
 	It("Should create a new revision in ready state when updating capp's secret environment variable", func() {
 		By("Creating a secret")
-		secretName := utilst.GenerateSecretName()
+		secretName := utils.GenerateSecretName()
 		secretObject := mocks.CreateSecretObject(secretName)
-		utilst.CreateSecret(k8sClient, secretObject)
+		utils.CreateSecret(k8sClient, secretObject)
 
 		By("Creating a capp instance with a secret environment variable")
 		testCapp := mocks.CreateBaseCapp()
 		testCapp.Spec.ConfigurationSpec.Template.Spec.PodSpec.Containers[0].Env = *mocks.CreateEnvVarObject(secretName)
-		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
-		assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		createdCapp := utils.CreateCapp(k8sClient, testCapp)
+		assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 
 		checkRevisionReadiness(assertionCapp.Name + consts.FirstRevisionSuffix)
 
 		By("Updating the secret")
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			secretObject := utilst.GetSecret(k8sClient, secretObject.Name, secretObject.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			secretObject := utils.GetSecret(k8sClient, secretObject.Name, secretObject.Namespace)
 			secretObject.Data = map[string][]byte{consts.NewSecretKey: []byte(consts.SecretValue)}
 
-			return utilst.UpdateResource(k8sClient, secretObject)
+			return utils.UpdateResource(k8sClient, secretObject)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Updating the capp secret environment variable")
 		var latestReadyRevisionBeforeUpdate string
-		err = retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err = retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
 
 			assertionCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Env[0].ValueFrom.SecretKeyRef.Key = consts.NewSecretKey
-			return utilst.UpdateResource(k8sClient, assertionCapp)
+			return utils.UpdateResource(k8sClient, assertionCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -264,12 +264,12 @@ var _ = Describe("Validate knative functionality", func() {
 			autoscaling.TargetAnnotationKey: "666",
 		}
 		testCapp.Spec.ConfigurationSpec.Template.Annotations = annotations
-		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
-		assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		createdCapp := utils.CreateCapp(k8sClient, testCapp)
+		assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 
 		By("Checking if the ksvc's defaults annotations were overridden")
 		Eventually(func() string {
-			ksvc := utilst.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
+			ksvc := utils.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
 			return ksvc.Spec.ConfigurationSpec.Template.Annotations[autoscaling.TargetAnnotationKey]
 		}, consts.Timeout, consts.Interval).Should(Equal("666"))
 	})
@@ -282,23 +282,23 @@ var _ = Describe("Validate knative functionality", func() {
 			consts.CappResourceKey: "test",
 		}
 		testCapp.Labels = labels
-		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
-		assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		createdCapp := utils.CreateCapp(k8sClient, testCapp)
+		assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 
 		By("Checking if user-defined labels were propagated to the ksvc")
 		Eventually(func() string {
-			ksvc := utilst.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
+			ksvc := utils.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
 			return ksvc.Spec.ConfigurationSpec.Template.Labels[consts.TestLabelKey]
 		}, consts.Timeout, consts.Interval).Should(Equal("test"))
 
 		By("Checking if labels set by the controller cannot be overridden by users")
 		Consistently(func() string {
-			ksvc := utilst.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
+			ksvc := utils.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
 			return ksvc.Spec.ConfigurationSpec.Template.Labels[consts.CappResourceKey]
 		}, consts.DefaultConsistently, consts.Interval).ShouldNot(Equal("test"))
 
 		Eventually(func() string {
-			ksvc := utilst.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
+			ksvc := utils.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
 			return ksvc.Spec.ConfigurationSpec.Template.Labels[consts.CappResourceKey]
 		}, consts.Timeout, consts.Interval).Should(Equal(assertionCapp.Name))
 	})
@@ -306,14 +306,14 @@ var _ = Describe("Validate knative functionality", func() {
 	It("Should check the default ksvc annotation is equal to the cappConfig's concurrency value", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
-		createdCapp := utilst.CreateCapp(k8sClient, testCapp)
-		assertionCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		createdCapp := utils.CreateCapp(k8sClient, testCapp)
+		assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 
-		cappConfig := utilst.GetCappConfig(k8sClient, consts.CappConfigName, consts.ControllerNS)
+		cappConfig := utils.GetCappConfig(k8sClient, consts.CappConfigName, consts.ControllerNS)
 
 		By("Checking if the ksvc's annotation is equal to the cappConfig's autoScale")
 		Eventually(func() bool {
-			ksvc := utilst.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
+			ksvc := utils.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
 			return ksvc.Spec.ConfigurationSpec.Template.ObjectMeta.Annotations[autoscaling.TargetAnnotationKey] == fmt.Sprintf("%d", cappConfig.Spec.AutoscaleConfig.Concurrency) &&
 				ksvc.Spec.ConfigurationSpec.Template.ObjectMeta.Annotations[autoscaling.ActivationScaleKey] == fmt.Sprintf("%d", cappConfig.Spec.AutoscaleConfig.ActivationScale)
 		}, consts.Timeout, consts.Interval).Should(BeTrue())

--- a/test/e2e/logger_test.go
+++ b/test/e2e/logger_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 
 	"github.com/dana-team/container-app-operator/test/e2e/mocks"
-	utilst "github.com/dana-team/container-app-operator/test/e2e/utils"
+	"github.com/dana-team/container-app-operator/test/e2e/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -22,12 +22,12 @@ func checkOutputParameters(logType cappv1alpha1.LogType, syslogNGOutputName stri
 	switch logType {
 	case cappv1alpha1.LogTypeElastic:
 		Eventually(func() string {
-			syslogNGOutput := utilst.GetSyslogNGOutput(k8sClient, syslogNGOutputName, syslogNGOutputNamespace)
+			syslogNGOutput := utils.GetSyslogNGOutput(k8sClient, syslogNGOutputName, syslogNGOutputNamespace)
 			return syslogNGOutput.Spec.Elasticsearch.Index
 		}, consts.Timeout, consts.Interval).Should(Equal(indexDesiredValue))
 	case cappv1alpha1.LogTypeElasticDataStream:
 		Eventually(func() string {
-			syslogNGOutput := utilst.GetSyslogNGOutput(k8sClient, syslogNGOutputName, syslogNGOutputNamespace)
+			syslogNGOutput := utils.GetSyslogNGOutput(k8sClient, syslogNGOutputName, syslogNGOutputNamespace)
 			return syslogNGOutput.Spec.ElasticsearchDatastream.URL
 		}, consts.Timeout, consts.Interval).Should(Equal(urlDesiredValue))
 	}
@@ -48,18 +48,18 @@ func editCappLogSpec(capp *cappv1alpha1.Capp, logType cappv1alpha1.LogType) {
 func testCappWithLogger(logType cappv1alpha1.LogType) {
 	It(fmt.Sprintf("Should create, update, and delete SyslogNGFlow and SyslogNGOutput when creating, updating, and deleting a Capp instance with %s logger", logType), func() {
 		By(fmt.Sprintf("Creating a Capp with %s logger", logType))
-		createdCapp := utilst.CreateCappWithLogger(logType, k8sClient)
+		createdCapp := utils.CreateCappWithLogger(logType, k8sClient)
 
 		syslogNGOutputName := createdCapp.Name
 		syslogNGOutputObject := mocks.CreateSyslogNGOutputObject(syslogNGOutputName)
 
 		By(fmt.Sprintf("Creating a secret containing %s credentials", logType))
-		utilst.CreateCredentialsSecret(logType, k8sClient)
+		utils.CreateCredentialsSecret(logType, k8sClient)
 
 		By("Checking if the SyslogNGOutput is active and has no problems")
 		syslogNGOutput := &loggingv1beta1.SyslogNGOutput{}
 		Eventually(func() bool {
-			syslogNGOutput = utilst.GetSyslogNGOutput(k8sClient, syslogNGOutputName, createdCapp.Namespace)
+			syslogNGOutput = utils.GetSyslogNGOutput(k8sClient, syslogNGOutputName, createdCapp.Namespace)
 			if syslogNGOutput.Status.Active == nil {
 				return false
 			}
@@ -71,7 +71,7 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 		Expect(syslogNGOutput.Labels[consts.ManagedByLabelKey]).Should(Equal(consts.CappKey))
 
 		Eventually(func() int {
-			syslogNGOutput = utilst.GetSyslogNGOutput(k8sClient, syslogNGOutputName, createdCapp.Namespace)
+			syslogNGOutput = utils.GetSyslogNGOutput(k8sClient, syslogNGOutputName, createdCapp.Namespace)
 			return syslogNGOutput.Status.ProblemsCount
 		}, consts.Timeout, consts.Interval).Should(Equal(0))
 
@@ -80,16 +80,16 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 		syslogNGFlowObject := mocks.CreateSyslogNGFlowObject(syslogNGFlowName)
 
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, syslogNGFlowObject)
+			return utils.DoesResourceExist(k8sClient, syslogNGFlowObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking the SyslogNGFlow has the needed labels")
-		syslogNGFlowObject = utilst.GetSyslogNGFlow(k8sClient, syslogNGFlowName, consts.NSName)
+		syslogNGFlowObject = utils.GetSyslogNGFlow(k8sClient, syslogNGFlowName, consts.NSName)
 		Expect(syslogNGFlowObject.Labels[consts.CappResourceKey]).Should(Equal(createdCapp.Name))
 		Expect(syslogNGFlowObject.Labels[consts.ManagedByLabelKey]).Should(Equal(consts.CappKey))
 
 		Eventually(func() bool {
-			syslogNGFlow := utilst.GetSyslogNGFlow(k8sClient, syslogNGFlowName, createdCapp.Namespace)
+			syslogNGFlow := utils.GetSyslogNGFlow(k8sClient, syslogNGFlowName, createdCapp.Namespace)
 			if syslogNGFlow.Status.Active == nil {
 				return false
 			}
@@ -97,11 +97,11 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 		}, consts.Timeout, consts.Interval).Should(BeTrue())
 
 		By(fmt.Sprintf("Updating the capp %s logger index/url", logType))
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			editCappLogSpec(toBeUpdatedCapp, logType)
 
-			return utilst.UpdateResource(k8sClient, toBeUpdatedCapp)
+			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -109,25 +109,25 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 		checkOutputParameters(logType, syslogNGOutputName, createdCapp.Namespace, consts.TestIndex, consts.ElasticDataStreamURL)
 
 		By("Deleting the Capp instance")
-		utilst.DeleteCapp(k8sClient, createdCapp)
+		utils.DeleteCapp(k8sClient, createdCapp)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, createdCapp)
+			return utils.DoesResourceExist(k8sClient, createdCapp)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the SyslogNGOutput was deleted successfully")
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, syslogNGOutputObject)
+			return utils.DoesResourceExist(k8sClient, syslogNGOutputObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the SyslogNGFlow was deleted successfully")
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, syslogNGFlowObject)
+			return utils.DoesResourceExist(k8sClient, syslogNGFlowObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
 	It("Should cleanup SyslogNGFlow and SyslogNGOutput when they are no longer required", func() {
 		By(fmt.Sprintf("Creating a Capp with %s logger", logType))
-		createdCapp := utilst.CreateCappWithLogger(logType, k8sClient)
+		createdCapp := utils.CreateCappWithLogger(logType, k8sClient)
 
 		By("Checking if the SyslogNGFlow and SyslogNGOutput were created successfully")
 		syslogNGFlowName := createdCapp.Name
@@ -137,28 +137,28 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 		syslogNGOutputObject := mocks.CreateSyslogNGOutputObject(syslogNGOutputName)
 
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, syslogNGFlowObject)
+			return utils.DoesResourceExist(k8sClient, syslogNGFlowObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, syslogNGOutputObject)
+			return utils.DoesResourceExist(k8sClient, syslogNGOutputObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Removing the logging requirement from Capp Spec and checking cleanup")
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			toBeUpdatedCapp := utilst.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			toBeUpdatedCapp.Spec.LogSpec = cappv1alpha1.LogSpec{}
 
-			return utilst.UpdateResource(k8sClient, toBeUpdatedCapp)
+			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, syslogNGFlowObject)
+			return utils.DoesResourceExist(k8sClient, syslogNGFlowObject)
 		}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should not find a resource.")
 
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, syslogNGOutputObject)
+			return utils.DoesResourceExist(k8sClient, syslogNGOutputObject)
 		}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should not find a resource.")
 	})
 }

--- a/test/e2e/mutating_test.go
+++ b/test/e2e/mutating_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	mock "github.com/dana-team/container-app-operator/test/e2e/mocks"
-	utilst "github.com/dana-team/container-app-operator/test/e2e/utils"
+	"github.com/dana-team/container-app-operator/test/e2e/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -20,12 +20,12 @@ const adminAnnotationValue = "kubernetes-admin"
 var _ = Describe("Validate the mutating webhook", func() {
 	AfterEach(func() {
 		// Revert k8sClient back to use the original configuration
-		utilst.SwitchUser(&k8sClient, cfg, consts.NSName, newScheme(), "")
+		utils.SwitchUser(&k8sClient, cfg, consts.NSName, newScheme(), "")
 	})
 
 	It("Should add annotation on create", func() {
 		baseCapp := mock.CreateBaseCapp()
-		capp := utilst.CreateCapp(k8sClient, baseCapp)
+		capp := utils.CreateCapp(k8sClient, baseCapp)
 
 		annotation := capp.ObjectMeta.Annotations[consts.LastUpdatedByAnnotationKey]
 		Expect(annotation).To(Equal(adminAnnotationValue))
@@ -33,24 +33,24 @@ var _ = Describe("Validate the mutating webhook", func() {
 
 	It("Should add annotation on update", func() {
 		baseCapp := mock.CreateBaseCapp()
-		capp := utilst.CreateCapp(k8sClient, baseCapp)
+		capp := utils.CreateCapp(k8sClient, baseCapp)
 
 		annotation := capp.ObjectMeta.Annotations[consts.LastUpdatedByAnnotationKey]
 		Expect(annotation).To(Equal(adminAnnotationValue))
 
-		utilst.SwitchUser(&k8sClient, cfg, consts.NSName, newScheme(), consts.ServiceAccountName)
+		utils.SwitchUser(&k8sClient, cfg, consts.NSName, newScheme(), consts.ServiceAccountName)
 
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
-			capp = utilst.GetCapp(k8sClient, capp.Name, capp.Namespace)
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			capp = utils.GetCapp(k8sClient, capp.Name, capp.Namespace)
 			if capp.ObjectMeta.Annotations == nil {
 				capp.ObjectMeta.Annotations = map[string]string{}
 			}
 			capp.ObjectMeta.Annotations["test"] = "test"
-			return utilst.UpdateResource(k8sClient, capp)
+			return utils.UpdateResource(k8sClient, capp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		updatedCapp := utilst.GetCapp(k8sClient, capp.Name, capp.Namespace)
+		updatedCapp := utils.GetCapp(k8sClient, capp.Name, capp.Namespace)
 
 		// Check if the annotation has changed
 		updatedAnnotation := updatedCapp.ObjectMeta.Annotations[consts.LastUpdatedByAnnotationKey]
@@ -59,7 +59,7 @@ var _ = Describe("Validate the mutating webhook", func() {
 
 	It("Should add default resources to Capp", func() {
 		baseCapp := mock.CreateBaseCapp()
-		capp := utilst.CreateCapp(k8sClient, baseCapp)
+		capp := utils.CreateCapp(k8sClient, baseCapp)
 
 		cpuRequest := capp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Resources.Requests.Cpu()
 		Expect(cpuRequest.String()).ToNot(Equal(""))
@@ -80,7 +80,7 @@ var _ = Describe("Validate the mutating webhook", func() {
 				corev1.ResourceMemory: resource.MustParse("23Mi"),
 			},
 		}
-		capp := utilst.CreateCapp(k8sClient, baseCapp)
+		capp := utils.CreateCapp(k8sClient, baseCapp)
 
 		cpuRequest := capp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Resources.Requests.Cpu()
 		Expect(cpuRequest.String()).To(Equal("23m"))

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 
-	utilst "github.com/dana-team/container-app-operator/test/e2e/utils"
+	"github.com/dana-team/container-app-operator/test/e2e/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -30,15 +30,15 @@ var _ = SynchronizedBeforeSuite(func() {
 	initClient()
 	cleanUp()
 	createE2ETestNamespace()
-	utilst.CreateTestUser(k8sClient, consts.NSName)
-	utilst.CreateExcludedServiceAccount(k8sClient)
+	utils.CreateTestUser(k8sClient, consts.NSName)
+	utils.CreateExcludedServiceAccount(k8sClient)
 }, func() {
 	initClient()
 })
 
 var _ = SynchronizedAfterSuite(func() {}, func() {
-	utilst.DeleteTestUser(k8sClient, consts.NSName)
-	utilst.DeleteExcludedServiceAccount(k8sClient)
+	utils.DeleteTestUser(k8sClient, consts.NSName)
+	utils.DeleteExcludedServiceAccount(k8sClient)
 
 	if os.Getenv("E2E_SKIP_CLEANUP") == "true" {
 		return
@@ -70,7 +70,7 @@ func createE2ETestNamespace() {
 
 	Expect(k8sClient.Create(context.Background(), namespace)).To(SatisfyAny(BeNil(), WithTransform(errors.IsAlreadyExists, BeTrue())))
 	Eventually(func() bool {
-		return utilst.DoesResourceExist(k8sClient, namespace)
+		return utils.DoesResourceExist(k8sClient, namespace)
 	}, consts.Timeout, consts.Interval).Should(BeTrue(), "The namespace should be created")
 }
 
@@ -82,7 +82,7 @@ func cleanUp() {
 		},
 	}
 
-	if utilst.DoesResourceExist(k8sClient, namespace) {
+	if utils.DoesResourceExist(k8sClient, namespace) {
 		Expect(k8sClient.Delete(context.Background(), namespace)).To(Succeed())
 		Eventually(func() error {
 			return k8sClient.Get(context.Background(), client.ObjectKey{Name: consts.NSName}, namespace)

--- a/test/e2e/validating_test.go
+++ b/test/e2e/validating_test.go
@@ -6,7 +6,7 @@ import (
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	mock "github.com/dana-team/container-app-operator/test/e2e/mocks"
-	utilst "github.com/dana-team/container-app-operator/test/e2e/utils"
+	"github.com/dana-team/container-app-operator/test/e2e/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,28 +22,28 @@ const (
 var _ = Describe("Validate the validating webhook", func() {
 	It("Should deny the use of an existing hostname", func() {
 		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Name = utilst.GenerateUniqueCappName(baseCapp.Name)
+		baseCapp.Name = utils.GenerateUniqueCappName(baseCapp.Name)
 		baseCapp.Spec.RouteSpec.Hostname = existingHostname
 		Expect(k8sClient.Create(context.Background(), baseCapp)).ShouldNot(Succeed())
 	})
 
 	It("Should deny the use of a hostname in cluster local", func() {
 		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Name = utilst.GenerateUniqueCappName(baseCapp.Name)
+		baseCapp.Name = utils.GenerateUniqueCappName(baseCapp.Name)
 		baseCapp.Spec.RouteSpec.Hostname = clusterLocalHostname
 		Expect(k8sClient.Create(context.Background(), baseCapp)).ShouldNot(Succeed())
 	})
 
 	It("Should allow the use of a hostname matching the allowed patterns", func() {
 		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Name = utilst.GenerateUniqueCappName(baseCapp.Name)
+		baseCapp.Name = utils.GenerateUniqueCappName(baseCapp.Name)
 		baseCapp.Spec.RouteSpec.Hostname = fmt.Sprintf("%s.allowed", baseCapp.Name)
 		Expect(k8sClient.Create(context.Background(), baseCapp)).Should(Succeed())
 	})
 
 	It("Should allow the use of a unique and valid hostname", func() {
 		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Name = utilst.GenerateUniqueCappName(baseCapp.Name)
+		baseCapp.Name = utils.GenerateUniqueCappName(baseCapp.Name)
 		validHostName := baseCapp.Name + validDomainSuffix
 		baseCapp.Spec.RouteSpec.Hostname = validHostName
 		Expect(k8sClient.Create(context.Background(), baseCapp)).Should(Succeed())
@@ -51,12 +51,12 @@ var _ = Describe("Validate the validating webhook", func() {
 
 	It("Should allow updating a capp with a hostname that has not been changed", func() {
 		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Name = utilst.GenerateUniqueCappName(baseCapp.Name)
+		baseCapp.Name = utils.GenerateUniqueCappName(baseCapp.Name)
 		validHostName := baseCapp.Name + validDomainSuffix
 		baseCapp.Spec.RouteSpec.Hostname = validHostName
 		Expect(k8sClient.Create(context.Background(), baseCapp)).Should(Succeed())
 
-		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
+		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 			cappInCluster := cappv1alpha1.Capp{}
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: baseCapp.Name, Namespace: baseCapp.Namespace}, &cappInCluster); err != nil {
 				return err

--- a/test/e2e/volumes_test.go
+++ b/test/e2e/volumes_test.go
@@ -6,7 +6,7 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 	"github.com/dana-team/container-app-operator/test/e2e/mocks"
-	utilst "github.com/dana-team/container-app-operator/test/e2e/utils"
+	"github.com/dana-team/container-app-operator/test/e2e/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -37,12 +37,12 @@ var _ = Describe("Validate NFSPVC functionality", func() {
 			},
 		}
 
-		cappName := utilst.GenerateCappName()
+		cappName := utils.GenerateCappName()
 		testCapp.Name = cappName
 		Expect(k8sClient.Create(context.Background(), testCapp)).To(Succeed())
 
 		Eventually(func() string {
-			capp := utilst.GetCapp(k8sClient, testCapp.Name, testCapp.Namespace)
+			capp := utils.GetCapp(k8sClient, testCapp.Name, testCapp.Namespace)
 			if len(capp.Spec.VolumesSpec.NFSVolumes) > 0 {
 				return capp.Spec.VolumesSpec.NFSVolumes[0].Name
 			}
@@ -52,18 +52,18 @@ var _ = Describe("Validate NFSPVC functionality", func() {
 		By("Checking if the NFSPVC was created successfully")
 		nfspvcObject := mocks.CreateNFSPVCObject(nfspvcName)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, nfspvcObject)
+			return utils.DoesResourceExist(k8sClient, nfspvcObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking the NFSPVC has the needed labels")
-		nfspvcObject = utilst.GetNFSPVC(k8sClient, nfspvcName, consts.NSName)
+		nfspvcObject = utils.GetNFSPVC(k8sClient, nfspvcName, consts.NSName)
 		Expect(nfspvcObject.Labels[consts.CappResourceKey]).Should(Equal(testCapp.Name))
 		Expect(nfspvcObject.Labels[consts.ManagedByLabelKey]).Should(Equal(consts.CappKey))
 
 		By("Deleting the Capp instance")
-		utilst.DeleteCapp(k8sClient, testCapp)
+		utils.DeleteCapp(k8sClient, testCapp)
 		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, nfspvcObject)
+			return utils.DoesResourceExist(k8sClient, nfspvcObject)
 		}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should find a resource.")
 	})
 })


### PR DESCRIPTION
Drop the utilst typo alias and use the package name directly
across all e2e test files.