### PR TITLE
feat: validate PasswordSecret existence at admission time

### DIFF
--- a/internal/webhook/rcs/v1alpha1/validator.go
+++ b/internal/webhook/rcs/v1alpha1/validator.go
@@ -13,6 +13,9 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/internal/webhook/rcs/common"
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -24,7 +27,8 @@ import (
 )
 
 const (
-	eventSourcePath = "spec.eventSourcesSpec.sources"
+	eventSourcePath  = "spec.eventSourcesSpec.sources"
+	elasticSecretKey = "elastic"
 )
 
 type CappValidator struct {
@@ -84,6 +88,10 @@ func (c *CappValidator) handle(ctx context.Context, operation admissionv1.Operat
 		if taken {
 			return admission.Denied(fmt.Sprintf("invalid name %q: hostname must be unique and not already taken", capp.Spec.RouteSpec.Hostname))
 		}
+	}
+
+	if err := validatePasswordSecret(ctx, c.Client, capp); err != nil {
+		return admission.Denied(err.Error())
 	}
 
 	if err := validateNFSVolumeMounts(capp); err != nil {
@@ -149,6 +157,32 @@ func validateNFSVolumeMounts(capp cappv1alpha1.Capp) error {
 	slices.Sort(missingVolumeNames)
 
 	return fmt.Errorf("invalid nfsVolumes: volumes [%s] must be mounted by at least one container", strings.Join(missingVolumeNames, ", "))
+}
+
+func validatePasswordSecret(ctx context.Context, r client.Reader, capp cappv1alpha1.Capp) error {
+	if capp.Spec.LogSpec.PasswordSecret == "" {
+		return nil
+	}
+	return validateSecretHasKeys(ctx, r, capp.Namespace, capp.Spec.LogSpec.PasswordSecret, []string{elasticSecretKey})
+}
+
+func validateSecretHasKeys(ctx context.Context, r client.Reader, namespace, name string, requiredKeys []string) error {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Namespace: namespace, Name: name}
+	if err := r.Get(ctx, key, secret); err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("secret %q not found in namespace %q", name, namespace)
+		}
+		return fmt.Errorf("failed to look up secret %q: %w", name, err)
+	}
+
+	for _, k := range requiredKeys {
+		if _, ok := secret.Data[k]; !ok {
+			return fmt.Errorf("secret %q is missing required key %q", name, k)
+		}
+	}
+
+	return nil
 }
 
 func validateEventSources(ctx context.Context, capp cappv1alpha1.Capp) error {

--- a/internal/webhook/rcs/v1alpha1/validator_test.go
+++ b/internal/webhook/rcs/v1alpha1/validator_test.go
@@ -29,6 +29,8 @@ const (
 	unchangedHostname      = "same.example.com"
 	oldHostname            = "old.example.com"
 	newHostname            = "new.example.com"
+	elasticHost            = "https://elastic.example.com"
+	elasticIndex           = "my-index"
 )
 
 func TestCappValidatorHandle(t *testing.T) {
@@ -112,6 +114,77 @@ func TestCappValidatorHandle(t *testing.T) {
 			oldCapp:     newCapp(oldHostname),
 			expectAllow: false,
 			expectMsg:   "spec.routeSpec.hostname is immutable once set",
+		},
+		{
+			name:      "Deny Capp when PasswordSecret does not exist",
+			operation: admissionv1.Create,
+			capp: &cappv1alpha1.Capp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cappName,
+					Namespace: nsName,
+				},
+				Spec: cappv1alpha1.CappSpec{
+					ScaleSpec: cappv1alpha1.ScaleSpec{
+						Metric: knativeautoscaling.CPU,
+					},
+					LogSpec: cappv1alpha1.LogSpec{
+						Type:           cappv1alpha1.LogTypeElastic,
+						Host:           elasticHost,
+						Index:          elasticIndex,
+						User:           elasticSecretKey,
+						PasswordSecret: "missing-secret",
+					},
+				},
+			},
+			expectAllow: false,
+			expectMsg:   "secret \"missing-secret\" not found",
+		},
+		{
+			name:      "Allow Capp when PasswordSecret exists",
+			operation: admissionv1.Create,
+			capp: &cappv1alpha1.Capp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cappName,
+					Namespace: nsName,
+				},
+				Spec: cappv1alpha1.CappSpec{
+					ScaleSpec: cappv1alpha1.ScaleSpec{
+						Metric: knativeautoscaling.CPU,
+					},
+					LogSpec: cappv1alpha1.LogSpec{
+						Type:           cappv1alpha1.LogTypeElastic,
+						Host:           elasticHost,
+						Index:          elasticIndex,
+						User:           elasticSecretKey,
+						PasswordSecret: "existing-secret",
+					},
+				},
+			},
+			expectAllow: true,
+		},
+		{
+			name:      "Deny Capp when PasswordSecret exists but missing required key",
+			operation: admissionv1.Create,
+			capp: &cappv1alpha1.Capp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cappName,
+					Namespace: nsName,
+				},
+				Spec: cappv1alpha1.CappSpec{
+					ScaleSpec: cappv1alpha1.ScaleSpec{
+						Metric: knativeautoscaling.CPU,
+					},
+					LogSpec: cappv1alpha1.LogSpec{
+						Type:           cappv1alpha1.LogTypeElastic,
+						Host:           elasticHost,
+						Index:          elasticIndex,
+						User:           elasticSecretKey,
+						PasswordSecret: "bad-key-secret",
+					},
+				},
+			},
+			expectAllow: false,
+			expectMsg:   "missing required key",
 		},
 	}
 
@@ -403,9 +476,25 @@ func newScheme(t *testing.T) *runtime.Scheme {
 func newCappValidator(t *testing.T, scheme *runtime.Scheme, decoder admission.Decoder) *CappValidator {
 	t.Helper()
 
+	existingSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-secret",
+			Namespace: nsName,
+		},
+		Data: map[string][]byte{elasticSecretKey: []byte("password")},
+	}
+
+	badKeySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bad-key-secret",
+			Namespace: nsName,
+		},
+		Data: map[string][]byte{"wrong-key": []byte("value")},
+	}
+
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(newCappConfig()).
+		WithObjects(newCappConfig(), existingSecret, badKeySecret).
 		Build()
 
 	return &CappValidator{

--- a/test/e2e/logger_test.go
+++ b/test/e2e/logger_test.go
@@ -47,14 +47,14 @@ func editCappLogSpec(capp *cappv1alpha1.Capp, logType cappv1alpha1.LogType) {
 // a Capp instance with a specified logger type.
 func testCappWithLogger(logType cappv1alpha1.LogType) {
 	It(fmt.Sprintf("Should create, update, and delete SyslogNGFlow and SyslogNGOutput when creating, updating, and deleting a Capp instance with %s logger", logType), func() {
+		By(fmt.Sprintf("Creating a secret containing %s credentials", logType))
+		utils.CreateCredentialsSecret(logType, k8sClient)
+
 		By(fmt.Sprintf("Creating a Capp with %s logger", logType))
 		createdCapp := utils.CreateCappWithLogger(logType, k8sClient)
 
 		syslogNGOutputName := createdCapp.Name
 		syslogNGOutputObject := mocks.CreateSyslogNGOutputObject(syslogNGOutputName)
-
-		By(fmt.Sprintf("Creating a secret containing %s credentials", logType))
-		utils.CreateCredentialsSecret(logType, k8sClient)
 
 		By("Checking if the SyslogNGOutput is active and has no problems")
 		syslogNGOutput := &loggingv1beta1.SyslogNGOutput{}
@@ -126,6 +126,9 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 	})
 
 	It("Should cleanup SyslogNGFlow and SyslogNGOutput when they are no longer required", func() {
+		By(fmt.Sprintf("Creating a secret containing %s credentials", logType))
+		utils.CreateCredentialsSecret(logType, k8sClient)
+
 		By(fmt.Sprintf("Creating a Capp with %s logger", logType))
 		createdCapp := utils.CreateCappWithLogger(logType, k8sClient)
 

--- a/test/e2e/utils/resources_adapter.go
+++ b/test/e2e/utils/resources_adapter.go
@@ -91,9 +91,12 @@ func UpdateResource(k8sClient client.Client, object client.Object) error {
 	return k8sClient.Update(context.Background(), object)
 }
 
-// CreateSecret creates a new secret.
+// CreateSecret creates a new secret, ignoring AlreadyExists errors.
 func CreateSecret(k8sClient client.Client, secret *corev1.Secret) {
-	Expect(k8sClient.Create(context.Background(), secret)).To(Succeed())
+	err := k8sClient.Create(context.Background(), secret)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		Expect(err).ToNot(HaveOccurred())
+	}
 }
 
 // NewRetryOnConflictBackoff returns a preconfigured backoff for RetryOnConflict.


### PR DESCRIPTION
When a Capp specifies a LogSpec with a PasswordSecret, the webhook now verifies that the referenced Secret exists in the same namespace before admitting the resource. This catches typos and missing secrets early instead of letting the reconciler fail silently at runtime.

Resolves #516