### PR TITLE
chore(lint): enable bodyclose, errname, gosec, forbidigo, durationcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,12 +5,17 @@ linters:
   default: none
   enable:
     - copyloopvar
+    - bodyclose
     - dupl
+    - durationcheck
     - errcheck
+    - errname
     - errorlint
+    - forbidigo
     - contextcheck
     - goconst
     - gocyclo
+    - gosec
     - govet
     - ineffassign
     - misspell
@@ -34,6 +39,9 @@ linters:
     rules:
       - linters:
           - staticcheck
+        path: test/e2e/*
+      - linters:
+          - gosec
         path: test/e2e/*
       - linters:
           - dupl


### PR DESCRIPTION
Turn on additional golangci-lint analyzers with zero findings on main. Exclude gosec from test/e2e to avoid false positives on fixtures and test-only random helpers.