### PR TITLE
feat(webhook): require confirmation for hostname changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ The `autoscaleConfig` section of the `CappConfig` CRD specifies the scale metric
 
 `Capp` enables using a custom hostname for the application. This in turn creates `DomainMapping`, a DNS Record object and a `Certificate` object if `TLS` is desired.
 
+To change an existing hostname, set annotation `rcs.dana.io/confirm-hostname-change` to the target hostname on the same update.
+
 To correctly create the resources, it is needed to provide the operator with the `DNS Config` where the application is exposed. 
 
 This is done using the `dnsConfig` section of the `CappConfig CRD` called `capp-config` which needs to be created in the operator namespace. 

--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -122,6 +122,8 @@ type NFSVolume struct {
 // RouteSpec defines the route specification for the Capp.
 type RouteSpec struct {
 	// Hostname is a custom DNS name for the Capp route.
+	// Changing an existing hostname is disruptive and may cause external route downtime.
+	// On Capp update, set metadata annotation rcs.dana.io/confirm-hostname-change to the target hostname.
 	// +optional
 	Hostname string `json:"hostname,omitempty"`
 

--- a/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
@@ -8860,8 +8860,10 @@ spec:
                           the Capp.
                         properties:
                           hostname:
-                            description: Hostname is a custom DNS name for the Capp
-                              route.
+                            description: |-
+                              Hostname is a custom DNS name for the Capp route.
+                              Changing an existing hostname is disruptive and may cause external route downtime.
+                              On Capp update, set metadata annotation rcs.dana.io/confirm-hostname-change to the target hostname.
                             type: string
                           routeTimeoutSeconds:
                             description: |-

--- a/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
@@ -8672,7 +8672,10 @@ spec:
                 description: RouteSpec defines the route specification for the Capp.
                 properties:
                   hostname:
-                    description: Hostname is a custom DNS name for the Capp route.
+                    description: |-
+                      Hostname is a custom DNS name for the Capp route.
+                      Changing an existing hostname is disruptive and may cause external route downtime.
+                      On Capp update, set metadata annotation rcs.dana.io/confirm-hostname-change to the target hostname.
                     type: string
                   routeTimeoutSeconds:
                     description: |-

--- a/config/crd/bases/rcs.dana.io_capprevisions.yaml
+++ b/config/crd/bases/rcs.dana.io_capprevisions.yaml
@@ -8860,8 +8860,10 @@ spec:
                           the Capp.
                         properties:
                           hostname:
-                            description: Hostname is a custom DNS name for the Capp
-                              route.
+                            description: |-
+                              Hostname is a custom DNS name for the Capp route.
+                              Changing an existing hostname is disruptive and may cause external route downtime.
+                              On Capp update, set metadata annotation rcs.dana.io/confirm-hostname-change to the target hostname.
                             type: string
                           routeTimeoutSeconds:
                             description: |-

--- a/config/crd/bases/rcs.dana.io_capps.yaml
+++ b/config/crd/bases/rcs.dana.io_capps.yaml
@@ -8672,7 +8672,10 @@ spec:
                 description: RouteSpec defines the route specification for the Capp.
                 properties:
                   hostname:
-                    description: Hostname is a custom DNS name for the Capp route.
+                    description: |-
+                      Hostname is a custom DNS name for the Capp route.
+                      Changing an existing hostname is disruptive and may cause external route downtime.
+                      On Capp update, set metadata annotation rcs.dana.io/confirm-hostname-change to the target hostname.
                     type: string
                   routeTimeoutSeconds:
                     description: |-

--- a/internal/kinds/capp/utils/utils.go
+++ b/internal/kinds/capp/utils/utils.go
@@ -12,10 +12,11 @@ import (
 )
 
 var (
-	CappAPIGroup      = cappv1alpha1.GroupVersion.Group
-	CappNamespaceKey  = CappAPIGroup + "/parent-capp-ns"
-	CappResourceKey   = CappAPIGroup + "/parent-capp"
-	ManagedByLabelKey = CappAPIGroup + "/managed-by"
+	CappAPIGroup                       = cappv1alpha1.GroupVersion.Group
+	CappNamespaceKey                   = CappAPIGroup + "/parent-capp-ns"
+	CappResourceKey                    = CappAPIGroup + "/parent-capp"
+	ManagedByLabelKey                  = CappAPIGroup + "/managed-by"
+	ConfirmHostnameChangeAnnotationKey = CappAPIGroup + "/confirm-hostname-change"
 )
 
 const (

--- a/internal/webhook/rcs/v1alpha1/validator.go
+++ b/internal/webhook/rcs/v1alpha1/validator.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	"github.com/dana-team/container-app-operator/internal/webhook/rcs/common"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -61,6 +62,10 @@ func (c *CappValidator) handle(ctx context.Context, capp cappv1alpha1.Capp, oldC
 		allowedHostnamePatterns = config.Spec.AllowedHostnamePatterns
 	}
 
+	if err := ensureHostnameChangeConfirmed(capp, oldCapp); err != nil {
+		return admission.Denied(err.Error())
+	}
+
 	if oldCapp == nil || capp.Spec.RouteSpec.Hostname != oldCapp.Spec.RouteSpec.Hostname {
 		if errs := common.ValidateDomainName(capp.Spec.RouteSpec.Hostname, allowedHostnamePatterns); errs != nil {
 			return admission.Denied(errs.Error())
@@ -99,6 +104,31 @@ func (c *CappValidator) handle(ctx context.Context, capp cappv1alpha1.Capp, oldC
 		return admission.Denied(fmt.Sprintf("invalid scaleDelaySeconds %d: must be less than or equal to global max scale delay %d", scaleDelay, config.Spec.AutoscaleConfig.MaxScaleDelay))
 	}
 	return admission.Allowed("")
+}
+
+func ensureHostnameChangeConfirmed(capp cappv1alpha1.Capp, oldCapp *cappv1alpha1.Capp) error {
+	if oldCapp == nil {
+		return nil
+	}
+
+	oldHostname := oldCapp.Spec.RouteSpec.Hostname
+	newHostname := capp.Spec.RouteSpec.Hostname
+	if oldHostname == "" || oldHostname == newHostname {
+		return nil
+	}
+
+	confirm, ok := "", false
+	if capp.Annotations != nil {
+		confirm, ok = capp.Annotations[utils.ConfirmHostnameChangeAnnotationKey]
+	}
+	if !ok || confirm != newHostname {
+		return fmt.Errorf(
+			"changing hostname from %q to %q is disruptive; set annotation %s=%q to proceed",
+			oldHostname, newHostname, utils.ConfirmHostnameChangeAnnotationKey, newHostname,
+		)
+	}
+
+	return nil
 }
 
 func validateNFSVolumeMounts(capp cappv1alpha1.Capp) error {

--- a/internal/webhook/rcs/v1alpha1/validator_test.go
+++ b/internal/webhook/rcs/v1alpha1/validator_test.go
@@ -135,6 +135,80 @@ func TestCappValidator_Handle(t *testing.T) {
 	}
 }
 
+func TestEnsureHostnameChangeConfirmed(t *testing.T) {
+	oldHostname := "old.example.com"
+	newHostname := "new.example.com"
+
+	tests := []struct {
+		name            string
+		oldHostname     string
+		newHostname     string
+		annotations     map[string]string
+		wantErrContains []string
+	}{
+		{
+			name:        "rejects hostname change without confirmation",
+			oldHostname: oldHostname,
+			newHostname: newHostname,
+			wantErrContains: []string{
+				"disruptive",
+				utils.ConfirmHostnameChangeAnnotationKey,
+			},
+		},
+		{
+			name:        "rejects hostname change when confirmation targets a different hostname",
+			oldHostname: oldHostname,
+			newHostname: newHostname,
+			annotations: map[string]string{
+				utils.ConfirmHostnameChangeAnnotationKey: "other.example.com",
+			},
+			wantErrContains: []string{
+				"disruptive",
+				utils.ConfirmHostnameChangeAnnotationKey,
+			},
+		},
+		{
+			name:        "allows confirmed hostname change",
+			oldHostname: oldHostname,
+			newHostname: newHostname,
+			annotations: map[string]string{
+				utils.ConfirmHostnameChangeAnnotationKey: newHostname,
+			},
+		},
+		{
+			name:        "rejects clearing hostname without confirmation",
+			oldHostname: oldHostname,
+			wantErrContains: []string{
+				"disruptive",
+				utils.ConfirmHostnameChangeAnnotationKey,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			capp := cappv1alpha1.Capp{
+				ObjectMeta: metav1.ObjectMeta{Annotations: tc.annotations},
+				Spec:       cappv1alpha1.CappSpec{RouteSpec: cappv1alpha1.RouteSpec{Hostname: tc.newHostname}},
+			}
+			oldCapp := &cappv1alpha1.Capp{
+				Spec: cappv1alpha1.CappSpec{RouteSpec: cappv1alpha1.RouteSpec{Hostname: tc.oldHostname}},
+			}
+
+			err := ensureHostnameChangeConfirmed(capp, oldCapp)
+			if len(tc.wantErrContains) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			for _, expectedSubstring := range tc.wantErrContains {
+				require.Contains(t, err.Error(), expectedSubstring)
+			}
+		})
+	}
+}
+
 func TestValidateNFSVolumeMounts(t *testing.T) {
 	invalidNFSVolumesMsg := "invalid nfsVolumes"
 	mustBeMountedMsg := "must be mounted by at least one container"

--- a/test/e2e/certificate_test.go
+++ b/test/e2e/certificate_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Validate Certificate functionality", func() {
 
 		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp = utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			toBeUpdatedCapp.Spec.RouteSpec.Hostname = updatedRouteHostname
+			utils.ConfirmHostnameChange(toBeUpdatedCapp, updatedRouteHostname)
 
 			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
@@ -136,7 +136,7 @@ var _ = Describe("Validate Certificate functionality", func() {
 		By("Removing the Certificate requirement from Capp Spec and checking cleanup", func() {
 			err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 				toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-				toBeUpdatedCapp.Spec.RouteSpec.Hostname = ""
+				utils.ConfirmHostnameChange(toBeUpdatedCapp, "")
 
 				return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 			})

--- a/test/e2e/dnsrecord_test.go
+++ b/test/e2e/dnsrecord_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Validate DNSRecord functionality", func() {
 
 		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			toBeUpdatedCapp.Spec.RouteSpec.Hostname = updatedRouteHostname
+			utils.ConfirmHostnameChange(toBeUpdatedCapp, updatedRouteHostname)
 
 			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
@@ -73,7 +73,7 @@ var _ = Describe("Validate DNSRecord functionality", func() {
 		By("Removing the DNSRecord requirement from Capp Spec and checking cleanup", func() {
 			err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 				toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-				toBeUpdatedCapp.Spec.RouteSpec.Hostname = ""
+				utils.ConfirmHostnameChange(toBeUpdatedCapp, "")
 
 				return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 			})

--- a/test/e2e/domain_mapping_test.go
+++ b/test/e2e/domain_mapping_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 		updatedRouteHostname := utils.GenerateResourceName(utils.GenerateRouteHostname(), consts.ZoneValue)
 		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			toBeUpdatedCapp.Spec.RouteSpec.Hostname = updatedRouteHostname
+			utils.ConfirmHostnameChange(toBeUpdatedCapp, updatedRouteHostname)
 
 			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
@@ -123,7 +123,7 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 		By("Removing the Route from the Capp and check the status and resource clean up")
 		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			toBeUpdatedCapp.Spec.RouteSpec = cappv1alpha1.RouteSpec{}
+			utils.ConfirmHostnameChange(toBeUpdatedCapp, "")
 
 			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})

--- a/test/e2e/utils/route_adapter.go
+++ b/test/e2e/utils/route_adapter.go
@@ -8,6 +8,7 @@ import (
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	mock "github.com/dana-team/container-app-operator/test/e2e/mocks"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,6 +33,15 @@ func CreateHTTPSCapp(k8sClient client.Client) (*cappv1alpha1.Capp, string) {
 	httpsCapp.Spec.RouteSpec.TlsEnabled = true
 
 	return CreateCapp(k8sClient, httpsCapp), hostname
+}
+
+// ConfirmHostnameChange sets the annotation and hostname required to change a Capp route.
+func ConfirmHostnameChange(capp *cappv1alpha1.Capp, hostname string) {
+	if capp.Annotations == nil {
+		capp.Annotations = map[string]string{}
+	}
+	capp.Annotations[utils.ConfirmHostnameChangeAnnotationKey] = hostname
+	capp.Spec.RouteSpec.Hostname = hostname
 }
 
 // GetDomainMapping fetches and returns an existing instance of a DomainMapping.


### PR DESCRIPTION
Deny disruptive Capp hostname updates unless metadata annotation
rcs.dana.io/confirm-hostname-change matches the target hostname.
Document the rule in API godoc, README, and CRDs; update e2e tests.

Fixes #523 