### PR TITLE
ci: enable revive import-shadowing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     revive:
       rules:
         - name: comment-spacings
+        - name: import-shadowing
   exclusions:
     generated: lax
     rules:

--- a/internal/kinds/capp/finalizer/finalizer_test.go
+++ b/internal/kinds/capp/finalizer/finalizer_test.go
@@ -28,8 +28,8 @@ func newScheme() *runtime.Scheme {
 }
 
 func newFakeClient() client.Client {
-	scheme := newScheme()
-	return fake.NewClientBuilder().WithScheme(scheme).Build()
+	runtimeScheme := newScheme()
+	return fake.NewClientBuilder().WithScheme(runtimeScheme).Build()
 }
 
 func TestEnsureFinalizer(t *testing.T) {

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -107,8 +107,8 @@ func (r DNSRecordManager) CleanUp(capp cappv1alpha1.Capp) error {
 				continue
 			}
 		}
-		record := rclient.GetBareDNSRecord(dnsRecord.Name, dnsRecord.Namespace)
-		if err := resourceManager.DeleteResource(&record); err != nil {
+		bareRecord := rclient.GetBareDNSRecord(dnsRecord.Name, dnsRecord.Namespace)
+		if err := resourceManager.DeleteResource(&bareRecord); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}

--- a/internal/kinds/capp/resourcemanagers/eventsource.go
+++ b/internal/kinds/capp/resourcemanagers/eventsource.go
@@ -75,14 +75,14 @@ func (e EventSourceManager) GetStatus(capp cappv1alpha1.Capp) (cappv1alpha1.Even
 
 // createOrUpdateSources applies CreateOrUpdate for each source declared in the spec.
 func (e EventSourceManager) createOrUpdateSources(capp cappv1alpha1.Capp) error {
-	client := rclient.ResourceManagerClient{Ctx: e.Ctx, K8sclient: e.K8sclient, Log: e.Log}
+	rm := rclient.ResourceManagerClient{Ctx: e.Ctx, K8sclient: e.K8sclient, Log: e.Log}
 	for _, source := range capp.Spec.EventSourcesSpec.Sources {
 		kind, exists := sources.GetEventSourceKind(source)
 		if !exists {
 			e.Log.Info("No kind registered for source, skipping", "sourceName", source.Name)
 			continue
 		}
-		err := kind.CreateOrUpdate(e.Ctx, client, e.Log, capp, source)
+		err := kind.CreateOrUpdate(e.Ctx, rm, e.Log, capp, source)
 		if err != nil {
 			return fmt.Errorf("failed to create or update %q source: %w", source.Name, err)
 		}

--- a/test/e2e/utils/logger_adapter.go
+++ b/test/e2e/utils/logger_adapter.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CreateCappWithLogger creates a Capp instance with the specified logger type and returns the created Capp object.
-func CreateCappWithLogger(logType cappv1alpha1.LogType, client client.Client) *cappv1alpha1.Capp {
+func CreateCappWithLogger(logType cappv1alpha1.LogType, k8sClient client.Client) *cappv1alpha1.Capp {
 	capp := mock.CreateBaseCapp()
 	switch logType {
 	case cappv1alpha1.LogTypeElastic:
@@ -16,18 +16,18 @@ func CreateCappWithLogger(logType cappv1alpha1.LogType, client client.Client) *c
 	case cappv1alpha1.LogTypeElasticDataStream:
 		capp.Spec.LogSpec = mock.CreateElasticDataStreamLogSpec()
 	}
-	return CreateCapp(client, capp)
+	return CreateCapp(k8sClient, capp)
 }
 
 // CreateCredentialsSecret creates a Kubernetes secret containing credentials for the specified logger type.
-func CreateCredentialsSecret(logType cappv1alpha1.LogType, client client.Client) {
+func CreateCredentialsSecret(logType cappv1alpha1.LogType, k8sClient client.Client) {
 	switch logType {
 	case cappv1alpha1.LogTypeElastic:
 		elasticSecret := mock.CreateElasticSecretObject()
-		CreateSecret(client, elasticSecret)
+		CreateSecret(k8sClient, elasticSecret)
 	case cappv1alpha1.LogTypeElasticDataStream:
 		elasticDataStreamSecret := mock.CreateElasticDataStreamSecretObject()
-		CreateSecret(client, elasticDataStreamSecret)
+		CreateSecret(k8sClient, elasticDataStreamSecret)
 	}
 }
 


### PR DESCRIPTION
Turn on revive import-shadowing and rename locals/params that shadowed imports (runtimeScheme, bareRecord, rm, k8sClient).