### PR TITLE
feat(api): validate CappConfig DNS fields at apply time

### DIFF
--- a/api/v1alpha1/cappconfig_types.go
+++ b/api/v1alpha1/cappconfig_types.go
@@ -41,13 +41,18 @@ type CappConfigSpec struct {
 }
 
 type DNSConfig struct {
-	// Zone defines the DNS zone for Capp Hostnames
+	// Zone defines the DNS zone for Capp Hostnames.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:XValidation:rule="self.endsWith('.')",message="zone must end with '.'"
 	Zone string `json:"zone"`
-	// CNAME defines the CNAME record that will be used for Capp Hostnames
+	// CNAME defines the CNAME record that will be used for Capp Hostnames.
+	// +kubebuilder:validation:MinLength=1
 	CNAME string `json:"cname"`
-	// Provider defines the DNS provider
+	// Provider defines the DNS provider.
+	// +kubebuilder:validation:MinLength=1
 	Provider string `json:"provider"`
-	// Issuer defines the certificate issuer
+	// Issuer defines the certificate issuer.
+	// +kubebuilder:validation:MinLength=1
 	Issuer string `json:"issuer"`
 }
 

--- a/charts/container-app-operator/crds/rcs.dana.io_cappconfigs.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_cappconfigs.yaml
@@ -14,190 +14,197 @@ spec:
     singular: cappconfig
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: CappConfig is the Schema for the cappconfigs API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: CappConfigSpec defines the desired state of CappConfig
-              properties:
-                allowedHostnamePatterns:
-                  default: []
-                  description: |-
-                    AllowedHostnamePatterns is a list of hostname patterns used to validate Capp hostnames.
-                    If the Capp hostname matches a pattern, it is allowed to be created.
-                    Defaults to an empty list (all hostnames denied) if not specified.
-                  items:
-                    description: HostnamePattern defines a regex pattern for validating
-                      Capp hostnames.
-                    properties:
-                      explanation:
-                        description: Explanation is a human-readable description shown
-                          in webhook error messages.
-                        maxLength: 100
-                        type: string
-                      match:
-                        description: Match is a regex used to match Capp hostnames.
-                        minLength: 1
-                        type: string
-                    required:
-                      - match
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CappConfig is the Schema for the cappconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CappConfigSpec defines the desired state of CappConfig
+            properties:
+              allowedHostnamePatterns:
+                default: []
+                description: |-
+                  AllowedHostnamePatterns is a list of hostname patterns used to validate Capp hostnames.
+                  If the Capp hostname matches a pattern, it is allowed to be created.
+                  Defaults to an empty list (all hostnames denied) if not specified.
+                items:
+                  description: HostnamePattern defines a regex pattern for validating
+                    Capp hostnames.
+                  properties:
+                    explanation:
+                      description: Explanation is a human-readable description shown
+                        in webhook error messages.
+                      maxLength: 100
+                      type: string
+                    match:
+                      description: Match is a regex used to match Capp hostnames.
+                      minLength: 1
+                      type: string
+                  required:
+                  - match
+                  type: object
+                type: array
+              autoscaleConfig:
+                properties:
+                  activationScale:
+                    description: ActivationScale is the default scale.
+                    type: integer
+                  concurrency:
+                    description: Concurrency is the maximum concurrency of a Capp.
+                    type: integer
+                  cpu:
+                    description: CPU is the desired CPU utilization to trigger upscaling.
+                    type: integer
+                  maxScaleDelay:
+                    default: 3600
+                    description: MaxScaleDelay is the maximum delay in seconds before
+                      the Autoscaler scales down the Capp to zero.
+                    minimum: 0
+                    type: integer
+                  memory:
+                    description: Memory is the desired memory utilization to trigger
+                      upscaling.
+                    type: integer
+                  minReplicasLimit:
+                    description: MinReplicasLimit is the global minimum scale. (maximum
+                      allowed value for minReplicas).
+                    minimum: 1
+                    type: integer
+                  rps:
+                    description: RPS is the desired requests per second to trigger
+                      upscaling.
+                    type: integer
+                required:
+                - activationScale
+                - concurrency
+                - cpu
+                - maxScaleDelay
+                - memory
+                - minReplicasLimit
+                - rps
+                type: object
+              defaultResources:
+                description: |-
+                  DefaultResources is the default resources to be assigned to Capp.
+                  If other resources are specified then they override the default values.
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
-                  type: array
-                autoscaleConfig:
-                  properties:
-                    activationScale:
-                      description: ActivationScale is the default scale.
-                      type: integer
-                    concurrency:
-                      description: Concurrency is the maximum concurrency of a Capp.
-                      type: integer
-                    cpu:
-                      description: CPU is the desired CPU utilization to trigger upscaling.
-                      type: integer
-                    maxScaleDelay:
-                      default: 3600
-                      description: MaxScaleDelay is the maximum delay in seconds before
-                        the Autoscaler scales down the Capp to zero.
-                      minimum: 0
-                      type: integer
-                    memory:
-                      description: Memory is the desired memory utilization to trigger
-                        upscaling.
-                      type: integer
-                    minReplicasLimit:
-                      description: MinReplicasLimit is the global minimum scale. (maximum
-                        allowed value for minReplicas).
-                      minimum: 1
-                      type: integer
-                    rps:
-                      description: RPS is the desired requests per second to trigger
-                        upscaling.
-                      type: integer
-                  required:
-                    - activationScale
-                    - concurrency
-                    - cpu
-                    - maxScaleDelay
-                    - memory
-                    - minReplicasLimit
-                    - rps
-                  type: object
-                defaultResources:
-                  description: |-
-                    DefaultResources is the default resources to be assigned to Capp.
-                    If other resources are specified then they override the default values.
-                  properties:
-                    claims:
-                      description: |-
-                        Claims lists the names of resources, defined in spec.resourceClaims,
-                        that are used by this container.
-                        
-                        This field depends on the
-                        DynamicResourceAllocation feature gate.
-                        
-                        This field is immutable. It can only be set for containers.
-                      items:
-                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                        properties:
-                          name:
-                            description: |-
-                              Name must match the name of one entry in pod.spec.resourceClaims of
-                              the Pod where this field is used. It makes that resource available
-                              inside a container.
-                            type: string
-                          request:
-                            description: |-
-                              Request is the name chosen for a request in the referenced claim.
-                              If empty, everything from the claim is made available, otherwise
-                              only the result of this request.
-                            type: string
-                        required:
-                          - name
-                        type: object
-                      type: array
-                      x-kubernetes-list-map-keys:
-                        - name
-                      x-kubernetes-list-type: map
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: |-
-                        Limits describes the maximum amount of compute resources allowed.
-                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: |-
-                        Requests describes the minimum amount of compute resources required.
-                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                      type: object
-                  type: object
-                dnsConfig:
-                  properties:
-                    cname:
-                      description: CNAME defines the CNAME record that will be used
-                        for Capp Hostnames
-                      type: string
-                    issuer:
-                      description: Issuer defines the certificate issuer
-                      type: string
-                    provider:
-                      description: Provider defines the DNS provider
-                      type: string
-                    zone:
-                      description: Zone defines the DNS zone for Capp Hostnames
-                      type: string
-                  required:
-                    - cname
-                    - issuer
-                    - provider
-                    - zone
-                  type: object
-                revisionHistoryLimit:
-                  default: 10
-                  description: RevisionHistoryLimit defines how many CappRevisions will
-                    be retained
-                  minimum: 1
-                  type: integer
-              required:
-                - allowedHostnamePatterns
-                - autoscaleConfig
-                - defaultResources
-                - dnsConfig
-              type: object
-            status:
-              description: CappConfigStatus defines the observed state of CappConfig
-              type: object
-          type: object
-      served: true
-      storage: true
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              dnsConfig:
+                properties:
+                  cname:
+                    description: CNAME defines the CNAME record that will be used
+                      for Capp Hostnames.
+                    minLength: 1
+                    type: string
+                  issuer:
+                    description: Issuer defines the certificate issuer.
+                    minLength: 1
+                    type: string
+                  provider:
+                    description: Provider defines the DNS provider.
+                    minLength: 1
+                    type: string
+                  zone:
+                    description: Zone defines the DNS zone for Capp Hostnames.
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: zone must end with '.'
+                      rule: self.endsWith('.')
+                required:
+                - cname
+                - issuer
+                - provider
+                - zone
+                type: object
+              revisionHistoryLimit:
+                default: 10
+                description: RevisionHistoryLimit defines how many CappRevisions will
+                  be retained
+                minimum: 1
+                type: integer
+            required:
+            - allowedHostnamePatterns
+            - autoscaleConfig
+            - defaultResources
+            - dnsConfig
+            type: object
+          status:
+            description: CappConfigStatus defines the observed state of CappConfig
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/config/crd/bases/rcs.dana.io_cappconfigs.yaml
+++ b/config/crd/bases/rcs.dana.io_cappconfigs.yaml
@@ -166,17 +166,24 @@ spec:
                 properties:
                   cname:
                     description: CNAME defines the CNAME record that will be used
-                      for Capp Hostnames
+                      for Capp Hostnames.
+                    minLength: 1
                     type: string
                   issuer:
-                    description: Issuer defines the certificate issuer
+                    description: Issuer defines the certificate issuer.
+                    minLength: 1
                     type: string
                   provider:
-                    description: Provider defines the DNS provider
+                    description: Provider defines the DNS provider.
+                    minLength: 1
                     type: string
                   zone:
-                    description: Zone defines the DNS zone for Capp Hostnames
+                    description: Zone defines the DNS zone for Capp Hostnames.
+                    minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: zone must end with '.'
+                      rule: self.endsWith('.')
                 required:
                 - cname
                 - issuer

--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -48,17 +48,7 @@ func (c CertificateManager) prepareResource(capp cappv1alpha1.Capp) (cmapi.Certi
 		return cmapi.Certificate{}, err
 	}
 
-	zone, err := utils.GetZoneFromConfig(dnsConfig)
-	if err != nil {
-		return cmapi.Certificate{}, err
-	}
-
-	issuer, err := utils.GetIssuerNameFromConfig(dnsConfig)
-	if err != nil {
-		return cmapi.Certificate{}, err
-	}
-
-	resourceName := utils.GenerateResourceName(capp.Spec.RouteSpec.Hostname, zone)
+	resourceName := utils.GenerateResourceName(capp.Spec.RouteSpec.Hostname, dnsConfig.Zone)
 	secretName := utils.GenerateSecretName(resourceName)
 
 	certificate := cmapi.Certificate{
@@ -78,7 +68,7 @@ func (c CertificateManager) prepareResource(capp cappv1alpha1.Capp) (cmapi.Certi
 			},
 			IsCA: false,
 			IssuerRef: cmmeta.IssuerReference{
-				Name:  issuer,
+				Name:  dnsConfig.Issuer,
 				Kind:  clusterIssuerKind,
 				Group: certv1alpha1.GroupVersion.Group,
 			},

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -45,18 +45,8 @@ func (r DNSRecordManager) prepareResource(capp cappv1alpha1.Capp) (dnsrecordv1al
 		return dnsrecordv1alpha1.CNAMERecord{}, err
 	}
 
-	zone, err := utils.GetZoneFromConfig(dnsConfig)
-	if err != nil {
-		return dnsrecordv1alpha1.CNAMERecord{}, err
-	}
-
-	cname, err := utils.GetDNSRecordFromConfig(dnsConfig)
-	if err != nil {
-		return dnsrecordv1alpha1.CNAMERecord{}, err
-	}
-
-	resourceName := utils.GenerateResourceName(capp.Spec.RouteSpec.Hostname, zone)
-	recordName := utils.GenerateRecordName(capp.Spec.RouteSpec.Hostname, zone)
+	resourceName := utils.GenerateResourceName(capp.Spec.RouteSpec.Hostname, dnsConfig.Zone)
+	recordName := utils.GenerateRecordName(capp.Spec.RouteSpec.Hostname, dnsConfig.Zone)
 
 	dnsRecord := dnsrecordv1alpha1.CNAMERecord{
 		TypeMeta: metav1.TypeMeta{},
@@ -70,18 +60,13 @@ func (r DNSRecordManager) prepareResource(capp cappv1alpha1.Capp) (dnsrecordv1al
 		Spec: dnsrecordv1alpha1.CNAMERecordSpec{
 			ForProvider: dnsrecordv1alpha1.CNAMERecordParameters{
 				Name:  &recordName,
-				Zone:  &zone,
-				Cname: &cname,
+				Zone:  &dnsConfig.Zone,
+				Cname: &dnsConfig.CNAME,
 			},
 		},
 	}
-	provider, err := utils.GetXPProviderFromConfig(dnsConfig)
-	if err != nil {
-		return dnsrecordv1alpha1.CNAMERecord{}, err
-	}
-
 	dnsRecord.Spec.ProviderConfigReference = &xpv1.ProviderConfigReference{
-		Name: provider,
+		Name: dnsConfig.Provider,
 		Kind: ClusterProviderConfigKind,
 	}
 

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -46,12 +46,7 @@ func (k KnativeDomainMappingManager) prepareResource(capp cappv1alpha1.Capp) (kn
 		return knativev1beta1.DomainMapping{}, err
 	}
 
-	zone, err := utils.GetZoneFromConfig(dnsConfig)
-	if err != nil {
-		return knativev1beta1.DomainMapping{}, err
-	}
-
-	resourceName := utils.GenerateResourceName(capp.Spec.RouteSpec.Hostname, zone)
+	resourceName := utils.GenerateResourceName(capp.Spec.RouteSpec.Hostname, dnsConfig.Zone)
 	secretName := utils.GenerateSecretName(resourceName)
 
 	knativeDomainMapping := &knativev1beta1.DomainMapping{

--- a/internal/kinds/capp/status/route.go
+++ b/internal/kinds/capp/status/route.go
@@ -26,22 +26,17 @@ func buildRouteStatus(ctx context.Context, kubeClient client.Client, capp cappv1
 		return routeStatus, err
 	}
 
-	zone, err := utils.GetZoneFromConfig(dnsConfig)
+	domainMappingStatus, err := buildDomainMappingStatus(ctx, kubeClient, capp, isRequired[rmanagers.DomainMapping], dnsConfig.Zone)
 	if err != nil {
 		return routeStatus, err
 	}
 
-	domainMappingStatus, err := buildDomainMappingStatus(ctx, kubeClient, capp, isRequired[rmanagers.DomainMapping], zone)
+	dnsRecordStatus, err := buildDNSRecordStatus(ctx, kubeClient, capp, isRequired[rmanagers.DNSRecord], dnsConfig.Zone)
 	if err != nil {
 		return routeStatus, err
 	}
 
-	dnsRecordStatus, err := buildDNSRecordStatus(ctx, kubeClient, capp, isRequired[rmanagers.DNSRecord], zone)
-	if err != nil {
-		return routeStatus, err
-	}
-
-	certificateStatus, err := buildCertificateStatus(ctx, kubeClient, capp, isRequired[rmanagers.Certificate], zone)
+	certificateStatus, err := buildCertificateStatus(ctx, kubeClient, capp, isRequired[rmanagers.Certificate], dnsConfig.Zone)
 	if err != nil {
 		return routeStatus, err
 	}

--- a/internal/kinds/capp/utils/route.go
+++ b/internal/kinds/capp/utils/route.go
@@ -46,52 +46,6 @@ func GetDNSConfig(ctx context.Context, k8sClient client.Client) (cappv1alpha1.DN
 	return cappConfig.Spec.DNSConfig, nil
 }
 
-// GetDNSRecordFromConfig returns the DNSRecord to be used for the record from a CappConfig CRD.
-func GetDNSRecordFromConfig(dnsConfig cappv1alpha1.DNSConfig) (string, error) {
-	dnsRecord := dnsConfig.CNAME
-
-	if dnsRecord == "" {
-		return "", fmt.Errorf("%q is empty in CappConfig DNSConfig data", "CNAME")
-	}
-	return dnsRecord, nil
-}
-
-// GetZoneFromConfig returns the zone to be used for the record from the CappConfig CRD.
-func GetZoneFromConfig(dnsConfig cappv1alpha1.DNSConfig) (string, error) {
-	zone := dnsConfig.Zone
-
-	if zone == "" {
-		return "", fmt.Errorf("%q is empty in CappConfig DNSConfig data", "Zone")
-	} else if !strings.HasSuffix(zone, dot) {
-		return "", fmt.Errorf("%q value must end with a %q in CappConfig DNSConfig data", "Zone", dot)
-	}
-
-	return zone, nil
-}
-
-// GetXPProviderFromConfig returns the Crossplane provider to be used for the record from the CappConfig CRD.
-func GetXPProviderFromConfig(dnsConfig cappv1alpha1.DNSConfig) (string, error) {
-	provider := dnsConfig.Provider
-
-	if provider == "" {
-		return "", fmt.Errorf("%q is empty in CappConfig DNSConfig data", "Provider")
-	}
-
-	return provider, nil
-}
-
-// GetIssuerNameFromConfig returns the name of the Certificate Issuer
-// to be used for the Certificate from a CappConfig CRD.
-func GetIssuerNameFromConfig(dnsConfig cappv1alpha1.DNSConfig) (string, error) {
-	issuer := dnsConfig.Issuer
-
-	if issuer == "" {
-		return "", fmt.Errorf("%q is empty in CappConfig DNSConfig data", "Issuer")
-	}
-
-	return issuer, nil
-}
-
 // GenerateResourceName generates the hostname based on the provided suffix and a dot(".") trailing character.
 // If the hostname does not already end with the suffix (minus the trailing dot), it appends the suffix to the hostname.
 func GenerateResourceName(hostname, suffix string) string {


### PR DESCRIPTION
Add OpenAPI constraints for dnsConfig (non-empty fields, zone suffix) and remove duplicate checks from Capp reconcile helpers. Regenerate and sync CappConfig CRDs.