### PR TITLE
ci: enable errcheck check-blank

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,8 @@ linters:
     - unparam
     - unused
   settings:
+    errcheck:
+      check-blank: true
     revive:
       rules:
         - name: comment-spacings

--- a/internal/kinds/capp/finalizer/finalizer_test.go
+++ b/internal/kinds/capp/finalizer/finalizer_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/scale/scheme"
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
@@ -19,11 +20,11 @@ import (
 
 func newScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
-	_ = cappv1alpha1.AddToScheme(s)
-	_ = knativev1beta1.AddToScheme(s)
-	_ = knativev1.AddToScheme(s)
-	_ = scheme.AddToScheme(s)
+	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(cappv1alpha1.AddToScheme(s))
+	utilruntime.Must(knativev1beta1.AddToScheme(s))
+	utilruntime.Must(knativev1.AddToScheme(s))
+	utilruntime.Must(scheme.AddToScheme(s))
 	return s
 }
 

--- a/internal/kinds/capp/resourceclient/resourcepreparers.go
+++ b/internal/kinds/capp/resourceclient/resourcepreparers.go
@@ -4,21 +4,9 @@ import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	nfspvcv1alpha1 "github.com/dana-team/nfspvc-operator/api/v1alpha1"
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
-	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 )
-
-// GetBareKSVC returns a KSVC object with only ObjectMeta set.
-func GetBareKSVC(name, namespace string) knativev1.Service {
-	return knativev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-}
 
 // GetBareDomainMapping returns a DomainMapping object with only ObjectMeta set.
 func GetBareDomainMapping(name, namespace string) knativev1beta1.DomainMapping {
@@ -43,26 +31,6 @@ func GetBareCertificate(name, namespace string) cmapi.Certificate {
 // GetBareNFSPVC returns a NFSPVC object with only ObjectMeta set.
 func GetBareNFSPVC(name, namespace string) nfspvcv1alpha1.NfsPvc {
 	return nfspvcv1alpha1.NfsPvc{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-}
-
-// GetBareSyslogNGFlow returns a SyslogNGFlow object with only ObjectMeta set.
-func GetBareSyslogNGFlow(name, namespace string) loggingv1beta1.SyslogNGFlow {
-	return loggingv1beta1.SyslogNGFlow{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-}
-
-// GetBareSyslogNGOutput returns a SyslogNGOutput object with only ObjectMeta set.
-func GetBareSyslogNGOutput(name, namespace string) loggingv1beta1.SyslogNGOutput {
-	return loggingv1beta1.SyslogNGOutput{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,

--- a/internal/kinds/capprevision/actionmanagers/update.go
+++ b/internal/kinds/capprevision/actionmanagers/update.go
@@ -72,7 +72,10 @@ func HandleCappUpdate(ctx context.Context, k8sClient client.Client, capp cappv1a
 	sortByCreationTime(cappRevisions)
 	numOfRevisions := len(cappRevisions)
 
-	cappConfig, _ := utils.GetCappConfig(k8sClient)
+	cappConfig, err := utils.GetCappConfig(k8sClient)
+	if err != nil {
+		return err
+	}
 	revisionsToKeep := cappConfig.Spec.RevisionHistoryLimit
 
 	latestRevision := cappRevisions[0]

--- a/test/e2e/capp_revision_test.go
+++ b/test/e2e/capp_revision_test.go
@@ -26,10 +26,11 @@ var _ = Describe("Validate CappRevision creation", func() {
 		By("Creating regular Capp")
 		desiredCapp := utils.CreateCapp(k8sClient, baseCapp)
 
-		Eventually(func() int {
-			cappRevisons, _ := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
-			return len(cappRevisons)
-		}, consts.Timeout, consts.Interval).ShouldNot(BeZero(), "Should create CappRevisions")
+		Eventually(func(g Gomega) {
+			cappRevisions, err := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(cappRevisions).ShouldNot(BeEmpty())
+		}, consts.Timeout, consts.Interval).Should(Succeed(), "Should create CappRevisions")
 
 		cappRevisionName := kmeta.ChildName(desiredCapp.Name, fmt.Sprintf("-%05d", 1))
 		utils.GetCappRevision(k8sClient, cappRevisionName, desiredCapp.Namespace)
@@ -44,20 +45,22 @@ var _ = Describe("Validate CappRevision creation", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() bool {
-			cappRevisions, _ := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
-			return len(cappRevisions) > 1
-		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should create new CappRevision")
+		Eventually(func(g Gomega) {
+			cappRevisions, err := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(len(cappRevisions)).To(BeNumerically(">", 1))
+		}, consts.Timeout, consts.Interval).Should(Succeed(), "Should create new CappRevision")
 
 		cappRevisionName = kmeta.ChildName(desiredCapp.Name, fmt.Sprintf("-%05d", 2))
 		utils.GetCappRevision(k8sClient, cappRevisionName, desiredCapp.Namespace)
 
 		By("Deleting Capp")
 		utils.DeleteCapp(k8sClient, desiredCapp)
-		Eventually(func() int {
-			cappRevisons, _ := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
-			return len(cappRevisons)
-		}, consts.Timeout, consts.Interval).Should(BeZero(), "Should delete all CappRevisions")
+		Eventually(func(g Gomega) {
+			cappRevisions, err := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(cappRevisions).To(BeEmpty())
+		}, consts.Timeout, consts.Interval).Should(Succeed(), "Should delete all CappRevisions")
 
 	})
 
@@ -88,10 +91,11 @@ var _ = Describe("Validate CappRevision creation", func() {
 			desiredCapp = utils.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 		}
 
-		Eventually(func() int {
-			cappRevisions, _ := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
-			return len(cappRevisions)
-		}, consts.Timeout, consts.Interval).Should(BeNumerically("<=", revisionsToKeep),
+		Eventually(func(g Gomega) {
+			cappRevisions, err := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(len(cappRevisions)).To(BeNumerically("<=", revisionsToKeep))
+		}, consts.Timeout, consts.Interval).Should(Succeed(),
 			fmt.Sprintf("Should limit to at most %s CappRevision", strconv.Itoa(revisionsToKeep)))
 	})
 })

--- a/test/e2e/helper.go
+++ b/test/e2e/helper.go
@@ -35,11 +35,9 @@ func newScheme() *runtime.Scheme {
 	utilruntime.Must(nfspvcv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(cmapi.AddToScheme(scheme))
 	utilruntime.Must(dnsrecordv1alpha1.AddToScheme(scheme))
-	_ = corev1.AddToScheme(scheme)
-	_ = loggingv1beta1.AddToScheme(scheme)
-	_ = knativev1alphav1.AddToScheme(scheme)
-	_ = knativev1.AddToScheme(scheme)
-	_ = networkingv1.Install(scheme)
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(knativev1alphav1.AddToScheme(scheme))
+	utilruntime.Must(networkingv1.Install(scheme))
 
 	return scheme
 }

--- a/test/e2e/mocks/base.go
+++ b/test/e2e/mocks/base.go
@@ -5,7 +5,6 @@ import (
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 )
@@ -101,46 +100,6 @@ func CreateServiceAccount(name, namespace string) *corev1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-		},
-	}
-}
-
-// CreateBaseCappConfig is responsible for making the most lean version of CappConfig, so we can manipulate it in the tests.
-func CreateBaseCappConfig() *cappv1alpha1.CappConfig {
-	return &cappv1alpha1.CappConfig{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "CappConfig",
-			APIVersion: "rcs.dana.io/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      consts.CappConfigName,
-			Namespace: consts.NSName,
-		},
-		Spec: cappv1alpha1.CappConfigSpec{
-			DNSConfig: cappv1alpha1.DNSConfig{
-				Zone:     "example.com",
-				CNAME:    "cname.example.com",
-				Provider: "mock-dns",
-				Issuer:   "letsencrypt",
-			},
-			AutoscaleConfig: cappv1alpha1.AutoscaleConfig{
-				RPS:             100,
-				CPU:             50,
-				Memory:          50,
-				Concurrency:     10,
-				ActivationScale: 1,
-			},
-			DefaultResources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("100m"),
-					corev1.ResourceMemory: resource.MustParse("128Mi"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("500m"),
-					corev1.ResourceMemory: resource.MustParse("512Mi"),
-				},
-			},
-			AllowedHostnamePatterns: []cappv1alpha1.HostnamePattern{{Match: ".*"}},
 		},
 	}
 }

--- a/test/e2e/utils/capp_adapter.go
+++ b/test/e2e/utils/capp_adapter.go
@@ -49,8 +49,3 @@ func GenerateUniqueCappName(baseCappName string) string {
 	randString := generateRandomString(consts.RandStrLength)
 	return baseCappName + "-" + randString
 }
-
-// UpdateCapp updates the provided Capp instance in the Kubernetes cluster, and returns it.
-func UpdateCapp(k8sClient client.Client, capp *cappv1alpha1.Capp) {
-	Expect(k8sClient.Update(context.Background(), capp)).To(Succeed())
-}

--- a/test/e2e/utils/knative_adapter.go
+++ b/test/e2e/utils/knative_adapter.go
@@ -1,24 +1,10 @@
 package utils
 
 import (
-	"fmt"
-	"regexp"
-	"strconv"
-
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// GetNextRevisionName generates the name for the next revision based on the current revision name.
-func GetNextRevisionName(currentRevision string) string {
-	re := regexp.MustCompile(`(\d+)$`)
-	match := re.FindStringSubmatch(currentRevision)
-	revisionNumber, _ := strconv.Atoi(match[1])
-	nextRevisionNumber := revisionNumber + 1
-	nextRevisionName := fmt.Sprintf("%s%05d", currentRevision[:len(currentRevision)-len(match[0])], nextRevisionNumber)
-	return nextRevisionName
-}
 
 // GetKSVC fetches and returns an existing instance of a Knative Serving.
 func GetKSVC(k8sClient client.Client, name string, namespace string) *knativev1.Service {

--- a/test/e2e/utils/resources_adapter.go
+++ b/test/e2e/utils/resources_adapter.go
@@ -48,11 +48,6 @@ func GetResource(k8sClient client.Client, obj client.Object, name, namespace str
 	Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, obj))
 }
 
-// GetClusterResource fetches an existing Cluster resource and returns an instance of it.
-func GetClusterResource(k8sClient client.Client, obj client.Object, name string) {
-	Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: name}, obj))
-}
-
 // generateName generates a new name by combining the given baseName
 // with a randomly generated string of a specified length.
 func generateName(baseName string) string {
@@ -106,14 +101,4 @@ func NewRetryOnConflictBackoff() wait.Backoff {
 	b := retry.DefaultRetry
 	b.Steps = consts.RetryOnConflictSteps
 	return b
-}
-
-// RandomName generates random names like kafka-source-x7k9p2
-func RandomName(prefix string) string {
-	const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
-	b := make([]byte, 6)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
-	}
-	return fmt.Sprintf("%s-%s", prefix, b)
 }


### PR DESCRIPTION
Reject ignored errors (_ = err) in golangci-lint. Propagate
GetCappConfig failures in CappRevision updates; assert list
errors in CappRevision e2e Eventually blocks; register test
schemes with utilruntime.Must and drop duplicate AddToScheme
calls in e2e helper setup.