### PR TITLE
fix(webhook): set Capp admission sideEffects to None

### DIFF
--- a/charts/container-app-operator/templates/mutating-webhook-configuration.yaml
+++ b/charts/container-app-operator/templates/mutating-webhook-configuration.yaml
@@ -27,4 +27,4 @@ webhooks:
     - UPDATE
     resources:
     - capps
-  sideEffects: NoneOnDryRun
+  sideEffects: None

--- a/charts/container-app-operator/templates/validating-webhook-configuration.yaml
+++ b/charts/container-app-operator/templates/validating-webhook-configuration.yaml
@@ -27,4 +27,4 @@ webhooks:
     - UPDATE
     resources:
     - capps
-  sideEffects: NoneOnDryRun
+  sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -24,7 +24,7 @@ webhooks:
     - UPDATE
     resources:
     - capps
-  sideEffects: NoneOnDryRun
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -51,4 +51,4 @@ webhooks:
     - UPDATE
     resources:
     - capps
-  sideEffects: NoneOnDryRun
+  sideEffects: None

--- a/internal/webhook/rcs/v1alpha1/mutator.go
+++ b/internal/webhook/rcs/v1alpha1/mutator.go
@@ -21,7 +21,7 @@ type CappMutator struct {
 	Decoder admission.Decoder
 }
 
-// +kubebuilder:webhook:path=/mutate-capp,mutating=true,sideEffects=NoneOnDryRun,failurePolicy=fail,groups=rcs.dana.io,resources=capps,verbs=create;update,versions=v1alpha1,name=capp.dana.io,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:path=/mutate-capp,mutating=true,sideEffects=None,failurePolicy=fail,groups=rcs.dana.io,resources=capps,verbs=create;update,versions=v1alpha1,name=capp.dana.io,admissionReviewVersions=v1;v1beta1
 
 var (
 	lastUpdatedByAnnotationKey = utils.CappAPIGroup + "/last-updated-by"

--- a/internal/webhook/rcs/v1alpha1/validator.go
+++ b/internal/webhook/rcs/v1alpha1/validator.go
@@ -33,7 +33,7 @@ type CappValidator struct {
 	Log     logr.Logger
 }
 
-// +kubebuilder:webhook:path=/validate-capp,mutating=false,sideEffects=NoneOnDryRun,failurePolicy=fail,groups="rcs.dana.io",resources=capps,verbs=create;update,versions=v1alpha1,name=capp.validate.rcs.dana.io,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:path=/validate-capp,mutating=false,sideEffects=None,failurePolicy=fail,groups="rcs.dana.io",resources=capps,verbs=create;update,versions=v1alpha1,name=capp.validate.rcs.dana.io,admissionReviewVersions=v1;v1beta1
 
 func (c *CappValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	logger := log.FromContext(ctx).WithValues("webhook", "capp Webhook", "Name", req.Name)


### PR DESCRIPTION
Capp validating and mutating webhooks only read and validate objects, so declare sideEffects=None instead of NoneOnDryRun.

Fixes #512