### PR TITLE
fix(autoscale): align KSVC scale annotations with Knative

### DIFF
--- a/api/v1alpha1/cappconfig_types.go
+++ b/api/v1alpha1/cappconfig_types.go
@@ -69,8 +69,8 @@ type AutoscaleConfig struct {
 	// Concurrency is the maximum concurrency of a Capp.
 	// +kubebuilder:validation:Minimum=1
 	Concurrency int `json:"concurrency"`
-	// ActivationScale is the default scale.
-	// +kubebuilder:validation:Minimum=1
+	// ActivationScale is the default number of replicas used when a scale-to-zero Capp scales up from idle.
+	// +kubebuilder:validation:Minimum=2
 	ActivationScale int `json:"activationScale"`
 	// MinReplicasLimit is the global minimum scale. (maximum allowed value for minReplicas).
 	// +kubebuilder:validation:Minimum=1

--- a/config/crd/bases/rcs.dana.io_cappconfigs.yaml
+++ b/config/crd/bases/rcs.dana.io_cappconfigs.yaml
@@ -65,8 +65,9 @@ spec:
               autoscaleConfig:
                 properties:
                   activationScale:
-                    description: ActivationScale is the default scale.
-                    minimum: 1
+                    description: ActivationScale is the default number of replicas
+                      used when a scale-to-zero Capp scales up from idle.
+                    minimum: 2
                     type: integer
                   concurrency:
                     description: Concurrency is the maximum concurrency of a Capp.

--- a/internal/kinds/capp/autoscale/autoscale.go
+++ b/internal/kinds/capp/autoscale/autoscale.go
@@ -29,23 +29,23 @@ func SetAutoScaler(capp cappv1alpha1.Capp, defaults cappv1alpha1.AutoscaleConfig
 		return autoScaleAnnotations
 	}
 
-	activationScale := defaults.ActivationScale
-
 	givenAutoScaleAnnotation := utils.FilterMap(capp.Spec.ConfigurationSpec.Template.Annotations, AutoScalerSubString)
 	autoScaleAnnotations[kautoscaling.ClassAnnotationKey] = getAutoScaleClassByMetric(scaleMetric)
 	autoScaleAnnotations[kautoscaling.MetricAnnotationKey] = scaleMetric
 	autoScaleAnnotations[kautoscaling.TargetAnnotationKey] = getTargetValue(scaleMetric, defaults)
-	autoScaleAnnotations[kautoscaling.ActivationScaleKey] = fmt.Sprintf("%d", activationScale)
-
-	if capp.Spec.ScaleSpec.MinReplicas != 0 {
-		autoScaleAnnotations[kautoscaling.MinScaleAnnotationKey] = fmt.Sprintf("%d", capp.Spec.ScaleSpec.MinReplicas)
-	}
 
 	if capp.Spec.ScaleSpec.ScaleDelaySeconds != 0 {
 		autoScaleAnnotations[kautoscaling.ScaleDownDelayAnnotationKey] = (time.Duration(capp.Spec.ScaleSpec.ScaleDelaySeconds) * time.Second).String()
 	}
 
 	autoScaleAnnotations = utils.MergeMaps(autoScaleAnnotations, givenAutoScaleAnnotation)
+	if capp.Spec.ScaleSpec.MinReplicas != 0 {
+		delete(autoScaleAnnotations, kautoscaling.ActivationScaleKey)
+		autoScaleAnnotations[kautoscaling.MinScaleAnnotationKey] = fmt.Sprintf("%d", capp.Spec.ScaleSpec.MinReplicas)
+	} else {
+		delete(autoScaleAnnotations, kautoscaling.MinScaleAnnotationKey)
+		autoScaleAnnotations[kautoscaling.ActivationScaleKey] = fmt.Sprintf("%d", defaults.ActivationScale)
+	}
 
 	return autoScaleAnnotations
 }

--- a/internal/kinds/capp/autoscale/autoscale_test.go
+++ b/internal/kinds/capp/autoscale/autoscale_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kautoscaling "knative.dev/serving/pkg/apis/autoscaling"
+	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 func TestSetAutoScaler(t *testing.T) {
@@ -61,13 +62,73 @@ func TestSetAutoScaler(t *testing.T) {
 				},
 			}
 			annotations := SetAutoScaler(capp, cappv1alpha1.AutoscaleConfig{
-				RPS:             200,
-				CPU:             80,
-				Memory:          70,
-				Concurrency:     10,
-				ActivationScale: 3,
+				RPS: 200, CPU: 80, Memory: 70, Concurrency: 10, ActivationScale: 3,
 			})
-			assert.Equal(t, tt.expected, annotations)
+			require.Equal(t, tt.expected, annotations)
+		})
+	}
+
+	scaleTests := []struct {
+		name                  string
+		minReplicas           int
+		templateAnnotations   map[string]string
+		expectMinScale        string
+		expectActivationScale string
+	}{
+		{
+			name:        "applies min replicas from spec and strips conflicting template scale annotations",
+			minReplicas: 5,
+			templateAnnotations: map[string]string{
+				kautoscaling.ActivationScaleKey:    "2",
+				kautoscaling.MinScaleAnnotationKey: "2",
+			},
+			expectMinScale: "5",
+		},
+		{
+			name:        "drops min-scale and uses activation scale from config when min replicas is zero",
+			minReplicas: 0,
+			templateAnnotations: map[string]string{
+				kautoscaling.MinScaleAnnotationKey: "3",
+				kautoscaling.ActivationScaleKey:    "1",
+			},
+			expectActivationScale: "3",
+		},
+	}
+
+	for _, tt := range scaleTests {
+		t.Run(tt.name, func(t *testing.T) {
+			capp := cappv1alpha1.Capp{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: cappv1alpha1.CappSpec{
+					ScaleSpec: cappv1alpha1.ScaleSpec{
+						Metric:      kautoscaling.CPU,
+						MinReplicas: tt.minReplicas,
+					},
+					ConfigurationSpec: knativev1.ConfigurationSpec{
+						Template: knativev1.RevisionTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Annotations: tt.templateAnnotations},
+						},
+					},
+				},
+			}
+
+			annotations := SetAutoScaler(capp, cappv1alpha1.AutoscaleConfig{
+				RPS: 200, CPU: 80, Memory: 70, Concurrency: 10, ActivationScale: 3,
+			})
+
+			if tt.expectMinScale == "" {
+				_, hasMinScale := annotations[kautoscaling.MinScaleAnnotationKey]
+				require.False(t, hasMinScale)
+			} else {
+				require.Equal(t, tt.expectMinScale, annotations[kautoscaling.MinScaleAnnotationKey])
+			}
+
+			if tt.expectActivationScale == "" {
+				_, hasActivationScale := annotations[kautoscaling.ActivationScaleKey]
+				require.False(t, hasActivationScale)
+			} else {
+				require.Equal(t, tt.expectActivationScale, annotations[kautoscaling.ActivationScaleKey])
+			}
 		})
 	}
 }


### PR DESCRIPTION
Stop invalid min-scale and activation-scale pairs on Knative Services when Capp minReplicas and cluster autoscale defaults disagree. Validate CappConfig activationScale at the API.

Fixes #573