### PR TITLE
chore: run golangci-lint via go tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,12 +81,12 @@ test-e2e: ## Run e2e tests (requires kubeconfig).
 	go run github.com/onsi/ginkgo/v2/ginkgo --vv -p $(GINKGO_E2E_PROCS_FLAG) $(GINKGO_E2E_FOCUS_FLAG) -coverprofile cover.out -timeout 10m ./test/e2e/...
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter
-	$(GOLANGCI_LINT) run
+lint: ## Run golangci-lint linter (uses Go toolchain from go.mod)
+	go tool golangci-lint run
 
 .PHONY: lint-fix
-lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
-	$(GOLANGCI_LINT) run --fix
+lint-fix: ## Run golangci-lint linter and perform fixes
+	go tool golangci-lint run --fix
 
 ##@ Build
 
@@ -237,7 +237,6 @@ KUBECTL ?= kubectl
 KUSTOMIZE ?= $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
 ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
-GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 HELMFILE ?= $(LOCALBIN)/helmfile-$(HELMFILE_VERSION)
 HELM_DOCS ?= $(LOCALBIN)/helm-docs-$(HELM_DOCS_VERSION)
 
@@ -248,7 +247,6 @@ HELMFILE_URL ?= https://github.com/helmfile/helmfile/releases/download/v${HELMFI
 KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v2.7.2
 HELMFILE_VERSION ?= 1.4.3
 HELM_DOCS_VERSION ?= v1.14.2
 
@@ -266,11 +264,6 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
-
-.PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
-$(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 .PHONY: helm
 helm: ## Install helm on the local machine


### PR DESCRIPTION
Use the module toolchain for make lint instead of a bin golangci-lint binary that breaks when go.mod bumps Go.