### PR TITLE
feat: add storageversion marker and Hub() for v1beta1 preparation

### DIFF
--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -326,6 +326,7 @@ type CappStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Custom URL",type="string",JSONPath=".spec.routeSpec.hostname",description="shorten url"
 // +kubebuilder:printcolumn:name="AutoScale Type",type="string",JSONPath=".spec.scaleSpec.metric",description="autoscale metric"
 // +kubebuilder:subresource:status

--- a/api/v1alpha1/capprevision_types.go
+++ b/api/v1alpha1/capprevision_types.go
@@ -44,6 +44,7 @@ type CappTemplate struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
 
 // CappRevision is the Schema for the CappRevisions API
 type CappRevision struct {

--- a/api/v1alpha1/conversion.go
+++ b/api/v1alpha1/conversion.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// Hub marks Capp as a conversion hub (storage version).
+func (*Capp) Hub() {}
+
+// Hub marks CappRevision as a conversion hub (storage version).
+func (*CappRevision) Hub() {}


### PR DESCRIPTION
Add +kubebuilder:storageversion marker to Capp and CappRevision types
and implement empty Hub() methods to satisfy the conversion.Hub interface.
This prepares the API for a future v1beta1 promotion by establishing the
current v1alpha1 as the canonical storage version.
Closes #522