### PR TITLE
feat(api): validate CappConfig autoscale fields at apply time

### DIFF
--- a/api/v1alpha1/cappconfig_types.go
+++ b/api/v1alpha1/cappconfig_types.go
@@ -58,14 +58,19 @@ type DNSConfig struct {
 
 type AutoscaleConfig struct {
 	// RPS is the desired requests per second to trigger upscaling.
+	// +kubebuilder:validation:Minimum=1
 	RPS int `json:"rps"`
 	// CPU is the desired CPU utilization to trigger upscaling.
+	// +kubebuilder:validation:Minimum=1
 	CPU int `json:"cpu"`
 	// Memory is the desired memory utilization to trigger upscaling.
+	// +kubebuilder:validation:Minimum=1
 	Memory int `json:"memory"`
 	// Concurrency is the maximum concurrency of a Capp.
+	// +kubebuilder:validation:Minimum=1
 	Concurrency int `json:"concurrency"`
 	// ActivationScale is the default scale.
+	// +kubebuilder:validation:Minimum=1
 	ActivationScale int `json:"activationScale"`
 	// MinReplicasLimit is the global minimum scale. (maximum allowed value for minReplicas).
 	// +kubebuilder:validation:Minimum=1

--- a/charts/container-app-operator/crds/rcs.dana.io_cappconfigs.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_cappconfigs.yaml
@@ -66,12 +66,15 @@ spec:
                 properties:
                   activationScale:
                     description: ActivationScale is the default scale.
+                    minimum: 1
                     type: integer
                   concurrency:
                     description: Concurrency is the maximum concurrency of a Capp.
+                    minimum: 1
                     type: integer
                   cpu:
                     description: CPU is the desired CPU utilization to trigger upscaling.
+                    minimum: 1
                     type: integer
                   maxScaleDelay:
                     default: 3600
@@ -82,6 +85,7 @@ spec:
                   memory:
                     description: Memory is the desired memory utilization to trigger
                       upscaling.
+                    minimum: 1
                     type: integer
                   minReplicasLimit:
                     description: MinReplicasLimit is the global minimum scale. (maximum
@@ -91,6 +95,7 @@ spec:
                   rps:
                     description: RPS is the desired requests per second to trigger
                       upscaling.
+                    minimum: 1
                     type: integer
                 required:
                 - activationScale

--- a/config/crd/bases/rcs.dana.io_cappconfigs.yaml
+++ b/config/crd/bases/rcs.dana.io_cappconfigs.yaml
@@ -66,12 +66,15 @@ spec:
                 properties:
                   activationScale:
                     description: ActivationScale is the default scale.
+                    minimum: 1
                     type: integer
                   concurrency:
                     description: Concurrency is the maximum concurrency of a Capp.
+                    minimum: 1
                     type: integer
                   cpu:
                     description: CPU is the desired CPU utilization to trigger upscaling.
+                    minimum: 1
                     type: integer
                   maxScaleDelay:
                     default: 3600
@@ -82,6 +85,7 @@ spec:
                   memory:
                     description: Memory is the desired memory utilization to trigger
                       upscaling.
+                    minimum: 1
                     type: integer
                   minReplicasLimit:
                     description: MinReplicasLimit is the global minimum scale. (maximum
@@ -91,6 +95,7 @@ spec:
                   rps:
                     description: RPS is the desired requests per second to trigger
                       upscaling.
+                    minimum: 1
                     type: integer
                 required:
                 - activationScale

--- a/internal/kinds/capp/autoscale/autoscale.go
+++ b/internal/kinds/capp/autoscale/autoscale.go
@@ -18,14 +18,6 @@ const (
 	concurrencyScaleKey = "concurrency"
 )
 
-var TargetDefaultValues = cappv1alpha1.AutoscaleConfig{
-	RPS:             200,
-	CPU:             80,
-	Memory:          70,
-	Concurrency:     10,
-	ActivationScale: 3,
-}
-
 var KPAMetrics = []string{"rps", "concurrency"}
 
 // SetAutoScaler takes a Capp and a Knative Service and sets the autoscaler annotations based on the Capp's ScaleSpec.Metric value.
@@ -35,10 +27,6 @@ func SetAutoScaler(capp cappv1alpha1.Capp, defaults cappv1alpha1.AutoscaleConfig
 	autoScaleAnnotations := make(map[string]string)
 	if scaleMetric == "" {
 		return autoScaleAnnotations
-	}
-
-	if isAutoScaleEmpty(defaults) {
-		defaults = TargetDefaultValues
 	}
 
 	activationScale := defaults.ActivationScale
@@ -79,11 +67,6 @@ func getTargetValue(scaleMetric string, autoscale cappv1alpha1.AutoscaleConfig) 
 		targetValue = "" // handle unknown scale metrics
 	}
 	return targetValue
-}
-
-// isAutoScaleEmpty checks if all the values of the AutoscaleConfig are empty.
-func isAutoScaleEmpty(config cappv1alpha1.AutoscaleConfig) bool {
-	return config.RPS == 0 && config.CPU == 0 && config.Memory == 0 && config.Concurrency == 0 && config.ActivationScale == 0
 }
 
 // Determines the autoscaling class based on the metric provided. Returns "kpa.autoscaling.knative.dev" if the metric is in KPAMetrics, "hpa.autoscaling.knative.dev" otherwise.

--- a/internal/kinds/capp/autoscale/autoscale_test.go
+++ b/internal/kinds/capp/autoscale/autoscale_test.go
@@ -16,7 +16,7 @@ func TestSetAutoScaler(t *testing.T) {
 		expected map[string]string
 	}{
 		{
-			name:   "uses HPA class and default cpu target for cpu metric",
+			name:   "uses HPA class and cpu target from autoscale config",
 			metric: kautoscaling.CPU,
 			expected: map[string]string{
 				kautoscaling.ClassAnnotationKey:  kautoscaling.HPA,
@@ -26,7 +26,7 @@ func TestSetAutoScaler(t *testing.T) {
 			},
 		},
 		{
-			name:   "uses KPA class and default rps target for rps metric",
+			name:   "uses KPA class and rps target from autoscale config",
 			metric: kautoscaling.RPS,
 			expected: map[string]string{
 				kautoscaling.ClassAnnotationKey:  kautoscaling.KPA,
@@ -36,7 +36,7 @@ func TestSetAutoScaler(t *testing.T) {
 			},
 		},
 		{
-			name:   "uses HPA class and default memory target for memory metric",
+			name:   "uses HPA class and memory target from autoscale config",
 			metric: kautoscaling.Memory,
 			expected: map[string]string{
 				kautoscaling.ClassAnnotationKey:  kautoscaling.HPA,
@@ -60,7 +60,13 @@ func TestSetAutoScaler(t *testing.T) {
 					},
 				},
 			}
-			annotations := SetAutoScaler(capp, cappv1alpha1.AutoscaleConfig{})
+			annotations := SetAutoScaler(capp, cappv1alpha1.AutoscaleConfig{
+				RPS:             200,
+				CPU:             80,
+				Memory:          70,
+				Concurrency:     10,
+				ActivationScale: 3,
+			})
 			assert.Equal(t, tt.expected, annotations)
 		})
 	}


### PR DESCRIPTION
Reject zero targets on CappConfig so partial misconfiguration cannot produce invalid Knative autoscale annotations. Remove reconcile fallback that masked an all-zero config.