### PR TITLE
ci: enable errorlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - copyloopvar
     - dupl
     - errcheck
+    - errorlint
     - goconst
     - gocyclo
     - govet

--- a/internal/webhook/rcs/common/utils.go
+++ b/internal/webhook/rcs/common/utils.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -68,7 +69,8 @@ func ValidateDomainName(domainName string, allowedPatterns []cappv1alpha1.Hostna
 func IsDomainNameTaken(domainName string) (bool, error) {
 	_, err := net.LookupHost(domainName)
 	if err != nil {
-		if err.(*net.DNSError).IsNotFound {
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
 			return false, nil
 		}
 		return false, err


### PR DESCRIPTION
Use errors.As for DNS lookup failures so wrapped net.DNSError values are recognized as "not found".