### PR TITLE
fix(api): reject routeSpec tlsEnabled without hostname

### DIFF
--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -120,12 +120,14 @@ type NFSVolume struct {
 }
 
 // RouteSpec defines the route specification for the Capp.
+// +kubebuilder:validation:XValidation:rule="!has(self.tlsEnabled) || !self.tlsEnabled || (has(self.hostname) && size(self.hostname) > 0)",message="hostname must be set when tlsEnabled is true"
 type RouteSpec struct {
-	// Hostname is a custom DNS name for the Capp route.
+	// Hostname is the custom DNS name for the Capp route.
+	// Required when tlsEnabled is true.
 	// +optional
 	Hostname string `json:"hostname,omitempty"`
 
-	// TlsEnabled determines whether to enable TLS for the Capp route.
+	// TlsEnabled enables HTTPS and automatic certificate management for hostname.
 	// +optional
 	TlsEnabled bool `json:"tlsEnabled,omitempty"`
 

--- a/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
@@ -2191,7 +2191,6 @@ spec:
                                                 procMount denotes the type of proc mount to use for the containers.
                                                 The default value is Default which uses the container runtime defaults for
                                                 readonly paths and masked paths.
-                                                This requires the ProcMountType feature flag to be enabled.
                                                 Note that this field cannot be set when spec.os.name is windows.
                                               type: string
                                             readOnlyRootFilesystem:
@@ -3810,7 +3809,6 @@ spec:
                                                 procMount denotes the type of proc mount to use for the containers.
                                                 The default value is Default which uses the container runtime defaults for
                                                 readonly paths and masked paths.
-                                                This requires the ProcMountType feature flag to be enabled.
                                                 Note that this field cannot be set when spec.os.name is windows.
                                               type: string
                                             readOnlyRootFilesystem:
@@ -4307,7 +4305,6 @@ spec:
                                       When set to false, a new userns is created for the pod. Setting false is useful for
                                       mitigating container breakout vulnerabilities even allowing users to run their
                                       containers as root without actually having root privileges on the host.
-                                      This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                                     type: boolean
                                   hostname:
                                     description: |-
@@ -5518,7 +5515,6 @@ spec:
                                                 procMount denotes the type of proc mount to use for the containers.
                                                 The default value is Default which uses the container runtime defaults for
                                                 readonly paths and masked paths.
-                                                This requires the ProcMountType feature flag to be enabled.
                                                 Note that this field cannot be set when spec.os.name is windows.
                                               type: string
                                             readOnlyRootFilesystem:
@@ -6098,6 +6094,14 @@ spec:
 
                                         It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                                         Containers that need access to the ResourceClaim reference it with this name.
+
+                                        When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                                        belongs to a PodGroup, a PodResourceClaim is matched to a
+                                        PodGroupResourceClaim if all of their fields are equal (Name,
+                                        ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                                        a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                                        the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                                        Pods.
                                       properties:
                                         name:
                                           description: |-
@@ -6122,6 +6126,16 @@ spec:
                                             will also be deleted. The pod name and resource name, along with a
                                             generated component, will be used to form a unique name for the
                                             ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                            When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                            belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                            Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                            ResourceClaim generated for the PodGroup. All pods in the group that
+                                            define an equivalent PodResourceClaim matching the
+                                            PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                            generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                            owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                            instead of any individual pod.
 
                                             This field is immutable and no changes will be made to the
                                             corresponding ResourceClaim by the control plane after creating the
@@ -6256,6 +6270,28 @@ spec:
                                     x-kubernetes-list-map-keys:
                                     - name
                                     x-kubernetes-list-type: map
+                                  schedulingGroup:
+                                    description: |-
+                                      SchedulingGroup provides a reference to the immediate scheduling runtime
+                                      grouping object that this Pod belongs to.
+                                      This field is used by the scheduler to identify the group and apply the
+                                      correct group scheduling policies. The association with a group also
+                                      impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                                      of scheduling like preemption, resource attachment, etc. If not specified,
+                                      the Pod is treated as a single unit in all of these aspects.
+                                      The group object referenced by this field may not exist at the time the
+                                      Pod is created.
+                                      This field is immutable, but a group object with the same name may be
+                                      recreated with different policies. Doing this during pod scheduling
+                                      may result in the placement not conforming to the expected policies.
+                                    properties:
+                                      podGroupName:
+                                        description: |-
+                                          PodGroupName specifies the name of the standalone PodGroup object
+                                          that represents the runtime instance of this group.
+                                          Must be a DNS subdomain.
+                                        type: string
+                                    type: object
                                   securityContext:
                                     description: |-
                                       SecurityContext holds pod-level security attributes and common container settings.
@@ -7722,7 +7758,7 @@ spec:
                                             A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                             The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                             The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                            The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                            The volume will be mounted read-only (ro).
                                             Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                             The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                           properties:
@@ -7898,8 +7934,7 @@ spec:
                                           description: |-
                                             portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                             Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                            are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                            is on.
+                                            are redirected to the pxd.portworx.com CSI driver.
                                           properties:
                                             fsType:
                                               description: |-
@@ -8757,42 +8792,6 @@ spec:
                                     x-kubernetes-list-map-keys:
                                     - name
                                     x-kubernetes-list-type: map
-                                  workloadRef:
-                                    description: |-
-                                      WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                                      This field is used by the scheduler to identify the PodGroup and apply the
-                                      correct group scheduling policies. The Workload object referenced
-                                      by this field may not exist at the time the Pod is created.
-                                      This field is immutable, but a Workload object with the same name
-                                      may be recreated with different policies. Doing this during pod scheduling
-                                      may result in the placement not conforming to the expected policies.
-                                    properties:
-                                      name:
-                                        description: |-
-                                          Name defines the name of the Workload object this Pod belongs to.
-                                          Workload must be in the same namespace as the Pod.
-                                          If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                          until a Workload object is created and observed by the kube-scheduler.
-                                          It must be a DNS subdomain.
-                                        type: string
-                                      podGroup:
-                                        description: |-
-                                          PodGroup is the name of the PodGroup within the Workload that this Pod
-                                          belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                          the Pod will remain unschedulable until the Workload object is recreated
-                                          and observed by the kube-scheduler. It must be a DNS label.
-                                        type: string
-                                      podGroupReplicaKey:
-                                        description: |-
-                                          PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                          Pod belongs. It is used to distinguish pods belonging to different replicas
-                                          of the same pod group. The pod group policy is applied separately to each replica.
-                                          When set, it must be a DNS label.
-                                        type: string
-                                    required:
-                                    - name
-                                    - podGroup
-                                    type: object
                                 required:
                                 - containers
                                 type: object
@@ -8860,8 +8859,9 @@ spec:
                           the Capp.
                         properties:
                           hostname:
-                            description: Hostname is a custom DNS name for the Capp
-                              route.
+                            description: |-
+                              Hostname is the custom DNS name for the Capp route.
+                              Required when tlsEnabled is true.
                             type: string
                           routeTimeoutSeconds:
                             description: |-
@@ -8870,8 +8870,8 @@ spec:
                             format: int64
                             type: integer
                           tlsEnabled:
-                            description: TlsEnabled determines whether to enable TLS
-                              for the Capp route.
+                            description: TlsEnabled enables HTTPS and automatic certificate
+                              management for hostname.
                             type: boolean
                           trafficTarget:
                             description: TrafficTarget holds a single entry of the
@@ -8923,6 +8923,10 @@ spec:
                                 type: string
                             type: object
                         type: object
+                        x-kubernetes-validations:
+                        - message: hostname must be set when tlsEnabled is true
+                          rule: '!has(self.tlsEnabled) || !self.tlsEnabled || (has(self.hostname)
+                            && size(self.hostname) > 0)'
                       scaleSpec:
                         description: ScaleSpec holds the Capp scaling configuration.
                         properties:

--- a/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
@@ -2135,7 +2135,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -3720,7 +3719,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -4207,7 +4205,6 @@ spec:
                               When set to false, a new userns is created for the pod. Setting false is useful for
                               mitigating container breakout vulnerabilities even allowing users to run their
                               containers as root without actually having root privileges on the host.
-                              This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                             type: boolean
                           hostname:
                             description: |-
@@ -5393,7 +5390,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -5964,6 +5960,14 @@ spec:
 
                                 It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                                 Containers that need access to the ResourceClaim reference it with this name.
+
+                                When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                                belongs to a PodGroup, a PodResourceClaim is matched to a
+                                PodGroupResourceClaim if all of their fields are equal (Name,
+                                ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                                a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                                the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                                Pods.
                               properties:
                                 name:
                                   description: |-
@@ -5988,6 +5992,16 @@ spec:
                                     will also be deleted. The pod name and resource name, along with a
                                     generated component, will be used to form a unique name for the
                                     ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                    When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                    belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                    Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                    ResourceClaim generated for the PodGroup. All pods in the group that
+                                    define an equivalent PodResourceClaim matching the
+                                    PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                    generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                    owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                    instead of any individual pod.
 
                                     This field is immutable and no changes will be made to the
                                     corresponding ResourceClaim by the control plane after creating the
@@ -6122,6 +6136,28 @@ spec:
                             x-kubernetes-list-map-keys:
                             - name
                             x-kubernetes-list-type: map
+                          schedulingGroup:
+                            description: |-
+                              SchedulingGroup provides a reference to the immediate scheduling runtime
+                              grouping object that this Pod belongs to.
+                              This field is used by the scheduler to identify the group and apply the
+                              correct group scheduling policies. The association with a group also
+                              impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                              of scheduling like preemption, resource attachment, etc. If not specified,
+                              the Pod is treated as a single unit in all of these aspects.
+                              The group object referenced by this field may not exist at the time the
+                              Pod is created.
+                              This field is immutable, but a group object with the same name may be
+                              recreated with different policies. Doing this during pod scheduling
+                              may result in the placement not conforming to the expected policies.
+                            properties:
+                              podGroupName:
+                                description: |-
+                                  PodGroupName specifies the name of the standalone PodGroup object
+                                  that represents the runtime instance of this group.
+                                  Must be a DNS subdomain.
+                                type: string
+                            type: object
                           securityContext:
                             description: |-
                               SecurityContext holds pod-level security attributes and common container settings.
@@ -7564,7 +7600,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -7738,8 +7774,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -8572,42 +8607,6 @@ spec:
                             x-kubernetes-list-map-keys:
                             - name
                             x-kubernetes-list-type: map
-                          workloadRef:
-                            description: |-
-                              WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                              This field is used by the scheduler to identify the PodGroup and apply the
-                              correct group scheduling policies. The Workload object referenced
-                              by this field may not exist at the time the Pod is created.
-                              This field is immutable, but a Workload object with the same name
-                              may be recreated with different policies. Doing this during pod scheduling
-                              may result in the placement not conforming to the expected policies.
-                            properties:
-                              name:
-                                description: |-
-                                  Name defines the name of the Workload object this Pod belongs to.
-                                  Workload must be in the same namespace as the Pod.
-                                  If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                  until a Workload object is created and observed by the kube-scheduler.
-                                  It must be a DNS subdomain.
-                                type: string
-                              podGroup:
-                                description: |-
-                                  PodGroup is the name of the PodGroup within the Workload that this Pod
-                                  belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                  the Pod will remain unschedulable until the Workload object is recreated
-                                  and observed by the kube-scheduler. It must be a DNS label.
-                                type: string
-                              podGroupReplicaKey:
-                                description: |-
-                                  PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                  Pod belongs. It is used to distinguish pods belonging to different replicas
-                                  of the same pod group. The pod group policy is applied separately to each replica.
-                                  When set, it must be a DNS label.
-                                type: string
-                            required:
-                            - name
-                            - podGroup
-                            type: object
                         required:
                         - containers
                         type: object
@@ -8672,7 +8671,9 @@ spec:
                 description: RouteSpec defines the route specification for the Capp.
                 properties:
                   hostname:
-                    description: Hostname is a custom DNS name for the Capp route.
+                    description: |-
+                      Hostname is the custom DNS name for the Capp route.
+                      Required when tlsEnabled is true.
                     type: string
                   routeTimeoutSeconds:
                     description: |-
@@ -8681,8 +8682,8 @@ spec:
                     format: int64
                     type: integer
                   tlsEnabled:
-                    description: TlsEnabled determines whether to enable TLS for the
-                      Capp route.
+                    description: TlsEnabled enables HTTPS and automatic certificate
+                      management for hostname.
                     type: boolean
                   trafficTarget:
                     description: TrafficTarget holds a single entry of the routing
@@ -8734,6 +8735,10 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: hostname must be set when tlsEnabled is true
+                  rule: '!has(self.tlsEnabled) || !self.tlsEnabled || (has(self.hostname)
+                    && size(self.hostname) > 0)'
               scaleSpec:
                 description: ScaleSpec holds the Capp scaling configuration.
                 properties:

--- a/config/crd/bases/rcs.dana.io_capprevisions.yaml
+++ b/config/crd/bases/rcs.dana.io_capprevisions.yaml
@@ -2191,7 +2191,6 @@ spec:
                                                 procMount denotes the type of proc mount to use for the containers.
                                                 The default value is Default which uses the container runtime defaults for
                                                 readonly paths and masked paths.
-                                                This requires the ProcMountType feature flag to be enabled.
                                                 Note that this field cannot be set when spec.os.name is windows.
                                               type: string
                                             readOnlyRootFilesystem:
@@ -3810,7 +3809,6 @@ spec:
                                                 procMount denotes the type of proc mount to use for the containers.
                                                 The default value is Default which uses the container runtime defaults for
                                                 readonly paths and masked paths.
-                                                This requires the ProcMountType feature flag to be enabled.
                                                 Note that this field cannot be set when spec.os.name is windows.
                                               type: string
                                             readOnlyRootFilesystem:
@@ -4307,7 +4305,6 @@ spec:
                                       When set to false, a new userns is created for the pod. Setting false is useful for
                                       mitigating container breakout vulnerabilities even allowing users to run their
                                       containers as root without actually having root privileges on the host.
-                                      This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                                     type: boolean
                                   hostname:
                                     description: |-
@@ -5518,7 +5515,6 @@ spec:
                                                 procMount denotes the type of proc mount to use for the containers.
                                                 The default value is Default which uses the container runtime defaults for
                                                 readonly paths and masked paths.
-                                                This requires the ProcMountType feature flag to be enabled.
                                                 Note that this field cannot be set when spec.os.name is windows.
                                               type: string
                                             readOnlyRootFilesystem:
@@ -6098,6 +6094,14 @@ spec:
 
                                         It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                                         Containers that need access to the ResourceClaim reference it with this name.
+
+                                        When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                                        belongs to a PodGroup, a PodResourceClaim is matched to a
+                                        PodGroupResourceClaim if all of their fields are equal (Name,
+                                        ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                                        a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                                        the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                                        Pods.
                                       properties:
                                         name:
                                           description: |-
@@ -6122,6 +6126,16 @@ spec:
                                             will also be deleted. The pod name and resource name, along with a
                                             generated component, will be used to form a unique name for the
                                             ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                            When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                            belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                            Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                            ResourceClaim generated for the PodGroup. All pods in the group that
+                                            define an equivalent PodResourceClaim matching the
+                                            PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                            generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                            owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                            instead of any individual pod.
 
                                             This field is immutable and no changes will be made to the
                                             corresponding ResourceClaim by the control plane after creating the
@@ -6256,6 +6270,28 @@ spec:
                                     x-kubernetes-list-map-keys:
                                     - name
                                     x-kubernetes-list-type: map
+                                  schedulingGroup:
+                                    description: |-
+                                      SchedulingGroup provides a reference to the immediate scheduling runtime
+                                      grouping object that this Pod belongs to.
+                                      This field is used by the scheduler to identify the group and apply the
+                                      correct group scheduling policies. The association with a group also
+                                      impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                                      of scheduling like preemption, resource attachment, etc. If not specified,
+                                      the Pod is treated as a single unit in all of these aspects.
+                                      The group object referenced by this field may not exist at the time the
+                                      Pod is created.
+                                      This field is immutable, but a group object with the same name may be
+                                      recreated with different policies. Doing this during pod scheduling
+                                      may result in the placement not conforming to the expected policies.
+                                    properties:
+                                      podGroupName:
+                                        description: |-
+                                          PodGroupName specifies the name of the standalone PodGroup object
+                                          that represents the runtime instance of this group.
+                                          Must be a DNS subdomain.
+                                        type: string
+                                    type: object
                                   securityContext:
                                     description: |-
                                       SecurityContext holds pod-level security attributes and common container settings.
@@ -7722,7 +7758,7 @@ spec:
                                             A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                             The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                             The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                            The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                            The volume will be mounted read-only (ro).
                                             Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                             The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                           properties:
@@ -7898,8 +7934,7 @@ spec:
                                           description: |-
                                             portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                             Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                            are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                            is on.
+                                            are redirected to the pxd.portworx.com CSI driver.
                                           properties:
                                             fsType:
                                               description: |-
@@ -8757,42 +8792,6 @@ spec:
                                     x-kubernetes-list-map-keys:
                                     - name
                                     x-kubernetes-list-type: map
-                                  workloadRef:
-                                    description: |-
-                                      WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                                      This field is used by the scheduler to identify the PodGroup and apply the
-                                      correct group scheduling policies. The Workload object referenced
-                                      by this field may not exist at the time the Pod is created.
-                                      This field is immutable, but a Workload object with the same name
-                                      may be recreated with different policies. Doing this during pod scheduling
-                                      may result in the placement not conforming to the expected policies.
-                                    properties:
-                                      name:
-                                        description: |-
-                                          Name defines the name of the Workload object this Pod belongs to.
-                                          Workload must be in the same namespace as the Pod.
-                                          If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                          until a Workload object is created and observed by the kube-scheduler.
-                                          It must be a DNS subdomain.
-                                        type: string
-                                      podGroup:
-                                        description: |-
-                                          PodGroup is the name of the PodGroup within the Workload that this Pod
-                                          belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                          the Pod will remain unschedulable until the Workload object is recreated
-                                          and observed by the kube-scheduler. It must be a DNS label.
-                                        type: string
-                                      podGroupReplicaKey:
-                                        description: |-
-                                          PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                          Pod belongs. It is used to distinguish pods belonging to different replicas
-                                          of the same pod group. The pod group policy is applied separately to each replica.
-                                          When set, it must be a DNS label.
-                                        type: string
-                                    required:
-                                    - name
-                                    - podGroup
-                                    type: object
                                 required:
                                 - containers
                                 type: object
@@ -8860,8 +8859,9 @@ spec:
                           the Capp.
                         properties:
                           hostname:
-                            description: Hostname is a custom DNS name for the Capp
-                              route.
+                            description: |-
+                              Hostname is the custom DNS name for the Capp route.
+                              Required when tlsEnabled is true.
                             type: string
                           routeTimeoutSeconds:
                             description: |-
@@ -8870,8 +8870,8 @@ spec:
                             format: int64
                             type: integer
                           tlsEnabled:
-                            description: TlsEnabled determines whether to enable TLS
-                              for the Capp route.
+                            description: TlsEnabled enables HTTPS and automatic certificate
+                              management for hostname.
                             type: boolean
                           trafficTarget:
                             description: TrafficTarget holds a single entry of the
@@ -8923,6 +8923,10 @@ spec:
                                 type: string
                             type: object
                         type: object
+                        x-kubernetes-validations:
+                        - message: hostname must be set when tlsEnabled is true
+                          rule: '!has(self.tlsEnabled) || !self.tlsEnabled || (has(self.hostname)
+                            && size(self.hostname) > 0)'
                       scaleSpec:
                         description: ScaleSpec holds the Capp scaling configuration.
                         properties:

--- a/config/crd/bases/rcs.dana.io_capps.yaml
+++ b/config/crd/bases/rcs.dana.io_capps.yaml
@@ -2135,7 +2135,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -3720,7 +3719,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -4207,7 +4205,6 @@ spec:
                               When set to false, a new userns is created for the pod. Setting false is useful for
                               mitigating container breakout vulnerabilities even allowing users to run their
                               containers as root without actually having root privileges on the host.
-                              This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                             type: boolean
                           hostname:
                             description: |-
@@ -5393,7 +5390,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -5964,6 +5960,14 @@ spec:
 
                                 It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                                 Containers that need access to the ResourceClaim reference it with this name.
+
+                                When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                                belongs to a PodGroup, a PodResourceClaim is matched to a
+                                PodGroupResourceClaim if all of their fields are equal (Name,
+                                ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                                a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                                the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                                Pods.
                               properties:
                                 name:
                                   description: |-
@@ -5988,6 +5992,16 @@ spec:
                                     will also be deleted. The pod name and resource name, along with a
                                     generated component, will be used to form a unique name for the
                                     ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                    When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                    belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                    Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                    ResourceClaim generated for the PodGroup. All pods in the group that
+                                    define an equivalent PodResourceClaim matching the
+                                    PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                    generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                    owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                    instead of any individual pod.
 
                                     This field is immutable and no changes will be made to the
                                     corresponding ResourceClaim by the control plane after creating the
@@ -6122,6 +6136,28 @@ spec:
                             x-kubernetes-list-map-keys:
                             - name
                             x-kubernetes-list-type: map
+                          schedulingGroup:
+                            description: |-
+                              SchedulingGroup provides a reference to the immediate scheduling runtime
+                              grouping object that this Pod belongs to.
+                              This field is used by the scheduler to identify the group and apply the
+                              correct group scheduling policies. The association with a group also
+                              impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                              of scheduling like preemption, resource attachment, etc. If not specified,
+                              the Pod is treated as a single unit in all of these aspects.
+                              The group object referenced by this field may not exist at the time the
+                              Pod is created.
+                              This field is immutable, but a group object with the same name may be
+                              recreated with different policies. Doing this during pod scheduling
+                              may result in the placement not conforming to the expected policies.
+                            properties:
+                              podGroupName:
+                                description: |-
+                                  PodGroupName specifies the name of the standalone PodGroup object
+                                  that represents the runtime instance of this group.
+                                  Must be a DNS subdomain.
+                                type: string
+                            type: object
                           securityContext:
                             description: |-
                               SecurityContext holds pod-level security attributes and common container settings.
@@ -7564,7 +7600,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -7738,8 +7774,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -8572,42 +8607,6 @@ spec:
                             x-kubernetes-list-map-keys:
                             - name
                             x-kubernetes-list-type: map
-                          workloadRef:
-                            description: |-
-                              WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                              This field is used by the scheduler to identify the PodGroup and apply the
-                              correct group scheduling policies. The Workload object referenced
-                              by this field may not exist at the time the Pod is created.
-                              This field is immutable, but a Workload object with the same name
-                              may be recreated with different policies. Doing this during pod scheduling
-                              may result in the placement not conforming to the expected policies.
-                            properties:
-                              name:
-                                description: |-
-                                  Name defines the name of the Workload object this Pod belongs to.
-                                  Workload must be in the same namespace as the Pod.
-                                  If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                  until a Workload object is created and observed by the kube-scheduler.
-                                  It must be a DNS subdomain.
-                                type: string
-                              podGroup:
-                                description: |-
-                                  PodGroup is the name of the PodGroup within the Workload that this Pod
-                                  belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                  the Pod will remain unschedulable until the Workload object is recreated
-                                  and observed by the kube-scheduler. It must be a DNS label.
-                                type: string
-                              podGroupReplicaKey:
-                                description: |-
-                                  PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                  Pod belongs. It is used to distinguish pods belonging to different replicas
-                                  of the same pod group. The pod group policy is applied separately to each replica.
-                                  When set, it must be a DNS label.
-                                type: string
-                            required:
-                            - name
-                            - podGroup
-                            type: object
                         required:
                         - containers
                         type: object
@@ -8672,7 +8671,9 @@ spec:
                 description: RouteSpec defines the route specification for the Capp.
                 properties:
                   hostname:
-                    description: Hostname is a custom DNS name for the Capp route.
+                    description: |-
+                      Hostname is the custom DNS name for the Capp route.
+                      Required when tlsEnabled is true.
                     type: string
                   routeTimeoutSeconds:
                     description: |-
@@ -8681,8 +8682,8 @@ spec:
                     format: int64
                     type: integer
                   tlsEnabled:
-                    description: TlsEnabled determines whether to enable TLS for the
-                      Capp route.
+                    description: TlsEnabled enables HTTPS and automatic certificate
+                      management for hostname.
                     type: boolean
                   trafficTarget:
                     description: TrafficTarget holds a single entry of the routing
@@ -8734,6 +8735,10 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: hostname must be set when tlsEnabled is true
+                  rule: '!has(self.tlsEnabled) || !self.tlsEnabled || (has(self.hostname)
+                    && size(self.hostname) > 0)'
               scaleSpec:
                 description: ScaleSpec holds the Capp scaling configuration.
                 properties:

--- a/test/e2e/certificate_test.go
+++ b/test/e2e/certificate_test.go
@@ -137,6 +137,7 @@ var _ = Describe("Validate Certificate functionality", func() {
 			err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 				toBeUpdatedCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 				toBeUpdatedCapp.Spec.RouteSpec.Hostname = ""
+				toBeUpdatedCapp.Spec.RouteSpec.TlsEnabled = false
 
 				return utils.UpdateResource(k8sClient, toBeUpdatedCapp)
 			})


### PR DESCRIPTION
Add RouteSpec CEL validation so tlsEnabled: true requires hostname on create and update. Regenerate Capp and CappRevision CRDs, sync Helm chart CRDs.

Fixes #511