### PR TITLE
ci: enable contextcheck for CappConfig fetches

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - dupl
     - errcheck
     - errorlint
+    - contextcheck
     - goconst
     - gocyclo
     - govet

--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -79,7 +79,7 @@ func (k KnativeServiceManager) prepareResource(capp cappv1alpha1.Capp, ctx conte
 	volumes := k.prepareVolumes(capp)
 	knativeService.Spec.Template.Spec.Volumes = append(knativeService.Spec.Template.Spec.Volumes, volumes...)
 
-	cappConfig, err := utils.GetCappConfig(k.K8sclient)
+	cappConfig, err := utils.GetCappConfig(ctx, k.K8sclient)
 	if err != nil {
 		k.Log.Error(err, fmt.Sprintf("could not fetch cappConfig from namespace %q", utils.CappNS))
 	}

--- a/internal/kinds/capp/utils/utils.go
+++ b/internal/kinds/capp/utils/utils.go
@@ -85,17 +85,17 @@ func GetListOptions(set labels.Set) client.ListOptions {
 }
 
 // GetResource fetches an existing resource and returns an instance of it.
-func GetResource(k8sClient client.Client, obj client.Object, name, namespace string) error {
-	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, obj); err != nil {
+func GetResource(ctx context.Context, k8sClient client.Client, obj client.Object, name, namespace string) error {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj); err != nil {
 		return err
 	}
 	return nil
 }
 
 // GetCappConfig fetches and returns an existing instance of an existing cappConfig
-func GetCappConfig(k8sClient client.Client) (*cappv1alpha1.CappConfig, error) {
+func GetCappConfig(ctx context.Context, k8sClient client.Client) (*cappv1alpha1.CappConfig, error) {
 	cappConfig := &cappv1alpha1.CappConfig{}
-	if err := GetResource(k8sClient, cappConfig, CappConfigName, CappNS); err != nil {
+	if err := GetResource(ctx, k8sClient, cappConfig, CappConfigName, CappNS); err != nil {
 		return nil, err
 	}
 	return cappConfig, nil

--- a/internal/kinds/capprevision/actionmanagers/update.go
+++ b/internal/kinds/capprevision/actionmanagers/update.go
@@ -72,7 +72,7 @@ func HandleCappUpdate(ctx context.Context, k8sClient client.Client, capp cappv1a
 	sortByCreationTime(cappRevisions)
 	numOfRevisions := len(cappRevisions)
 
-	cappConfig, err := utils.GetCappConfig(k8sClient)
+	cappConfig, err := utils.GetCappConfig(ctx, k8sClient)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Thread reconcile context through GetCappConfig and GetResource instead of context.Background().