### PR TITLE
fix(webhook): reject capp hostname changes on update

### DIFF
--- a/internal/webhook/rcs/v1alpha1/validator.go
+++ b/internal/webhook/rcs/v1alpha1/validator.go
@@ -45,8 +45,9 @@ func (c *CappValidator) Handle(ctx context.Context, req admission.Request) admis
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	oldCapp := &cappv1alpha1.Capp{}
+	var oldCapp *cappv1alpha1.Capp
 	if req.Operation == admissionv1.Update {
+		oldCapp = &cappv1alpha1.Capp{}
 		err := c.Decoder.DecodeRaw(req.OldObject, oldCapp)
 		if err != nil {
 			logger.Error(err, "could not decode old capp object")
@@ -54,10 +55,10 @@ func (c *CappValidator) Handle(ctx context.Context, req admission.Request) admis
 		}
 	}
 
-	return c.handle(ctx, capp, oldCapp)
+	return c.handle(ctx, req.Operation, capp, oldCapp)
 }
 
-func (c *CappValidator) handle(ctx context.Context, capp cappv1alpha1.Capp, oldCapp *cappv1alpha1.Capp) admission.Response {
+func (c *CappValidator) handle(ctx context.Context, operation admissionv1.Operation, capp cappv1alpha1.Capp, oldCapp *cappv1alpha1.Capp) admission.Response {
 	config, err := common.GetCappConfig(ctx, c.Client)
 	if err != nil {
 		return admission.Denied("Failed to fetch CappConfig")
@@ -68,7 +69,11 @@ func (c *CappValidator) handle(ctx context.Context, capp cappv1alpha1.Capp, oldC
 		allowedHostnamePatterns = config.Spec.AllowedHostnamePatterns
 	}
 
-	if oldCapp == nil || capp.Spec.RouteSpec.Hostname != oldCapp.Spec.RouteSpec.Hostname {
+	if err := validateHostnameImmutability(operation, capp, oldCapp); err != nil {
+		return admission.Denied(err.Error())
+	}
+
+	if operation == admissionv1.Create || capp.Spec.RouteSpec.Hostname != oldCapp.Spec.RouteSpec.Hostname {
 		if errs := common.ValidateDomainName(capp.Spec.RouteSpec.Hostname, allowedHostnamePatterns); errs != nil {
 			return admission.Denied(errs.Error())
 		}
@@ -106,6 +111,20 @@ func (c *CappValidator) handle(ctx context.Context, capp cappv1alpha1.Capp, oldC
 		return admission.Denied(fmt.Sprintf("invalid scaleDelaySeconds %d: must be less than or equal to global max scale delay %d", scaleDelay, config.Spec.AutoscaleConfig.MaxScaleDelay))
 	}
 	return admission.Allowed("")
+}
+
+func validateHostnameImmutability(operation admissionv1.Operation, capp cappv1alpha1.Capp, oldCapp *cappv1alpha1.Capp) error {
+	if operation != admissionv1.Update {
+		return nil
+	}
+
+	oldHostname := oldCapp.Spec.RouteSpec.Hostname
+	newHostname := capp.Spec.RouteSpec.Hostname
+	if oldHostname == newHostname || oldHostname == "" {
+		return nil
+	}
+
+	return fmt.Errorf("spec.routeSpec.hostname is immutable once set")
 }
 
 func validateNFSVolumeMounts(capp cappv1alpha1.Capp) error {

--- a/internal/webhook/rcs/v1alpha1/validator_test.go
+++ b/internal/webhook/rcs/v1alpha1/validator_test.go
@@ -26,9 +26,12 @@ const (
 	mountedNFSVolumeName   = "mounted"
 	unmountedNFSVolumeName = "a-data"
 	eventSourceName        = "ping-a"
+	unchangedHostname      = "same.example.com"
+	oldHostname            = "old.example.com"
+	newHostname            = "new.example.com"
 )
 
-func TestCappValidator_Handle(t *testing.T) {
+func TestCappValidatorHandle(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(cappv1alpha1.AddToScheme(scheme))
@@ -37,12 +40,15 @@ func TestCappValidator_Handle(t *testing.T) {
 
 	tests := []struct {
 		name        string
+		operation   admissionv1.Operation
 		capp        *cappv1alpha1.Capp
+		oldCapp     *cappv1alpha1.Capp
 		expectAllow bool
 		expectMsg   string
 	}{
 		{
-			name: "Allow capp without sources",
+			name:      "Allow capp without sources",
+			operation: admissionv1.Create,
 			capp: &cappv1alpha1.Capp{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      cappName,
@@ -61,7 +67,8 @@ func TestCappValidator_Handle(t *testing.T) {
 			expectAllow: true,
 		},
 		{
-			name: "Allow Capp with valid scaleDelaySeconds",
+			name:      "Allow Capp with valid scaleDelaySeconds",
+			operation: admissionv1.Create,
 			capp: &cappv1alpha1.Capp{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      cappName,
@@ -77,7 +84,8 @@ func TestCappValidator_Handle(t *testing.T) {
 			expectAllow: true,
 		},
 		{
-			name: "Deny Capp with invalid scaleDelaySeconds",
+			name:      "Deny Capp with invalid scaleDelaySeconds",
+			operation: admissionv1.Create,
 			capp: &cappv1alpha1.Capp{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      cappName,
@@ -92,6 +100,61 @@ func TestCappValidator_Handle(t *testing.T) {
 			},
 			expectAllow: false,
 			expectMsg:   "must be less than or equal to global max scale delay",
+		},
+		{
+			name:      "allows update when hostname remains unchanged",
+			operation: admissionv1.Update,
+			capp: &cappv1alpha1.Capp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cappName,
+					Namespace: nsName,
+				},
+				Spec: cappv1alpha1.CappSpec{
+					RouteSpec: cappv1alpha1.RouteSpec{
+						Hostname: unchangedHostname,
+					},
+				},
+			},
+			oldCapp: &cappv1alpha1.Capp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cappName,
+					Namespace: nsName,
+				},
+				Spec: cappv1alpha1.CappSpec{
+					RouteSpec: cappv1alpha1.RouteSpec{
+						Hostname: unchangedHostname,
+					},
+				},
+			},
+			expectAllow: true,
+		},
+		{
+			name:      "rejects update when hostname changes",
+			operation: admissionv1.Update,
+			capp: &cappv1alpha1.Capp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cappName,
+					Namespace: nsName,
+				},
+				Spec: cappv1alpha1.CappSpec{
+					RouteSpec: cappv1alpha1.RouteSpec{
+						Hostname: newHostname,
+					},
+				},
+			},
+			oldCapp: &cappv1alpha1.Capp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cappName,
+					Namespace: nsName,
+				},
+				Spec: cappv1alpha1.CappSpec{
+					RouteSpec: cappv1alpha1.RouteSpec{
+						Hostname: oldHostname,
+					},
+				},
+			},
+			expectAllow: false,
+			expectMsg:   "spec.routeSpec.hostname is immutable once set",
 		},
 	}
 
@@ -126,7 +189,7 @@ func TestCappValidator_Handle(t *testing.T) {
 
 			req := admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
-					Operation: admissionv1.Create,
+					Operation: tc.operation,
 					Object: runtime.RawExtension{
 						Raw: raw,
 					},
@@ -134,12 +197,80 @@ func TestCappValidator_Handle(t *testing.T) {
 					Namespace: nsName,
 				},
 			}
+			if tc.operation == admissionv1.Update {
+				oldRaw, marshalErr := json.Marshal(tc.oldCapp)
+				require.NoError(t, marshalErr)
+				req.OldObject = runtime.RawExtension{Raw: oldRaw}
+			}
 
 			resp := validator.Handle(context.Background(), req)
 			assert.Equal(t, tc.expectAllow, resp.Allowed, "Expected allowed: %v, got: %v. Result: %v", tc.expectAllow, resp.Allowed, resp.Result)
 			if !tc.expectAllow && tc.expectMsg != "" {
 				assert.Contains(t, resp.Result.Message, tc.expectMsg)
 			}
+		})
+	}
+
+}
+
+func TestValidateHostnameImmutability(t *testing.T) {
+	tests := []struct {
+		name        string
+		operation   admissionv1.Operation
+		oldHostname string
+		newHostname string
+		wantErr     bool
+	}{
+		{
+			name:      "allows create",
+			operation: admissionv1.Create,
+		},
+		{
+			name:        "allows update when hostname remains unchanged",
+			operation:   admissionv1.Update,
+			oldHostname: unchangedHostname,
+			newHostname: unchangedHostname,
+		},
+		{
+			name:        "allows update when hostname is set from empty",
+			operation:   admissionv1.Update,
+			newHostname: newHostname,
+		},
+		{
+			name:        "rejects update when hostname changes",
+			operation:   admissionv1.Update,
+			oldHostname: oldHostname,
+			newHostname: newHostname,
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			capp := cappv1alpha1.Capp{
+				Spec: cappv1alpha1.CappSpec{
+					RouteSpec: cappv1alpha1.RouteSpec{
+						Hostname: tc.newHostname,
+					},
+				},
+			}
+			oldCapp := &cappv1alpha1.Capp{
+				Spec: cappv1alpha1.CappSpec{
+					RouteSpec: cappv1alpha1.RouteSpec{
+						Hostname: tc.oldHostname,
+					},
+				},
+			}
+
+			err := validateHostnameImmutability(tc.operation, capp, oldCapp)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "spec.routeSpec.hostname")
+			require.Contains(t, err.Error(), "immutable")
 		})
 	}
 }

--- a/test/e2e/certificate_test.go
+++ b/test/e2e/certificate_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"context"
 
-	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 	"github.com/dana-team/container-app-operator/test/e2e/mocks"
 	"github.com/dana-team/container-app-operator/test/e2e/utils"
@@ -46,41 +45,35 @@ var _ = Describe("Validate Certificate functionality", func() {
 			return false
 		}, consts.DefaultConsistently, consts.Interval).Should(BeFalse(), "Should not have Certificate creation failure events")
 
-		By("Updating the Capp Route hostname and checking the status")
-		var toBeUpdatedCapp *cappv1alpha1.Capp
-		updatedRouteHostname := utils.GenerateResourceName(utils.GenerateRouteHostname(), consts.ZoneValue)
-
+		By("Updating the Capp Route TLS flag off and on")
 		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
-			toBeUpdatedCapp = utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			toBeUpdatedCapp.Spec.RouteSpec.Hostname = updatedRouteHostname
+			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			toBeUpdatedCapp.Spec.RouteSpec.TlsEnabled = false
 
 			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() string {
-			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			if capp.Status.RouteStatus.DomainMappingObjectStatus.URL == nil {
-				return ""
-			}
-			return capp.Status.RouteStatus.DomainMappingObjectStatus.URL.Host
-		}, consts.Timeout, consts.Interval).Should(Equal(updatedRouteHostname), "Should update Route Status of Capp")
-
-		By("checking if the Certificate object was updated after changing the Capp Route Hostname")
-		updatedCertificateObject := mocks.CreateCertificateObject(updatedRouteHostname)
 		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, updatedCertificateObject)
-		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
+			return utils.DoesResourceExist(k8sClient, certificateObject)
+		}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should not find a resource.")
 
-		Eventually(func() []string {
-			updatedCertificateObject = utils.GetCertificate(k8sClient, updatedRouteHostname, toBeUpdatedCapp.Namespace)
-			return updatedCertificateObject.Spec.DNSNames
-		}, consts.Timeout, consts.Interval).Should(Equal([]string{updatedRouteHostname}))
+		err = retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
+			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
+			toBeUpdatedCapp.Spec.RouteSpec.TlsEnabled = true
+
+			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func() bool {
+			return utils.DoesResourceExist(k8sClient, certificateObject)
+		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Deleting the Capp instance and checking if the Certificate was deleted successfully")
 		utils.DeleteCapp(k8sClient, createdCapp)
 		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, updatedCertificateObject)
+			return utils.DoesResourceExist(k8sClient, certificateObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
@@ -110,33 +103,6 @@ var _ = Describe("Validate Certificate functionality", func() {
 		By("Removing the Certificate requirement from Capp Spec and checking cleanup", func() {
 			err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 				toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-				toBeUpdatedCapp.Spec.RouteSpec.TlsEnabled = false
-
-				return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(func() bool {
-				return utils.DoesResourceExist(k8sClient, certificateObject)
-			}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should not find a resource.")
-		})
-	})
-
-	It("Should cleanup Certificate when no longer required (hostname)", func() {
-		By("Creating an HTTPS Capp")
-		createdCapp, routeHostname := utils.CreateHTTPSCapp(k8sClient)
-
-		By("Checking if the Certificate was created successfully")
-		certificateName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
-		certificateObject := mocks.CreateCertificateObject(certificateName)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, certificateObject)
-		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
-
-		By("Removing the Certificate requirement from Capp Spec and checking cleanup", func() {
-			err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
-				toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-				toBeUpdatedCapp.Spec.RouteSpec.Hostname = ""
 				toBeUpdatedCapp.Spec.RouteSpec.TlsEnabled = false
 
 				return utils.UpdateResource(k8sClient, toBeUpdatedCapp)

--- a/test/e2e/dnsrecord_test.go
+++ b/test/e2e/dnsrecord_test.go
@@ -29,23 +29,20 @@ var _ = Describe("Validate DNSRecord functionality", func() {
 		Expect(dnsRecordObject.Labels[consts.CappNamespaceKey]).Should(Equal(createdCapp.Namespace))
 		Expect(dnsRecordObject.Labels[consts.ManagedByLabelKey]).Should(Equal(consts.CappKey))
 
-		By("checking if the DNSRecord object was updated after changing the Capp Route Hostname")
-		updatedRouteHostname := utils.GenerateRouteHostname()
-
+		By("checking if the DNSRecord object is preserved after a route timeout update")
+		routeTimeoutSeconds := int64(30)
 		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			toBeUpdatedCapp.Spec.RouteSpec.Hostname = updatedRouteHostname
+			toBeUpdatedCapp.Spec.RouteSpec.RouteTimeoutSeconds = &routeTimeoutSeconds
 
 			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		updatedDNSRecord := dnsRecordObject
-		updatedDNSRecordName := utils.GenerateResourceName(updatedRouteHostname, consts.ZoneValue)
 		Eventually(func() *string {
-			updatedDNSRecord = utils.GetDNSRecord(k8sClient, updatedDNSRecordName, createdCapp.Namespace)
-			return updatedDNSRecord.Spec.ForProvider.Name
-		}, consts.Timeout, consts.Interval).Should(Equal(&updatedRouteHostname))
+			currentDNSRecord := utils.GetDNSRecord(k8sClient, dnsRecordName, createdCapp.Namespace)
+			return currentDNSRecord.Spec.ForProvider.Name
+		}, consts.Timeout, consts.Interval).Should(Equal(&createdCapp.Spec.RouteSpec.Hostname))
 
 		By("Deleting the Capp instance")
 		utils.DeleteCapp(k8sClient, createdCapp)
@@ -55,34 +52,8 @@ var _ = Describe("Validate DNSRecord functionality", func() {
 
 		By("Checking if the DNSRecord was deleted successfully")
 		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, updatedDNSRecord)
-		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
-	})
-
-	It("Should cleanup DNSRecord when no longer required", func() {
-		By("Creating a capp with a route")
-		createdCapp, _ := utils.CreateCappWithHTTPHostname(k8sClient)
-
-		By("Checking if the DNSRecord was created successfully")
-		dnsRecordName := utils.GenerateResourceName(createdCapp.Spec.RouteSpec.Hostname, consts.ZoneValue)
-		dnsRecordObject := mocks.CreateDNSRecordObject(dnsRecordName)
-		Eventually(func() bool {
 			return utils.DoesResourceExist(k8sClient, dnsRecordObject)
-		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
-
-		By("Removing the DNSRecord requirement from Capp Spec and checking cleanup", func() {
-			err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
-				toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-				toBeUpdatedCapp.Spec.RouteSpec.Hostname = ""
-
-				return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(func() bool {
-				return utils.DoesResourceExist(k8sClient, dnsRecordObject)
-			}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should not find a resource.")
-		})
+		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
 	It("Should not update DNSRecord when only Capp metadata changes", func() {

--- a/test/e2e/domain_mapping_test.go
+++ b/test/e2e/domain_mapping_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 	"github.com/dana-team/container-app-operator/test/e2e/mocks"
 	"github.com/dana-team/container-app-operator/test/e2e/utils"
@@ -37,29 +36,23 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 			return capp.Status.RouteStatus.DomainMappingObjectStatus.URL.Host
 		}, consts.Timeout, consts.Interval).Should(Equal(domainMappingName), "Should update Route Status of Capp")
 
-		By("Updating the Capp Route hostname and checking the status")
-		updatedRouteHostname := utils.GenerateResourceName(utils.GenerateRouteHostname(), consts.ZoneValue)
+		By("Updating route timeout and checking DomainMapping is preserved")
+		routeTimeoutSeconds := int64(30)
 		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			toBeUpdatedCapp.Spec.RouteSpec.Hostname = updatedRouteHostname
+			toBeUpdatedCapp.Spec.RouteSpec.RouteTimeoutSeconds = &routeTimeoutSeconds
 
 			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() string {
-			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			if capp.Status.RouteStatus.DomainMappingObjectStatus.URL == nil {
+			domainMapping := utils.GetDomainMapping(k8sClient, domainMappingName, createdCapp.Namespace)
+			if domainMapping.Spec.Ref.Name == "" {
 				return ""
 			}
-			return capp.Status.RouteStatus.DomainMappingObjectStatus.URL.Host
-		}, consts.Timeout, consts.Interval).Should(Equal(updatedRouteHostname), "Should update Route Status of Capp")
-
-		By("checking if the domainMapping was updated")
-		updatedDomainMappingObject := mocks.CreateDomainMappingObject(updatedRouteHostname)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, updatedDomainMappingObject)
-		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
+			return domainMapping.Spec.Ref.Name
+		}, consts.Timeout, consts.Interval).Should(Equal(createdCapp.Name), "Should keep DomainMapping after route timeout update")
 
 		By("Deleting the Capp instance")
 		utils.DeleteCapp(k8sClient, createdCapp)
@@ -69,7 +62,7 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 
 		By("Checking if the domainMapping was deleted successfully")
 		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, updatedDomainMappingObject)
+			return utils.DoesResourceExist(k8sClient, domainMappingObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
@@ -120,23 +113,30 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 			return capp.Status.RouteStatus.DomainMappingObjectStatus.URL.Host
 		}, consts.Timeout, consts.Interval).Should(Equal(domainMappingName), "Should update Route Status of Capp")
 
-		By("Removing the Route from the Capp and check the status and resource clean up")
+		By("Updating route timeout and checking RouteStatus is preserved")
+		routeTimeoutSeconds := int64(45)
 		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 			toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			toBeUpdatedCapp.Spec.RouteSpec = cappv1alpha1.RouteSpec{}
+			toBeUpdatedCapp.Spec.RouteSpec.RouteTimeoutSeconds = &routeTimeoutSeconds
 
 			return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		domainMappingObject := mocks.CreateDomainMappingObject(domainMappingName)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, domainMappingObject)
-		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
-
-		Eventually(func() cappv1alpha1.RouteStatus {
+		Eventually(func() string {
 			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			return capp.Status.RouteStatus
-		}, consts.Timeout, consts.Interval).Should(Equal(cappv1alpha1.RouteStatus{}), "Should update Route Status of Capp")
+			if capp.Status.RouteStatus.DomainMappingObjectStatus.URL == nil {
+				return ""
+			}
+			return capp.Status.RouteStatus.DomainMappingObjectStatus.URL.Host
+		}, consts.Timeout, consts.Interval).Should(Equal(domainMappingName), "Should keep Route Status of Capp")
+
+		Eventually(func() string {
+			domainMapping := utils.GetDomainMapping(k8sClient, domainMappingName, createdCapp.Namespace)
+			if domainMapping.Spec.Ref.Name == "" {
+				return ""
+			}
+			return domainMapping.Spec.Ref.Name
+		}, consts.Timeout, consts.Interval).Should(Equal(createdCapp.Name), "Should keep DomainMapping after route timeout update")
 	})
 })


### PR DESCRIPTION
Treat spec.routeSpec.hostname as immutable after create in the Capp webhook, while keeping create behavior unchanged.

Add focused update-path coverage in TestCappValidatorHandle and direct immutability helper tests for unchanged vs changed hostnames.

Refs #523