### PR TITLE
ci: enable noctx for DNS hostname checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - noctx
     - nakedret
     - staticcheck
     - prealloc

--- a/internal/webhook/rcs/common/utils.go
+++ b/internal/webhook/rcs/common/utils.go
@@ -65,8 +65,8 @@ func ValidateDomainName(domainName string, allowedPatterns []cappv1alpha1.Hostna
 }
 
 // IsDomainNameTaken checks if the given hostname is already in use.
-func IsDomainNameTaken(domainName string) (bool, error) {
-	_, err := net.LookupHost(domainName)
+func IsDomainNameTaken(ctx context.Context, domainName string) (bool, error) {
+	_, err := net.DefaultResolver.LookupHost(ctx, domainName)
 	if err != nil {
 		if err.(*net.DNSError).IsNotFound {
 			return false, nil

--- a/internal/webhook/rcs/v1alpha1/validator.go
+++ b/internal/webhook/rcs/v1alpha1/validator.go
@@ -65,7 +65,7 @@ func (c *CappValidator) handle(ctx context.Context, capp cappv1alpha1.Capp, oldC
 		if errs := common.ValidateDomainName(capp.Spec.RouteSpec.Hostname, allowedHostnamePatterns); errs != nil {
 			return admission.Denied(errs.Error())
 		}
-		taken, err := common.IsDomainNameTaken(capp.Spec.RouteSpec.Hostname)
+		taken, err := common.IsDomainNameTaken(ctx, capp.Spec.RouteSpec.Hostname)
 		if err != nil {
 			return admission.Denied(fmt.Sprintf("hostname check error: %v", err))
 		}


### PR DESCRIPTION
Use context-aware LookupHost in IsDomainNameTaken and pass the admission request context from the validating webhook.