### PR TITLE
refactor(resourcemanagers): remove dead hostname migration prune logic

### DIFF
--- a/internal/kinds/capp/controllers/controller.go
+++ b/internal/kinds/capp/controllers/controller.go
@@ -34,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	rmanagers "github.com/dana-team/container-app-operator/internal/kinds/capp/resourcemanagers"
 	"github.com/go-logr/logr"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
@@ -304,15 +305,16 @@ func (r *CappReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, fmt.Errorf("failed to get Capp: %s", err.Error())
 	}
 
+	rmClient := rclient.ResourceManagerClient{Ctx: ctx, K8sclient: r.Client, Log: logger}
 	resourceManagers := map[string]rmanagers.ResourceManager{
-		rmanagers.KnativeServing: rmanagers.KnativeServiceManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.DNSRecord:      rmanagers.DNSRecordManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.Certificate:    rmanagers.CertificateManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.DomainMapping:  rmanagers.KnativeDomainMappingManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.SyslogNGFlow:   rmanagers.SyslogNGFlowManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.SyslogNGOutput: rmanagers.SyslogNGOutputManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.NfsPVC:         rmanagers.NFSPVCManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.PingSource:     rmanagers.PingSourceManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
+		rmanagers.KnativeServing: rmanagers.KnativeServiceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.DNSRecord:      rmanagers.DNSRecordManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.Certificate:    rmanagers.CertificateManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.DomainMapping:  rmanagers.KnativeDomainMappingManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.SyslogNGFlow:   rmanagers.SyslogNGFlowManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.SyslogNGOutput: rmanagers.SyslogNGOutputManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.NfsPVC:         rmanagers.NFSPVCManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.PingSource:     rmanagers.PingSourceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
 	}
 
 	err, deleted := finalizer.HandleResourceDeletion(ctx, capp, r.Client, resourceManagers)

--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -148,37 +148,7 @@ func (c CertificateManager) reconcileCertificate(capp cappv1alpha1.Capp) error {
 		return fmt.Errorf("update Certificate %q: %w", certificate.Name, err)
 	}
 
-	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
-		if err := c.handlePreviousCertificates(capp, certificateFromCapp.Name); err != nil {
-			return fmt.Errorf("failed to handle previous Certificates: %w", err)
-		}
-	}
-
 	return nil
-}
-
-// handlePreviousCertificates takes care of removing unneeded Certificate objects. If the DNSRecord
-// which corresponds to the latest Certificate object is not yet available then return early
-// and do not delete the previous Certificates.
-func (c CertificateManager) handlePreviousCertificates(capp cappv1alpha1.Capp, name string) error {
-	var available bool
-	var err error
-
-	available, err = utils.IsDNSRecordAvailable(c.Ctx, c.K8sclient, name, capp.Namespace)
-	if err != nil {
-		return err
-	}
-
-	if !available {
-		return nil
-	}
-
-	certificates, err := c.getPreviousCertificates(capp)
-	if err != nil {
-		return err
-	}
-
-	return c.deletePreviousCertificates(certificates, capp.Spec.RouteSpec.Hostname)
 }
 
 // getPreviousCertificates returns a list of all Certificate objects that are related to the given Capp.
@@ -195,17 +165,4 @@ func (c CertificateManager) getPreviousCertificates(capp cappv1alpha1.Capp) (cma
 	}
 
 	return certificates, nil
-}
-
-// deletePreviousCertificates deletes all previous Certificates associated with a Capp.
-func (c CertificateManager) deletePreviousCertificates(certificates cmapi.CertificateList, hostname string) error {
-	for _, certificate := range certificates.Items {
-		if certificate.Name != hostname {
-			cert := rclient.GetBareCertificate(certificate.Name, certificate.Namespace)
-			if err := c.DeleteResource(&cert); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }

--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -1,8 +1,6 @@
 package resourcemanagers
 
 import (
-	"context"
-
 	"fmt"
 
 	certv1alpha1 "github.com/dana-team/cert-external-issuer/api/v1alpha1"
@@ -11,17 +9,13 @@ import (
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
-	"github.com/go-logr/logr"
 	"k8s.io/client-go/tools/events"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -35,9 +29,7 @@ const (
 )
 
 type CertificateManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -88,8 +80,6 @@ func (c CertificateManager) prepareResource(capp cappv1alpha1.Capp) (cmapi.Certi
 
 // CleanUp attempts to delete all Certificates associated with a given Capp resource.
 func (c CertificateManager) CleanUp(capp cappv1alpha1.Capp) error {
-	resourceManager := rclient.ResourceManagerClient{Ctx: c.Ctx, K8sclient: c.K8sclient, Log: c.Log}
-
 	certificates, err := c.getPreviousCertificates(capp)
 	if err != nil {
 		return err
@@ -106,7 +96,7 @@ func (c CertificateManager) CleanUp(capp cappv1alpha1.Capp) error {
 			}
 		}
 		cert := rclient.GetBareCertificate(certificate.Name, certificate.Namespace)
-		if err := resourceManager.DeleteResource(&cert); err != nil {
+		if err := c.DeleteResource(&cert); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
@@ -140,34 +130,26 @@ func (c CertificateManager) reconcileCertificate(capp cappv1alpha1.Capp) error {
 	}
 
 	certificate := cmapi.Certificate{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: c.Ctx, K8sclient: c.K8sclient, Log: c.Log}
 
 	if err := c.K8sclient.Get(c.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: certificateFromCapp.Name}, &certificate); err != nil {
 		if errors.IsNotFound(err) {
-			if err := c.createCertificate(capp, certificateFromCapp, resourceManager); err != nil {
-				return err
-			}
-
-			return nil
+			return createManagedResource(c.K8sclient, c.CreateResource, c.EventRecorder, &capp, &certificateFromCapp,
+				"Certificate", eventCappCertificateCreated, eventCappCertificateCreationFailed)
 		}
 		return fmt.Errorf("failed to get Certificate %q: %w", certificateFromCapp.Name, err)
 	}
 
 	orig := certificate.DeepCopy()
-	if err := controllerutil.SetOwnerReference(&capp, &certificate, c.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set Certificate owner reference: %w", err)
-	}
 	certificate.Spec = *certificateFromCapp.Spec.DeepCopy()
-
-	if !equality.Semantic.DeepEqual(orig.Spec, certificate.Spec) ||
-		!equality.Semantic.DeepEqual(orig.OwnerReferences, certificate.OwnerReferences) {
-		if err := resourceManager.UpdateResource(&certificate); err != nil {
-			return fmt.Errorf("update Certificate %q: %w", certificate.Name, err)
-		}
+	if err := ensureOwnerReference(c.K8sclient, &capp, &certificate, "Certificate"); err != nil {
+		return err
+	}
+	if err := updateManagedResourceIfNeeded(c.UpdateResource, &certificate, orig.Spec, certificate.Spec, orig.OwnerReferences); err != nil {
+		return fmt.Errorf("update Certificate %q: %w", certificate.Name, err)
 	}
 
 	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
-		if err := c.handlePreviousCertificates(capp, resourceManager, certificateFromCapp.Name); err != nil {
+		if err := c.handlePreviousCertificates(capp, certificateFromCapp.Name); err != nil {
 			return fmt.Errorf("failed to handle previous Certificates: %w", err)
 		}
 	}
@@ -175,28 +157,10 @@ func (c CertificateManager) reconcileCertificate(capp cappv1alpha1.Capp) error {
 	return nil
 }
 
-// createCertificate creates a new Certificate and emits an event.
-func (c CertificateManager) createCertificate(capp cappv1alpha1.Capp, certificateFromCapp cmapi.Certificate, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(&capp, &certificateFromCapp, c.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set Certificate owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(&certificateFromCapp); err != nil {
-		c.EventRecorder.Eventf(&capp, nil, corev1.EventTypeWarning, eventCappCertificateCreationFailed, eventCappCertificateCreationFailed,
-			fmt.Sprintf("Failed to create Certificate %s", certificateFromCapp.Name))
-
-		return err
-	}
-
-	c.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappCertificateCreated, eventCappCertificateCreated,
-		fmt.Sprintf("Created Certificate %s", certificateFromCapp.Name))
-
-	return nil
-}
-
 // handlePreviousCertificates takes care of removing unneeded Certificate objects. If the DNSRecord
 // which corresponds to the latest Certificate object is not yet available then return early
 // and do not delete the previous Certificates.
-func (c CertificateManager) handlePreviousCertificates(capp cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient, name string) error {
+func (c CertificateManager) handlePreviousCertificates(capp cappv1alpha1.Capp, name string) error {
 	var available bool
 	var err error
 
@@ -214,7 +178,7 @@ func (c CertificateManager) handlePreviousCertificates(capp cappv1alpha1.Capp, r
 		return err
 	}
 
-	return c.deletePreviousCertificates(certificates, resourceManager, capp.Spec.RouteSpec.Hostname)
+	return c.deletePreviousCertificates(certificates, capp.Spec.RouteSpec.Hostname)
 }
 
 // getPreviousCertificates returns a list of all Certificate objects that are related to the given Capp.
@@ -234,11 +198,11 @@ func (c CertificateManager) getPreviousCertificates(capp cappv1alpha1.Capp) (cma
 }
 
 // deletePreviousCertificates deletes all previous Certificates associated with a Capp.
-func (c CertificateManager) deletePreviousCertificates(certificates cmapi.CertificateList, resourceManager rclient.ResourceManagerClient, hostname string) error {
+func (c CertificateManager) deletePreviousCertificates(certificates cmapi.CertificateList, hostname string) error {
 	for _, certificate := range certificates.Items {
 		if certificate.Name != hostname {
 			cert := rclient.GetBareCertificate(certificate.Name, certificate.Namespace)
-			if err := resourceManager.DeleteResource(&cert); err != nil {
+			if err := c.DeleteResource(&cert); err != nil {
 				return err
 			}
 		}

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -128,12 +128,6 @@ func (r DNSRecordManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 		return fmt.Errorf("failed to get DNSRecord %q: %w", dnsRecordFromCapp.Name, err)
 	}
 
-	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
-		if err := r.handlePreviousDNSRecords(capp, dnsRecordFromCapp.Name); err != nil {
-			return fmt.Errorf("failed to delete previous DNSRecords: %w", err)
-		}
-	}
-
 	return r.updateDNSRecord(dnsRecord, dnsRecordFromCapp, &capp)
 }
 
@@ -191,26 +185,6 @@ func (r DNSRecordManager) dnsRecordNeedsUpdate(current, desired dnsrecordv1alpha
 	return !ok, nil
 }
 
-// handlePreviousDNSRecords takes care of removing unneeded DNSRecord objects. If the new DNSRecord
-// is not yet available then return early and do not delete the previous Records.
-func (r DNSRecordManager) handlePreviousDNSRecords(capp cappv1alpha1.Capp, name string) error {
-	available, err := utils.IsDNSRecordAvailable(r.Ctx, r.K8sclient, name, capp.Namespace)
-	if err != nil {
-		return err
-	}
-
-	if !available {
-		return nil
-	}
-
-	dnsRecords, err := r.getPreviousDNSRecords(capp)
-	if err != nil {
-		return err
-	}
-
-	return r.deletePreviousDNSRecords(dnsRecords, capp.Spec.RouteSpec.Hostname)
-}
-
 // getPreviousDNSRecords returns a list of all DNSRecord objects that are related to the given Capp.
 func (r DNSRecordManager) getPreviousDNSRecords(capp cappv1alpha1.Capp) (dnsrecordv1alpha1.CNAMERecordList, error) {
 	dnsRecords := dnsrecordv1alpha1.CNAMERecordList{}
@@ -227,17 +201,4 @@ func (r DNSRecordManager) getPreviousDNSRecords(capp cappv1alpha1.Capp) (dnsreco
 	}
 
 	return dnsRecords, nil
-}
-
-// deletePreviousDNSRecords deletes all previous DNSRecords associated with a Capp.
-func (r DNSRecordManager) deletePreviousDNSRecords(dnsRecords dnsrecordv1alpha1.CNAMERecordList, hostname string) error {
-	for _, dnsRecord := range dnsRecords.Items {
-		if dnsRecord.Name != hostname {
-			recordset := rclient.GetBareDNSRecord(dnsRecord.Name, dnsRecord.Namespace)
-			if err := r.DeleteResource(&recordset); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -1,7 +1,6 @@
 package resourcemanagers
 
 import (
-	"context"
 	"fmt"
 
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
@@ -10,8 +9,6 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
-	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,7 +17,6 @@ import (
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/retry"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -32,9 +28,7 @@ const (
 )
 
 type DNSRecordManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -75,8 +69,6 @@ func (r DNSRecordManager) prepareResource(capp cappv1alpha1.Capp) (dnsrecordv1al
 
 // CleanUp attempts to delete all DNSRecords associated with a given Capp resource.
 func (r DNSRecordManager) CleanUp(capp cappv1alpha1.Capp) error {
-	resourceManager := rclient.ResourceManagerClient{Ctx: r.Ctx, K8sclient: r.K8sclient, Log: r.Log}
-
 	dnsRecords, err := r.getPreviousDNSRecords(capp)
 	if err != nil {
 		return err
@@ -93,7 +85,7 @@ func (r DNSRecordManager) CleanUp(capp cappv1alpha1.Capp) error {
 			}
 		}
 		bareRecord := rclient.GetBareDNSRecord(dnsRecord.Name, dnsRecord.Namespace)
-		if err := resourceManager.DeleteResource(&bareRecord); err != nil {
+		if err := r.DeleteResource(&bareRecord); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
@@ -127,45 +119,26 @@ func (r DNSRecordManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 	}
 
 	dnsRecord := dnsrecordv1alpha1.CNAMERecord{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: r.Ctx, K8sclient: r.K8sclient, Log: r.Log}
 
 	if err := r.K8sclient.Get(r.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: dnsRecordFromCapp.Name}, &dnsRecord); err != nil {
 		if errors.IsNotFound(err) {
-			return r.createDNSRecord(capp, dnsRecordFromCapp, resourceManager)
-		} else {
-			return fmt.Errorf("failed to get DNSRecord %q: %w", dnsRecordFromCapp.Name, err)
+			return createManagedResource(r.K8sclient, r.CreateResource, r.EventRecorder, &capp, &dnsRecordFromCapp,
+				"DNSRecord", eventCappDNSRecordCreated, eventCappDNSRecordCreationFailed)
 		}
+		return fmt.Errorf("failed to get DNSRecord %q: %w", dnsRecordFromCapp.Name, err)
 	}
 
 	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
-		if err := r.handlePreviousDNSRecords(capp, resourceManager, dnsRecordFromCapp.Name); err != nil {
+		if err := r.handlePreviousDNSRecords(capp, dnsRecordFromCapp.Name); err != nil {
 			return fmt.Errorf("failed to delete previous DNSRecords: %w", err)
 		}
 	}
 
-	return r.updateDNSRecord(dnsRecord, dnsRecordFromCapp, &capp, resourceManager)
-}
-
-// createDNSRecord creates a new DNSRecord and emits an event.
-func (r DNSRecordManager) createDNSRecord(capp cappv1alpha1.Capp, dnsRecordFromCapp dnsrecordv1alpha1.CNAMERecord, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(&capp, &dnsRecordFromCapp, r.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set DNSRecord owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(&dnsRecordFromCapp); err != nil {
-		r.EventRecorder.Eventf(&capp, nil, corev1.EventTypeWarning, eventCappDNSRecordCreationFailed, eventCappDNSRecordCreationFailed,
-			fmt.Sprintf("Failed to create DNSRecord %s", dnsRecordFromCapp.Name))
-
-		return err
-	}
-
-	r.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappDNSRecordCreated, eventCappDNSRecordCreated,
-		fmt.Sprintf("Created DNSRecord %s", dnsRecordFromCapp.Name))
-
-	return nil
+	return r.updateDNSRecord(dnsRecord, dnsRecordFromCapp, &capp)
 }
 
 // updateDNSRecord checks if an update to the DNSRecord is necessary and performs the update to match desired state.
-func (r DNSRecordManager) updateDNSRecord(dnsRecord, dnsRecordFromCapp dnsrecordv1alpha1.CNAMERecord, capp *cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient) error {
+func (r DNSRecordManager) updateDNSRecord(dnsRecord, dnsRecordFromCapp dnsrecordv1alpha1.CNAMERecord, capp *cappv1alpha1.Capp) error {
 	needs, err := r.dnsRecordNeedsUpdate(dnsRecord, dnsRecordFromCapp, capp)
 	if err != nil {
 		return err
@@ -188,8 +161,8 @@ func (r DNSRecordManager) updateDNSRecord(dnsRecord, dnsRecordFromCapp dnsrecord
 		}
 
 		orig := latestRecord.DeepCopy()
-		if err := controllerutil.SetOwnerReference(capp, &latestRecord, r.K8sclient.Scheme()); err != nil {
-			return fmt.Errorf("set DNSRecord owner reference: %w", err)
+		if err := ensureOwnerReference(r.K8sclient, capp, &latestRecord, "DNSRecord"); err != nil {
+			return err
 		}
 		latestRecord.Spec.ForProvider = *dnsRecordFromCapp.Spec.ForProvider.DeepCopy()
 		if dnsRecordFromCapp.Spec.ProviderConfigReference != nil {
@@ -198,12 +171,11 @@ func (r DNSRecordManager) updateDNSRecord(dnsRecord, dnsRecordFromCapp dnsrecord
 			latestRecord.Spec.ProviderConfigReference = nil
 		}
 
-		if equality.Semantic.DeepEqual(orig.Spec, latestRecord.Spec) &&
-			equality.Semantic.DeepEqual(orig.OwnerReferences, latestRecord.OwnerReferences) {
+		if !managedResourceNeedsUpdate(orig.Spec, latestRecord.Spec, orig.OwnerReferences, latestRecord.OwnerReferences) {
 			return nil
 		}
 
-		return resourceManager.UpdateResource(&latestRecord)
+		return r.UpdateResource(&latestRecord)
 	})
 }
 
@@ -221,7 +193,7 @@ func (r DNSRecordManager) dnsRecordNeedsUpdate(current, desired dnsrecordv1alpha
 
 // handlePreviousDNSRecords takes care of removing unneeded DNSRecord objects. If the new DNSRecord
 // is not yet available then return early and do not delete the previous Records.
-func (r DNSRecordManager) handlePreviousDNSRecords(capp cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient, name string) error {
+func (r DNSRecordManager) handlePreviousDNSRecords(capp cappv1alpha1.Capp, name string) error {
 	available, err := utils.IsDNSRecordAvailable(r.Ctx, r.K8sclient, name, capp.Namespace)
 	if err != nil {
 		return err
@@ -236,7 +208,7 @@ func (r DNSRecordManager) handlePreviousDNSRecords(capp cappv1alpha1.Capp, resou
 		return err
 	}
 
-	return r.deletePreviousDNSRecords(dnsRecords, resourceManager, capp.Spec.RouteSpec.Hostname)
+	return r.deletePreviousDNSRecords(dnsRecords, capp.Spec.RouteSpec.Hostname)
 }
 
 // getPreviousDNSRecords returns a list of all DNSRecord objects that are related to the given Capp.
@@ -258,11 +230,11 @@ func (r DNSRecordManager) getPreviousDNSRecords(capp cappv1alpha1.Capp) (dnsreco
 }
 
 // deletePreviousDNSRecords deletes all previous DNSRecords associated with a Capp.
-func (r DNSRecordManager) deletePreviousDNSRecords(dnsRecords dnsrecordv1alpha1.CNAMERecordList, resourceManager rclient.ResourceManagerClient, hostname string) error {
+func (r DNSRecordManager) deletePreviousDNSRecords(dnsRecords dnsrecordv1alpha1.CNAMERecordList, hostname string) error {
 	for _, dnsRecord := range dnsRecords.Items {
 		if dnsRecord.Name != hostname {
 			recordset := rclient.GetBareDNSRecord(dnsRecord.Name, dnsRecord.Namespace)
-			if err := resourceManager.DeleteResource(&recordset); err != nil {
+			if err := r.DeleteResource(&recordset); err != nil {
 				return err
 			}
 		}

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -1,7 +1,6 @@
 package resourcemanagers
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
@@ -9,9 +8,7 @@ import (
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -32,9 +29,7 @@ const (
 )
 
 type KnativeDomainMappingManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -78,9 +73,8 @@ func (k KnativeDomainMappingManager) prepareResource(capp cappv1alpha1.Capp) (kn
 // setHTTPSKnativeDomainMapping sets the DomainMapping TLS based on Capp.
 func (k KnativeDomainMappingManager) setHTTPSKnativeDomainMapping(secretName, secretNamespace string, knativeDomainMapping *knativev1beta1.DomainMapping) error {
 	tlsSecret := corev1.Secret{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: k.Ctx, K8sclient: k.K8sclient, Log: k.Log}
 
-	if err := resourceManager.K8sclient.Get(resourceManager.Ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, &tlsSecret); err != nil {
+	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, &tlsSecret); err != nil {
 		if errors.IsNotFound(err) {
 			k.Log.Info("tlsSecret does not yet exist", "secretName", secretName)
 			return nil
@@ -97,8 +91,6 @@ func (k KnativeDomainMappingManager) setHTTPSKnativeDomainMapping(secretName, se
 
 // CleanUp attempts to delete the associated DomainMappings and tls secrets for a given Capp resource.
 func (k KnativeDomainMappingManager) CleanUp(capp cappv1alpha1.Capp) error {
-	resourceManager := rclient.ResourceManagerClient{Ctx: k.Ctx, K8sclient: k.K8sclient, Log: k.Log}
-
 	domainMappings, err := k.getPreviousDomainMappings(capp)
 	if err != nil {
 		return err
@@ -121,13 +113,13 @@ func (k KnativeDomainMappingManager) CleanUp(capp cappv1alpha1.Capp) error {
 				continue
 			}
 		}
-		if err := resourceManager.DeleteResource(&dm); err != nil {
+		if err := k.DeleteResource(&dm); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
 			return err
 		}
-		if err := deleteTLSSecret(resourceManager, utils.GenerateSecretName(dm.Name), dm.Namespace); err != nil {
+		if err := k.deleteTLSSecret(utils.GenerateSecretName(dm.Name), dm.Namespace); err != nil {
 			return err
 		}
 	}
@@ -158,61 +150,33 @@ func (k KnativeDomainMappingManager) createOrUpdate(capp cappv1alpha1.Capp) erro
 	}
 
 	domainMapping := knativev1beta1.DomainMapping{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: k.Ctx, K8sclient: k.K8sclient, Log: k.Log}
 
 	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: domainMappingFromCapp.Name}, &domainMapping); err != nil {
 		if errors.IsNotFound(err) {
-			return k.createDomainMapping(&capp, domainMappingFromCapp, resourceManager)
-		} else {
-			return fmt.Errorf("failed to get DomainMapping %q: %w", domainMappingFromCapp.Name, err)
+			return createManagedResource(k.K8sclient, k.CreateResource, k.EventRecorder, &capp, &domainMappingFromCapp,
+				"DomainMapping", eventCappDomainMappingCreated, eventCappDomainMappingCreationFailed)
 		}
+		return fmt.Errorf("failed to get DomainMapping %q: %w", domainMappingFromCapp.Name, err)
 	}
 
 	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
-		if err := k.handlePreviousDomainMappings(capp, resourceManager, domainMappingFromCapp.Name); err != nil {
+		if err := k.handlePreviousDomainMappings(capp, domainMappingFromCapp.Name); err != nil {
 			return fmt.Errorf("failed to delete previous DomainMappings: %w", err)
 		}
 	}
 
-	return k.updateDomainMapping(&domainMapping, domainMappingFromCapp, &capp, resourceManager)
-}
-
-// createDomainMapping creates a new DomainMapping and emits an event.
-func (k KnativeDomainMappingManager) createDomainMapping(capp *cappv1alpha1.Capp, domainMappingFromCapp knativev1beta1.DomainMapping, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(capp, &domainMappingFromCapp, k.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set DomainMapping owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(&domainMappingFromCapp); err != nil {
-		k.EventRecorder.Eventf(capp, nil, corev1.EventTypeWarning, eventCappDomainMappingCreationFailed, eventCappDomainMappingCreationFailed,
-			fmt.Sprintf("Failed to create DomainMapping %s", domainMappingFromCapp.Name))
-
+	orig := domainMapping.DeepCopy()
+	domainMapping.Spec = domainMappingFromCapp.Spec
+	if err := ensureOwnerReference(k.K8sclient, &capp, &domainMapping, "DomainMapping"); err != nil {
 		return err
 	}
-
-	k.EventRecorder.Eventf(capp, nil, corev1.EventTypeNormal, eventCappDomainMappingCreated, eventCappDomainMappingCreated,
-		fmt.Sprintf("Created DomainMapping %s", domainMappingFromCapp.Name))
-
-	return nil
-}
-
-// updateDomainMapping checks if an update to the DomainMapping is necessary and performs the update to match desired state.
-func (k KnativeDomainMappingManager) updateDomainMapping(knativeDomainMapping *knativev1beta1.DomainMapping, domainMappingFromCapp knativev1beta1.DomainMapping, capp *cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient) error {
-	orig := knativeDomainMapping.DeepCopy()
-	if err := controllerutil.SetOwnerReference(capp, knativeDomainMapping, k.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set DomainMapping owner reference: %w", err)
-	}
-	knativeDomainMapping.Spec = domainMappingFromCapp.Spec
-	if equality.Semantic.DeepEqual(orig.Spec, knativeDomainMapping.Spec) &&
-		equality.Semantic.DeepEqual(orig.OwnerReferences, knativeDomainMapping.OwnerReferences) {
-		return nil
-	}
-	return resourceManager.UpdateResource(knativeDomainMapping)
+	return updateManagedResourceIfNeeded(k.UpdateResource, &domainMapping, orig.Spec, domainMapping.Spec, orig.OwnerReferences)
 }
 
 // handlePreviousDomainMappings takes care of removing unneeded DomainMapping objects. If the DNSRecord
 // which corresponds to the latest DomainMapping object is not yet available then return early
 // and do not delete the previous DomainMappings.
-func (k KnativeDomainMappingManager) handlePreviousDomainMappings(capp cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient, name string) error {
+func (k KnativeDomainMappingManager) handlePreviousDomainMappings(capp cappv1alpha1.Capp, name string) error {
 	var available bool
 	var err error
 
@@ -230,7 +194,7 @@ func (k KnativeDomainMappingManager) handlePreviousDomainMappings(capp cappv1alp
 		return err
 	}
 
-	return k.deletePreviousDomainMappings(domainMappings, resourceManager, capp.Spec.RouteSpec.Hostname)
+	return k.deletePreviousDomainMappings(domainMappings, capp.Spec.RouteSpec.Hostname)
 }
 
 // getPreviousDomainMappings returns a list of all DomainMapping objects that are related to the given Capp.
@@ -250,14 +214,14 @@ func (k KnativeDomainMappingManager) getPreviousDomainMappings(capp cappv1alpha1
 }
 
 // deletePreviousDomainMappings deletes all previous DomainMappings associated with a Capp.
-func (k KnativeDomainMappingManager) deletePreviousDomainMappings(knativeDomainMappings knativev1beta1.DomainMappingList, resourceManager rclient.ResourceManagerClient, hostname string) error {
+func (k KnativeDomainMappingManager) deletePreviousDomainMappings(knativeDomainMappings knativev1beta1.DomainMappingList, hostname string) error {
 	for _, domainMapping := range knativeDomainMappings.Items {
 		if domainMapping.Name != hostname {
 			dm := rclient.GetBareDomainMapping(domainMapping.Name, domainMapping.Namespace)
-			if err := resourceManager.DeleteResource(&dm); err != nil {
+			if err := k.DeleteResource(&dm); err != nil {
 				return err
 			}
-			if err := deleteTLSSecret(resourceManager, utils.GenerateSecretName(domainMapping.Name), domainMapping.Namespace); err != nil {
+			if err := k.deleteTLSSecret(utils.GenerateSecretName(domainMapping.Name), domainMapping.Namespace); err != nil {
 				return err
 			}
 		}
@@ -266,13 +230,13 @@ func (k KnativeDomainMappingManager) deletePreviousDomainMappings(knativeDomainM
 }
 
 // deleteTLSSecret deletes the tls secret associated with the DomainMapping.
-func deleteTLSSecret(resourceManager rclient.ResourceManagerClient, secretName, namespace string) error {
+func (k KnativeDomainMappingManager) deleteTLSSecret(secretName, namespace string) error {
 	secret := corev1.Secret{}
-	if err := resourceManager.K8sclient.Get(resourceManager.Ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &secret); err != nil {
+	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &secret); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
-	return resourceManager.DeleteResource(&secret)
+	return k.DeleteResource(&secret)
 }

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -159,42 +159,12 @@ func (k KnativeDomainMappingManager) createOrUpdate(capp cappv1alpha1.Capp) erro
 		return fmt.Errorf("failed to get DomainMapping %q: %w", domainMappingFromCapp.Name, err)
 	}
 
-	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
-		if err := k.handlePreviousDomainMappings(capp, domainMappingFromCapp.Name); err != nil {
-			return fmt.Errorf("failed to delete previous DomainMappings: %w", err)
-		}
-	}
-
 	orig := domainMapping.DeepCopy()
 	domainMapping.Spec = domainMappingFromCapp.Spec
 	if err := ensureOwnerReference(k.K8sclient, &capp, &domainMapping, "DomainMapping"); err != nil {
 		return err
 	}
 	return updateManagedResourceIfNeeded(k.UpdateResource, &domainMapping, orig.Spec, domainMapping.Spec, orig.OwnerReferences)
-}
-
-// handlePreviousDomainMappings takes care of removing unneeded DomainMapping objects. If the DNSRecord
-// which corresponds to the latest DomainMapping object is not yet available then return early
-// and do not delete the previous DomainMappings.
-func (k KnativeDomainMappingManager) handlePreviousDomainMappings(capp cappv1alpha1.Capp, name string) error {
-	var available bool
-	var err error
-
-	available, err = utils.IsDNSRecordAvailable(k.Ctx, k.K8sclient, name, capp.Namespace)
-	if err != nil {
-		return err
-	}
-
-	if !available {
-		return nil
-	}
-
-	domainMappings, err := k.getPreviousDomainMappings(capp)
-	if err != nil {
-		return err
-	}
-
-	return k.deletePreviousDomainMappings(domainMappings, capp.Spec.RouteSpec.Hostname)
 }
 
 // getPreviousDomainMappings returns a list of all DomainMapping objects that are related to the given Capp.
@@ -211,22 +181,6 @@ func (k KnativeDomainMappingManager) getPreviousDomainMappings(capp cappv1alpha1
 	}
 
 	return knativeDomainMappings, nil
-}
-
-// deletePreviousDomainMappings deletes all previous DomainMappings associated with a Capp.
-func (k KnativeDomainMappingManager) deletePreviousDomainMappings(knativeDomainMappings knativev1beta1.DomainMappingList, hostname string) error {
-	for _, domainMapping := range knativeDomainMappings.Items {
-		if domainMapping.Name != hostname {
-			dm := rclient.GetBareDomainMapping(domainMapping.Name, domainMapping.Namespace)
-			if err := k.DeleteResource(&dm); err != nil {
-				return err
-			}
-			if err := k.deleteTLSSecret(utils.GenerateSecretName(domainMapping.Name), domainMapping.Namespace); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 // deleteTLSSecret deletes the tls secret associated with the DomainMapping.

--- a/internal/kinds/capp/resourcemanagers/helpers.go
+++ b/internal/kinds/capp/resourcemanagers/helpers.go
@@ -1,0 +1,53 @@
+package resourcemanagers
+
+import (
+	"fmt"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func ensureOwnerReference(k8s client.Client, capp *cappv1alpha1.Capp, obj client.Object, kind string) error {
+	if err := controllerutil.SetOwnerReference(capp, obj, k8s.Scheme()); err != nil {
+		return fmt.Errorf("set %s owner reference: %w", kind, err)
+	}
+	return nil
+}
+
+func createManagedResource(
+	k8s client.Client,
+	create func(client.Object) error,
+	recorder events.EventRecorder,
+	capp *cappv1alpha1.Capp,
+	obj client.Object,
+	kind, eventCreated, eventFailed string,
+) error {
+	if err := ensureOwnerReference(k8s, capp, obj, kind); err != nil {
+		return err
+	}
+	if err := create(obj); err != nil {
+		recorder.Eventf(capp, nil, corev1.EventTypeWarning, eventFailed, eventFailed,
+			fmt.Sprintf("Failed to create %s %s", kind, obj.GetName()))
+		return err
+	}
+	recorder.Eventf(capp, nil, corev1.EventTypeNormal, eventCreated, eventCreated,
+		fmt.Sprintf("Created %s %s", kind, obj.GetName()))
+	return nil
+}
+
+func managedResourceNeedsUpdate(origSpec, newSpec any, origOwners, newOwners []metav1.OwnerReference) bool {
+	return !equality.Semantic.DeepEqual(origSpec, newSpec) ||
+		!equality.Semantic.DeepEqual(origOwners, newOwners)
+}
+
+func updateManagedResourceIfNeeded(update func(client.Object) error, obj client.Object, origSpec, newSpec any, origOwners []metav1.OwnerReference) error {
+	if !managedResourceNeedsUpdate(origSpec, newSpec, origOwners, obj.GetOwnerReferences()) {
+		return nil
+	}
+	return update(obj)
+}

--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -10,9 +10,7 @@ import (
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,9 +35,7 @@ const (
 )
 
 type KnativeServiceManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -119,8 +115,7 @@ func (k KnativeServiceManager) CleanUp(capp cappv1alpha1.Capp) error {
 			return err
 		}
 	}
-	rm := rclient.ResourceManagerClient{Ctx: k.Ctx, K8sclient: k.K8sclient, Log: k.Log}
-	return client.IgnoreNotFound(rm.DeleteResource(&ksvc))
+	return client.IgnoreNotFound(k.DeleteResource(&ksvc))
 }
 
 // IsRequired determines if a Knative service (ksvc) is required based on the Capp's spec.
@@ -156,11 +151,11 @@ func (k KnativeServiceManager) Manage(capp cappv1alpha1.Capp) error {
 func (k KnativeServiceManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 	knativeServiceFromCapp := k.prepareResource(capp, k.Ctx)
 	knativeService := knativev1.Service{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: k.Ctx, K8sclient: k.K8sclient, Log: k.Log}
 
 	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, &knativeService); err != nil {
 		if errors.IsNotFound(err) {
-			if err := k.createKSVC(&capp, &knativeServiceFromCapp, resourceManager); err != nil {
+			if err := createManagedResource(k.K8sclient, k.CreateResource, k.EventRecorder, &capp, &knativeServiceFromCapp,
+				"KnativeService", eventCappKnativeServiceCreated, eventCappKnativeServiceCreationFailed); err != nil {
 				return err
 			}
 
@@ -169,48 +164,21 @@ func (k KnativeServiceManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 				k.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappEnabled, eventCappEnabled, fmt.Sprintf("Capp %q state changed to enabled", capp.Name))
 			}
 			return nil
-		} else {
-			return fmt.Errorf("failed to get KnativeService %q: %w", knativeService.Name, err)
 		}
+		return fmt.Errorf("failed to get KnativeService %q: %w", knativeService.Name, err)
 	}
 
-	return k.updateKSVC(&knativeService, &knativeServiceFromCapp, &capp, resourceManager)
-}
-
-// createKSVC creates a new knativeService and emits an event.
-func (k KnativeServiceManager) createKSVC(capp *cappv1alpha1.Capp, knativeServiceFromCapp *knativev1.Service, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(capp, knativeServiceFromCapp, k.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set Knative Service owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(knativeServiceFromCapp); err != nil {
-		k.EventRecorder.Eventf(capp, nil, corev1.EventTypeWarning, eventCappKnativeServiceCreationFailed, eventCappKnativeServiceCreationFailed,
-			fmt.Sprintf("Failed to create KnativeService %s", knativeServiceFromCapp.Name))
+	orig := knativeService.DeepCopy()
+	knativeService.Spec = knativeServiceFromCapp.Spec
+	if err := ensureOwnerReference(k.K8sclient, &capp, &knativeService, "Knative Service"); err != nil {
 		return err
 	}
-
-	k.EventRecorder.Eventf(capp, nil, corev1.EventTypeNormal, eventCappKnativeServiceCreated, eventCappKnativeServiceCreated,
-		fmt.Sprintf("Created KnativeService %s", knativeServiceFromCapp.Name))
-
-	return nil
-}
-
-// updateKSVC checks if an update to the KnativeService is necessary and performs the update to match desired state.
-func (k KnativeServiceManager) updateKSVC(knativeService, knativeServiceFromCapp *knativev1.Service, capp *cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient) error {
-	orig := knativeService.DeepCopy()
-	if err := controllerutil.SetOwnerReference(capp, knativeService, k.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set Knative Service owner reference: %w", err)
+	if managedResourceNeedsUpdate(orig.Spec, knativeService.Spec, orig.OwnerReferences, knativeService.OwnerReferences) {
+		k.Log.V(1).Info("KnativeService spec or owner metadata differs from desired; applying update",
+			"knativeService", knativeService.Name,
+			"namespace", knativeService.Namespace,
+			"resourceVersion", knativeService.ResourceVersion,
+			"generation", knativeService.Generation)
 	}
-	knativeService.Spec = knativeServiceFromCapp.Spec
-
-	if equality.Semantic.DeepEqual(orig.Spec, knativeService.Spec) &&
-		equality.Semantic.DeepEqual(orig.OwnerReferences, knativeService.OwnerReferences) {
-		return nil
-	}
-
-	k.Log.V(1).Info("KnativeService spec or owner metadata differs from desired; applying update",
-		"knativeService", knativeService.Name,
-		"namespace", knativeService.Namespace,
-		"resourceVersion", knativeService.ResourceVersion,
-		"generation", knativeService.Generation)
-	return resourceManager.UpdateResource(knativeService)
+	return updateManagedResourceIfNeeded(k.UpdateResource, &knativeService, orig.Spec, knativeService.Spec, orig.OwnerReferences)
 }

--- a/internal/kinds/capp/resourcemanagers/nfspvc.go
+++ b/internal/kinds/capp/resourcemanagers/nfspvc.go
@@ -1,7 +1,6 @@
 package resourcemanagers
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
@@ -10,9 +9,7 @@ import (
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	nfspvcv1alpha1 "github.com/dana-team/nfspvc-operator/api/v1alpha1"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -29,9 +26,7 @@ const (
 )
 
 type NFSPVCManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -81,8 +76,6 @@ func (n NFSPVCManager) getPreviousNFSPVCs(capp cappv1alpha1.Capp) (nfspvcv1alpha
 
 // CleanUp attempts to delete the associated NFSPVCs for a given Capp resource.
 func (n NFSPVCManager) CleanUp(capp cappv1alpha1.Capp) error {
-	resourceManager := rclient.ResourceManagerClient{Ctx: n.Ctx, K8sclient: n.K8sclient, Log: n.Log}
-
 	nfsPvcs, err := n.getPreviousNFSPVCs(capp)
 	if err != nil {
 		return err
@@ -100,7 +93,7 @@ func (n NFSPVCManager) CleanUp(capp cappv1alpha1.Capp) error {
 		}
 		nfsPvcVolume := rclient.GetBareNFSPVC(nfsPvc.Name, nfsPvc.Namespace)
 
-		if err := resourceManager.DeleteResource(&nfsPvcVolume); err != nil {
+		if err := n.DeleteResource(&nfsPvcVolume); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
@@ -129,56 +122,30 @@ func (n NFSPVCManager) Manage(capp cappv1alpha1.Capp) error {
 // createOrUpdate creates or updates a NFSPVC resource.
 func (n NFSPVCManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 	generatedNFSPVCs := n.prepareResource(capp)
-	resourceManager := rclient.ResourceManagerClient{Ctx: n.Ctx, K8sclient: n.K8sclient, Log: n.Log}
 
 	for i := range generatedNFSPVCs {
 		nfspvc := &generatedNFSPVCs[i]
 		existingNFSPVC := nfspvcv1alpha1.NfsPvc{}
 		if err := n.K8sclient.Get(n.Ctx, client.ObjectKey{Namespace: nfspvc.Namespace, Name: nfspvc.Name}, &existingNFSPVC); err != nil {
 			if errors.IsNotFound(err) {
-				if err := n.createNFSPVC(&capp, nfspvc, resourceManager); err != nil {
+				if err := createManagedResource(n.K8sclient, n.CreateResource, n.EventRecorder, &capp, nfspvc,
+					"NFSPVC", eventNFSPVCCreated, eventNFSPVCCreationFailed); err != nil {
 					return err
 				}
 			} else {
 				return fmt.Errorf("failed to get NFSPVC %q: %w", nfspvc.Name, err)
 			}
-		} else if err := n.updateNFSPVC(&capp, existingNFSPVC, nfspvc, resourceManager); err != nil {
-			return err
+		} else {
+			orig := existingNFSPVC.DeepCopy()
+			existingNFSPVC.Spec = *nfspvc.Spec.DeepCopy()
+			if err := ensureOwnerReference(n.K8sclient, &capp, &existingNFSPVC, "NfsPvc"); err != nil {
+				return err
+			}
+			if err := updateManagedResourceIfNeeded(n.UpdateResource, &existingNFSPVC, orig.Spec, existingNFSPVC.Spec, orig.OwnerReferences); err != nil {
+				return err
+			}
 		}
 	}
 
 	return nil
-}
-
-// createNFSPVC creates a new NFSPVC and emits an event.
-func (n NFSPVCManager) createNFSPVC(capp *cappv1alpha1.Capp, nfspvc *nfspvcv1alpha1.NfsPvc, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(capp, nfspvc, n.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set NfsPvc owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(nfspvc); err != nil {
-		n.EventRecorder.Eventf(capp, nil, corev1.EventTypeWarning, eventNFSPVCCreationFailed, eventNFSPVCCreationFailed,
-			fmt.Sprintf("Failed to create NFSPVC %s", nfspvc.Name))
-		return err
-	}
-
-	n.EventRecorder.Eventf(capp, nil, corev1.EventTypeNormal, eventNFSPVCCreated, eventNFSPVCCreated,
-		fmt.Sprintf("Created NFSPVC %s", nfspvc.Name))
-
-	return nil
-}
-
-// updateNFSPVC checks if an update to the NFSPVC is necessary and performs the update to match desired state.
-func (n NFSPVCManager) updateNFSPVC(capp *cappv1alpha1.Capp, existingNFSPVC nfspvcv1alpha1.NfsPvc, nfspvc *nfspvcv1alpha1.NfsPvc, resourceManager rclient.ResourceManagerClient) error {
-	orig := existingNFSPVC.DeepCopy()
-	if err := controllerutil.SetOwnerReference(capp, &existingNFSPVC, n.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set NfsPvc owner reference: %w", err)
-	}
-	existingNFSPVC.Spec = *nfspvc.Spec.DeepCopy()
-
-	if equality.Semantic.DeepEqual(orig.Spec, existingNFSPVC.Spec) &&
-		equality.Semantic.DeepEqual(orig.OwnerReferences, existingNFSPVC.OwnerReferences) {
-		return nil
-	}
-
-	return resourceManager.UpdateResource(&existingNFSPVC)
 }

--- a/internal/kinds/capp/resourcemanagers/pingsource.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource.go
@@ -1,17 +1,15 @@
 package resourcemanagers
 
 import (
-	"context"
 	"fmt"
 	"sort"
 
 	"github.com/cloudevents/sdk-go/v2/event"
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
-	"github.com/go-logr/logr"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -21,7 +19,6 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -31,9 +28,7 @@ const (
 )
 
 type PingSourceManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -56,7 +51,7 @@ func (p PingSourceManager) CleanUp(capp cappv1alpha1.Capp) error {
 	}
 	for i := range pingSources.Items {
 		ps := &pingSources.Items[i]
-		if err := p.K8sclient.Delete(p.Ctx, ps); client.IgnoreNotFound(err) != nil {
+		if err := client.IgnoreNotFound(p.DeleteResource(ps)); err != nil {
 			return fmt.Errorf("failed to delete PingSource %q: %w", ps.Name, err)
 		}
 	}
@@ -116,38 +111,19 @@ func (p PingSourceManager) createOrUpdate(capp cappv1alpha1.Capp, source cappv1a
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get PingSource %q: %w", desired.Name, err)
 		}
-		return p.createPingSource(&capp, desired)
+		return createManagedResource(p.K8sclient, p.CreateResource, p.EventRecorder, &capp, desired,
+			"PingSource", eventPingSourceCreated, eventPingSourceCreationFailed)
 	}
-	return p.updatePingSource(&capp, existing, desired)
-}
 
-func (p PingSourceManager) createPingSource(capp *cappv1alpha1.Capp, ps *sourcesv1.PingSource) error {
-	if err := controllerutil.SetOwnerReference(capp, ps, p.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set PingSource owner reference: %w", err)
-	}
-	p.Log.Info("Creating PingSource", "Name", ps.Name)
-	if err := p.K8sclient.Create(p.Ctx, ps); err != nil {
-		p.EventRecorder.Eventf(capp, nil, corev1.EventTypeWarning, eventPingSourceCreationFailed, eventPingSourceCreationFailed,
-			"Failed to create PingSource %s", ps.Name)
+	orig := existing.DeepCopy()
+	existing.Spec = desired.Spec
+	if err := ensureOwnerReference(p.K8sclient, &capp, existing, "PingSource"); err != nil {
 		return err
 	}
-	p.EventRecorder.Eventf(capp, nil, corev1.EventTypeNormal, eventPingSourceCreated, eventPingSourceCreated,
-		"Created PingSource %s", ps.Name)
-	return nil
-}
-
-func (p PingSourceManager) updatePingSource(capp *cappv1alpha1.Capp, existing, desired *sourcesv1.PingSource) error {
-	orig := existing.DeepCopy()
-	if err := controllerutil.SetOwnerReference(capp, existing, p.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set PingSource owner reference: %w", err)
+	if managedResourceNeedsUpdate(orig.Spec, existing.Spec, orig.OwnerReferences, existing.OwnerReferences) {
+		p.Log.Info("Updating PingSource", "Name", existing.Name)
 	}
-	existing.Spec = desired.Spec
-	if equality.Semantic.DeepEqual(orig.Spec, existing.Spec) &&
-		equality.Semantic.DeepEqual(orig.OwnerReferences, existing.OwnerReferences) {
-		return nil
-	}
-	p.Log.Info("Updating PingSource", "Name", existing.Name)
-	return p.K8sclient.Update(p.Ctx, existing)
+	return updateManagedResourceIfNeeded(p.UpdateResource, existing, orig.Spec, existing.Spec, orig.OwnerReferences)
 }
 
 func (p PingSourceManager) cleanUpOrphans(capp cappv1alpha1.Capp) error {
@@ -164,7 +140,7 @@ func (p PingSourceManager) cleanUpOrphans(capp cappv1alpha1.Capp) error {
 	for i := range owned.Items {
 		ps := &owned.Items[i]
 		if _, keep := desired[ps.Name]; !keep {
-			if err := p.K8sclient.Delete(p.Ctx, ps); client.IgnoreNotFound(err) != nil {
+			if err := client.IgnoreNotFound(p.DeleteResource(ps)); err != nil {
 				return fmt.Errorf("failed to delete orphaned PingSource %q: %w", ps.Name, err)
 			}
 		}

--- a/internal/kinds/capp/resourcemanagers/pingsource_test.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -45,10 +46,8 @@ func newPingSourceScheme() *runtime.Scheme {
 
 func newPingSourceManager(k8sClient client.Client) PingSourceManager {
 	return PingSourceManager{
-		Ctx:           context.Background(),
-		K8sclient:     k8sClient,
-		Log:           logr.Discard(),
-		EventRecorder: events.NewFakeRecorder(10),
+		ResourceManagerClient: rclient.ResourceManagerClient{Ctx: context.Background(), K8sclient: k8sClient, Log: logr.Discard()},
+		EventRecorder:         events.NewFakeRecorder(10),
 	}
 }
 

--- a/internal/kinds/capp/resourcemanagers/syslogngflow.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngflow.go
@@ -1,18 +1,14 @@
 package resourcemanagers
 
 import (
-	"context"
 	"fmt"
 
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
-	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
-	"github.com/go-logr/logr"
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/filter"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,9 +26,7 @@ const (
 )
 
 type SyslogNGFlowManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -72,8 +66,7 @@ func (f SyslogNGFlowManager) CleanUp(capp cappv1alpha1.Capp) error {
 			return err
 		}
 	}
-	resourceManager := rclient.ResourceManagerClient{Ctx: f.Ctx, K8sclient: f.K8sclient, Log: f.Log}
-	return client.IgnoreNotFound(resourceManager.DeleteResource(&syslogNGFlow))
+	return client.IgnoreNotFound(f.DeleteResource(&syslogNGFlow))
 }
 
 // IsRequired is responsible to determine if resource logging operator SyslogNGFlow is required.
@@ -95,48 +88,19 @@ func (f SyslogNGFlowManager) Manage(capp cappv1alpha1.Capp) error {
 func (f SyslogNGFlowManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 	syslogNGFlowFromCapp := f.prepareResource(capp)
 	syslogNGFlow := loggingv1beta1.SyslogNGFlow{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: f.Ctx, K8sclient: f.K8sclient, Log: f.Log}
 
 	if err := f.K8sclient.Get(f.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: syslogNGFlowFromCapp.Name}, &syslogNGFlow); err != nil {
 		if errors.IsNotFound(err) {
-			return f.createSyslogNGFlow(syslogNGFlowFromCapp, capp, resourceManager)
-		} else {
-			return fmt.Errorf("failed to get SyslogNGFlow %q: %w", syslogNGFlow.Name, err)
+			return createManagedResource(f.K8sclient, f.CreateResource, f.EventRecorder, &capp, &syslogNGFlowFromCapp,
+				"SyslogNGFlow", eventCappSyslogNGFlowCreated, eventCappSyslogNGFlowCreationFailed)
 		}
+		return fmt.Errorf("failed to get SyslogNGFlow %q: %w", syslogNGFlow.Name, err)
 	}
 
-	return f.updateSyslogNGFlow(&capp, &syslogNGFlow, &syslogNGFlowFromCapp, resourceManager)
-}
-
-// createSyslogNGFlow creates a new SyslogNGFlow and emits an event.
-func (f SyslogNGFlowManager) createSyslogNGFlow(syslogNGFlowFromCapp loggingv1beta1.SyslogNGFlow, capp cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(&capp, &syslogNGFlowFromCapp, f.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set SyslogNGFlow owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(&syslogNGFlowFromCapp); err != nil {
-		f.EventRecorder.Eventf(&capp, nil, corev1.EventTypeWarning, eventCappSyslogNGFlowCreationFailed, eventCappSyslogNGFlowCreationFailed,
-			fmt.Sprintf("Failed to create SyslogNGFlow %s", syslogNGFlowFromCapp.Name))
+	orig := syslogNGFlow.DeepCopy()
+	syslogNGFlow.Spec = *syslogNGFlowFromCapp.Spec.DeepCopy()
+	if err := ensureOwnerReference(f.K8sclient, &capp, &syslogNGFlow, "SyslogNGFlow"); err != nil {
 		return err
 	}
-
-	f.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappSyslogNGFlowCreated, eventCappSyslogNGFlowCreated,
-		fmt.Sprintf("Created SyslogNGFlow %s", syslogNGFlowFromCapp.Name))
-
-	return nil
-}
-
-// updateSyslogNGFlow checks if an update to the SyslogNGFlow is necessary and performs the update to match desired state.
-func (f SyslogNGFlowManager) updateSyslogNGFlow(capp *cappv1alpha1.Capp, syslogNGFlow, syslogNGFlowFromCapp *loggingv1beta1.SyslogNGFlow, resourceManager rclient.ResourceManagerClient) error {
-	orig := syslogNGFlow.DeepCopy()
-	if err := controllerutil.SetOwnerReference(capp, syslogNGFlow, f.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set SyslogNGFlow owner reference: %w", err)
-	}
-	syslogNGFlow.Spec = *syslogNGFlowFromCapp.Spec.DeepCopy()
-
-	if equality.Semantic.DeepEqual(orig.Spec, syslogNGFlow.Spec) &&
-		equality.Semantic.DeepEqual(orig.OwnerReferences, syslogNGFlow.OwnerReferences) {
-		return nil
-	}
-
-	return resourceManager.UpdateResource(syslogNGFlow)
+	return updateManagedResourceIfNeeded(f.UpdateResource, &syslogNGFlow, orig.Spec, syslogNGFlow.Spec, orig.OwnerReferences)
 }

--- a/internal/kinds/capp/resourcemanagers/syslogngoutput.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngoutput.go
@@ -1,7 +1,6 @@
 package resourcemanagers
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
@@ -9,12 +8,10 @@ import (
 	"github.com/cisco-open/operator-tools/pkg/secret"
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
-	"github.com/go-logr/logr"
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/output"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,9 +32,7 @@ const (
 )
 
 type SyslogNGOutputManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -150,8 +145,7 @@ func (o SyslogNGOutputManager) CleanUp(capp cappv1alpha1.Capp) error {
 			return err
 		}
 	}
-	resourceManager := rclient.ResourceManagerClient{Ctx: o.Ctx, K8sclient: o.K8sclient, Log: o.Log}
-	return client.IgnoreNotFound(resourceManager.DeleteResource(&syslogNGOutput))
+	return client.IgnoreNotFound(o.DeleteResource(&syslogNGOutput))
 }
 
 // IsRequired is responsible to determine if resource logging operator is required.
@@ -176,48 +170,19 @@ func (o SyslogNGOutputManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 		return fmt.Errorf("unsupported log type %q", capp.Spec.LogSpec.Type)
 	}
 	syslogNGOutput := loggingv1beta1.SyslogNGOutput{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: o.Ctx, K8sclient: o.K8sclient, Log: o.Log}
 
 	if err := o.K8sclient.Get(o.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: syslogNGOutputFromCapp.Name}, &syslogNGOutput); err != nil {
 		if errors.IsNotFound(err) {
-			return o.createSyslogNGOutput(syslogNGOutputFromCapp, capp, resourceManager)
-		} else {
-			return fmt.Errorf("failed to get SyslogNGOutput %q: %w", syslogNGOutputFromCapp.Name, err)
+			return createManagedResource(o.K8sclient, o.CreateResource, o.EventRecorder, &capp, &syslogNGOutputFromCapp,
+				"SyslogNGOutput", eventCappSyslogNGOutputCreated, eventCappSyslogNGOutputCreationFailed)
 		}
+		return fmt.Errorf("failed to get SyslogNGOutput %q: %w", syslogNGOutputFromCapp.Name, err)
 	}
 
-	return o.updateSyslogNGOutput(&capp, &syslogNGOutput, &syslogNGOutputFromCapp, resourceManager)
-}
-
-// createSyslogNGOutput creates a new SyslogNGOutput and emits an event.
-func (o SyslogNGOutputManager) createSyslogNGOutput(syslogNGOutputFromCapp loggingv1beta1.SyslogNGOutput, capp cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(&capp, &syslogNGOutputFromCapp, o.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set SyslogNGOutput owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(&syslogNGOutputFromCapp); err != nil {
-		o.EventRecorder.Eventf(&capp, nil, corev1.EventTypeWarning, eventCappSyslogNGOutputCreationFailed, eventCappSyslogNGOutputCreationFailed,
-			fmt.Sprintf("Failed to create SyslogNGOutput %s", syslogNGOutputFromCapp.Name))
+	orig := syslogNGOutput.DeepCopy()
+	syslogNGOutput.Spec = *syslogNGOutputFromCapp.Spec.DeepCopy()
+	if err := ensureOwnerReference(o.K8sclient, &capp, &syslogNGOutput, "SyslogNGOutput"); err != nil {
 		return err
 	}
-
-	o.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappSyslogNGOutputCreated, eventCappSyslogNGOutputCreated,
-		fmt.Sprintf("Created SyslogNGOutput %s", syslogNGOutputFromCapp.Name))
-
-	return nil
-}
-
-// updateSyslogNGOutput checks if an update to the SyslogNGOutput is necessary and performs the update to match desired state.
-func (o SyslogNGOutputManager) updateSyslogNGOutput(capp *cappv1alpha1.Capp, syslogNGOutput, syslogNGOutputFromCapp *loggingv1beta1.SyslogNGOutput, resourceManager rclient.ResourceManagerClient) error {
-	orig := syslogNGOutput.DeepCopy()
-	if err := controllerutil.SetOwnerReference(capp, syslogNGOutput, o.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set SyslogNGOutput owner reference: %w", err)
-	}
-	syslogNGOutput.Spec = *syslogNGOutputFromCapp.Spec.DeepCopy()
-
-	if equality.Semantic.DeepEqual(orig.Spec, syslogNGOutput.Spec) &&
-		equality.Semantic.DeepEqual(orig.OwnerReferences, syslogNGOutput.OwnerReferences) {
-		return nil
-	}
-
-	return resourceManager.UpdateResource(syslogNGOutput)
+	return updateManagedResourceIfNeeded(o.UpdateResource, &syslogNGOutput, orig.Spec, syslogNGOutput.Spec, orig.OwnerReferences)
 }

--- a/internal/kinds/capp/utils/route.go
+++ b/internal/kinds/capp/utils/route.go
@@ -6,11 +6,6 @@ import (
 	"strings"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
-
-	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
-
-	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -19,23 +14,6 @@ const (
 	dot                 = "."
 	maxCommonNameLength = 64
 )
-
-// IsDNSRecordAvailable returns a boolean indicating whether a CNAMERecord is currently available.
-func IsDNSRecordAvailable(ctx context.Context, k8sClient client.Client, name, namespace string) (bool, error) {
-	var available bool
-
-	dnsRecord := dnsrecordv1alpha1.CNAMERecord{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &dnsRecord); err != nil {
-		return false, fmt.Errorf("failed getting DNSRecord: %w", err)
-	}
-
-	if dnsRecord.Status.Conditions != nil {
-		readyCondition := dnsRecord.Status.GetCondition(xpv1.TypeReady)
-		available = readyCondition.Status == corev1.ConditionTrue && readyCondition.Reason == xpv1.ReasonAvailable
-	}
-
-	return available, nil
-}
 
 // GetDNSConfig returns the data of the DNS for the CappConfig CRD.
 func GetDNSConfig(ctx context.Context, k8sClient client.Client) (cappv1alpha1.DNSConfig, error) {


### PR DESCRIPTION
handlePrevious* waited for DNS Ready, then deleted stale route CRs after
a hostname change. The validating webhook now makes hostname immutable
once set, so that path is unreachable via normal updates.
    
CleanUp and the Capp finalizer still delete route resources on TLS-off
or Capp delete.
