### PR TITLE
feat(api): validate Capp logSpec at apply time

### DIFF
--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -173,6 +173,9 @@ const (
 )
 
 // LogSpec defines the configuration for shipping Capp logs.
+// +kubebuilder:validation:XValidation:rule="!has(self.type) || self.type != 'elastic' || (has(self.host) && size(self.host) > 0 && has(self.index) && size(self.index) > 0 && has(self.user) && size(self.user) > 0 && has(self.passwordSecret) && size(self.passwordSecret) > 0)",message="elastic log configuration requires host, index, user, and passwordSecret"
+// +kubebuilder:validation:XValidation:rule="!has(self.type) || self.type != 'elastic-datastream' || (has(self.host) && size(self.host) > 0 && has(self.user) && size(self.user) > 0 && has(self.passwordSecret) && size(self.passwordSecret) > 0)",message="elastic-datastream log configuration requires host, user, and passwordSecret"
+// +kubebuilder:validation:XValidation:rule="(!has(self.host) || size(self.host) == 0) && (!has(self.index) || size(self.index) == 0) && (!has(self.user) || size(self.user) == 0) && (!has(self.passwordSecret) || size(self.passwordSecret) == 0) || (has(self.type) && (self.type == 'elastic' || self.type == 'elastic-datastream'))",message="type must be elastic or elastic-datastream when log configuration fields are set"
 type LogSpec struct {
 	// Type defines where to send the Capp logs
 	// +kubebuilder:validation:Enum=elastic;elastic-datastream

--- a/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
@@ -8868,6 +8868,26 @@ spec:
                             description: User defines a User for authentication.
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: elastic log configuration requires host, index,
+                            user, and passwordSecret
+                          rule: '!has(self.type) || self.type != ''elastic'' || (has(self.host)
+                            && size(self.host) > 0 && has(self.index) && size(self.index)
+                            > 0 && has(self.user) && size(self.user) > 0 && has(self.passwordSecret)
+                            && size(self.passwordSecret) > 0)'
+                        - message: elastic-datastream log configuration requires host,
+                            user, and passwordSecret
+                          rule: '!has(self.type) || self.type != ''elastic-datastream''
+                            || (has(self.host) && size(self.host) > 0 && has(self.user)
+                            && size(self.user) > 0 && has(self.passwordSecret) &&
+                            size(self.passwordSecret) > 0)'
+                        - message: type must be elastic or elastic-datastream when
+                            log configuration fields are set
+                          rule: (!has(self.host) || size(self.host) == 0) && (!has(self.index)
+                            || size(self.index) == 0) && (!has(self.user) || size(self.user)
+                            == 0) && (!has(self.passwordSecret) || size(self.passwordSecret)
+                            == 0) || (has(self.type) && (self.type == 'elastic' ||
+                            self.type == 'elastic-datastream'))
                       routeSpec:
                         description: RouteSpec defines the route specification for
                           the Capp.

--- a/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
@@ -8680,6 +8680,26 @@ spec:
                     description: User defines a User for authentication.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: elastic log configuration requires host, index, user, and
+                    passwordSecret
+                  rule: '!has(self.type) || self.type != ''elastic'' || (has(self.host)
+                    && size(self.host) > 0 && has(self.index) && size(self.index)
+                    > 0 && has(self.user) && size(self.user) > 0 && has(self.passwordSecret)
+                    && size(self.passwordSecret) > 0)'
+                - message: elastic-datastream log configuration requires host, user,
+                    and passwordSecret
+                  rule: '!has(self.type) || self.type != ''elastic-datastream'' ||
+                    (has(self.host) && size(self.host) > 0 && has(self.user) && size(self.user)
+                    > 0 && has(self.passwordSecret) && size(self.passwordSecret) >
+                    0)'
+                - message: type must be elastic or elastic-datastream when log configuration
+                    fields are set
+                  rule: (!has(self.host) || size(self.host) == 0) && (!has(self.index)
+                    || size(self.index) == 0) && (!has(self.user) || size(self.user)
+                    == 0) && (!has(self.passwordSecret) || size(self.passwordSecret)
+                    == 0) || (has(self.type) && (self.type == 'elastic' || self.type
+                    == 'elastic-datastream'))
               routeSpec:
                 description: RouteSpec defines the route specification for the Capp.
                 properties:

--- a/config/crd/bases/rcs.dana.io_capprevisions.yaml
+++ b/config/crd/bases/rcs.dana.io_capprevisions.yaml
@@ -8868,6 +8868,26 @@ spec:
                             description: User defines a User for authentication.
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: elastic log configuration requires host, index,
+                            user, and passwordSecret
+                          rule: '!has(self.type) || self.type != ''elastic'' || (has(self.host)
+                            && size(self.host) > 0 && has(self.index) && size(self.index)
+                            > 0 && has(self.user) && size(self.user) > 0 && has(self.passwordSecret)
+                            && size(self.passwordSecret) > 0)'
+                        - message: elastic-datastream log configuration requires host,
+                            user, and passwordSecret
+                          rule: '!has(self.type) || self.type != ''elastic-datastream''
+                            || (has(self.host) && size(self.host) > 0 && has(self.user)
+                            && size(self.user) > 0 && has(self.passwordSecret) &&
+                            size(self.passwordSecret) > 0)'
+                        - message: type must be elastic or elastic-datastream when
+                            log configuration fields are set
+                          rule: (!has(self.host) || size(self.host) == 0) && (!has(self.index)
+                            || size(self.index) == 0) && (!has(self.user) || size(self.user)
+                            == 0) && (!has(self.passwordSecret) || size(self.passwordSecret)
+                            == 0) || (has(self.type) && (self.type == 'elastic' ||
+                            self.type == 'elastic-datastream'))
                       routeSpec:
                         description: RouteSpec defines the route specification for
                           the Capp.

--- a/config/crd/bases/rcs.dana.io_capps.yaml
+++ b/config/crd/bases/rcs.dana.io_capps.yaml
@@ -8680,6 +8680,26 @@ spec:
                     description: User defines a User for authentication.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: elastic log configuration requires host, index, user, and
+                    passwordSecret
+                  rule: '!has(self.type) || self.type != ''elastic'' || (has(self.host)
+                    && size(self.host) > 0 && has(self.index) && size(self.index)
+                    > 0 && has(self.user) && size(self.user) > 0 && has(self.passwordSecret)
+                    && size(self.passwordSecret) > 0)'
+                - message: elastic-datastream log configuration requires host, user,
+                    and passwordSecret
+                  rule: '!has(self.type) || self.type != ''elastic-datastream'' ||
+                    (has(self.host) && size(self.host) > 0 && has(self.user) && size(self.user)
+                    > 0 && has(self.passwordSecret) && size(self.passwordSecret) >
+                    0)'
+                - message: type must be elastic or elastic-datastream when log configuration
+                    fields are set
+                  rule: (!has(self.host) || size(self.host) == 0) && (!has(self.index)
+                    || size(self.index) == 0) && (!has(self.user) || size(self.user)
+                    == 0) && (!has(self.passwordSecret) || size(self.passwordSecret)
+                    == 0) || (has(self.type) && (self.type == 'elastic' || self.type
+                    == 'elastic-datastream'))
               routeSpec:
                 description: RouteSpec defines the route specification for the Capp.
                 properties:

--- a/internal/webhook/rcs/common/utils.go
+++ b/internal/webhook/rcs/common/utils.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
@@ -18,13 +17,6 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/network"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	logSpecFieldHost           = "Host"
-	logSpecFieldIndex          = "Index"
-	logSpecFieldUser           = "User"
-	logSpecFieldPasswordSecret = "PasswordSecret"
 )
 
 // ValidateDomainName checks if the hostname is valid domain name and not part of the cluster's domain.
@@ -83,49 +75,6 @@ func IsDomainNameTaken(ctx context.Context, domainName string) (bool, error) {
 		return false, err
 	}
 	return true, nil
-}
-
-// ValidateLogSpec checks if the LogSpec is valid based on the Type field.
-func ValidateLogSpec(logSpec cappv1alpha1.LogSpec) *apis.FieldError {
-	requiredFields := map[cappv1alpha1.LogType][]string{
-		cappv1alpha1.LogTypeElastic:           {logSpecFieldHost, logSpecFieldIndex, logSpecFieldUser, logSpecFieldPasswordSecret},
-		cappv1alpha1.LogTypeElasticDataStream: {logSpecFieldHost, logSpecFieldUser, logSpecFieldPasswordSecret},
-	}
-	required, exists := requiredFields[logSpec.Type]
-	if !exists {
-		validTypes := make([]string, 0, len(requiredFields))
-		for validType := range requiredFields {
-			validTypes = append(validTypes, string(validType))
-		}
-		sort.Strings(validTypes)
-		return apis.ErrGeneric(
-			fmt.Sprintf("Invalid LogSpec Type: %q. Valid types are: %q", logSpec.Type, strings.Join(validTypes, ", ")),
-			"logSpec.Type")
-	}
-	missingFields := findMissingFields(logSpec, required)
-	if len(missingFields) > 0 {
-		return apis.ErrGeneric(
-			fmt.Sprintf("%s log configuration is missing required fields: %q", logSpec.Type, strings.Join(missingFields, ", ")),
-			"logSpec")
-	}
-	return nil
-}
-
-// findMissingFields checks for missing fields in LogSpec.
-func findMissingFields(logSpec cappv1alpha1.LogSpec, required []string) []string {
-	var missingFields []string
-	fieldValues := map[string]string{
-		logSpecFieldHost:           logSpec.Host,
-		logSpecFieldIndex:          logSpec.Index,
-		logSpecFieldUser:           logSpec.User,
-		logSpecFieldPasswordSecret: logSpec.PasswordSecret,
-	}
-	for _, reqField := range required {
-		if value, ok := fieldValues[reqField]; !ok || value == "" {
-			missingFields = append(missingFields, reqField)
-		}
-	}
-	return missingFields
 }
 
 // GetCappConfig returns an instance of Capp Config.

--- a/internal/webhook/rcs/common/utils_test.go
+++ b/internal/webhook/rcs/common/utils_test.go
@@ -5,7 +5,6 @@ import (
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -105,62 +104,6 @@ func TestValidateDomainName(t *testing.T) {
 				}
 			} else {
 				assert.Nil(t, errs)
-			}
-		})
-	}
-}
-
-func TestValidateLogSpec(t *testing.T) {
-	const elasticLogHost = "https://elasticsearch.dana.com/_bulk"
-
-	tests := []struct {
-		name        string
-		logSpec     cappv1alpha1.LogSpec
-		wantErr     bool
-		errContains []string
-	}{
-		{
-			name: "denies when elastic log configuration omits required fields",
-			logSpec: cappv1alpha1.LogSpec{
-				Type: cappv1alpha1.LogTypeElastic,
-				Host: elasticLogHost,
-			},
-			wantErr: true,
-		},
-		{
-			name: "denies when log type is invalid",
-			logSpec: cappv1alpha1.LogSpec{
-				Type: cappv1alpha1.LogType("bogus"),
-			},
-			wantErr: true,
-			errContains: []string{
-				string(cappv1alpha1.LogTypeElastic),
-				string(cappv1alpha1.LogTypeElasticDataStream),
-			},
-		},
-		{
-			name: "accepts when elastic log configuration includes all required fields",
-			logSpec: cappv1alpha1.LogSpec{
-				Type:           cappv1alpha1.LogTypeElastic,
-				Host:           elasticLogHost,
-				Index:          "main",
-				User:           "user",
-				PasswordSecret: "elastic-secret",
-			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateLogSpec(tt.logSpec)
-			if tt.wantErr {
-				require.NotNil(t, err)
-				for _, sub := range tt.errContains {
-					require.Contains(t, err.Error(), sub)
-				}
-			} else {
-				require.Nil(t, err)
 			}
 		})
 	}

--- a/internal/webhook/rcs/v1alpha1/validator.go
+++ b/internal/webhook/rcs/v1alpha1/validator.go
@@ -86,12 +86,6 @@ func (c *CappValidator) handle(ctx context.Context, operation admissionv1.Operat
 		}
 	}
 
-	if capp.Spec.LogSpec != (cappv1alpha1.LogSpec{}) {
-		if errs := common.ValidateLogSpec(capp.Spec.LogSpec); errs != nil {
-			return admission.Denied(errs.Error())
-		}
-	}
-
 	if err := validateNFSVolumeMounts(capp); err != nil {
 		return admission.Denied(err.Error())
 	}

--- a/test/e2e/mocks/base.go
+++ b/test/e2e/mocks/base.go
@@ -49,7 +49,6 @@ func CreateBaseCapp() *cappv1alpha1.Capp {
 				},
 			},
 			RouteSpec: cappv1alpha1.RouteSpec{},
-			LogSpec:   cappv1alpha1.LogSpec{},
 		},
 	}
 }


### PR DESCRIPTION
Add CEL rules for elastic and elastic-datastream required fields and require a valid type when any log field is set. Remove duplicate ValidateLogSpec webhook logic.