### PR TITLE
fix(capp): pass context into resource managers instead of storing it

### DIFF
--- a/internal/kinds/capp/controllers/controller.go
+++ b/internal/kinds/capp/controllers/controller.go
@@ -305,7 +305,7 @@ func (r *CappReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, fmt.Errorf("failed to get Capp: %s", err.Error())
 	}
 
-	rmClient := rclient.ResourceManagerClient{Ctx: ctx, K8sclient: r.Client, Log: logger}
+	rmClient := rclient.ResourceManagerClient{K8sclient: r.Client, Log: logger}
 	resourceManagers := map[string]rmanagers.ResourceManager{
 		rmanagers.KnativeServing: rmanagers.KnativeServiceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
 		rmanagers.DNSRecord:      rmanagers.DNSRecordManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
@@ -344,7 +344,7 @@ func (r *CappReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 // It ensures all manifests are applied according to the specification and synchronizes the status accordingly.
 func (r *CappReconciler) SyncApplication(ctx context.Context, capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.ResourceManager, logger logr.Logger) error {
 	for _, manager := range resourceManagers {
-		if err := manager.Manage(capp); err != nil {
+		if err := manager.Manage(ctx, capp); err != nil {
 			return err
 		}
 	}

--- a/internal/kinds/capp/controllers/controller.go
+++ b/internal/kinds/capp/controllers/controller.go
@@ -34,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	rmanagers "github.com/dana-team/container-app-operator/internal/kinds/capp/resourcemanagers"
 	"github.com/go-logr/logr"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
@@ -304,15 +305,16 @@ func (r *CappReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, fmt.Errorf("failed to get Capp: %s", err.Error())
 	}
 
+	rmClient := rclient.ResourceManagerClient{Ctx: ctx, K8sclient: r.Client, Log: logger}
 	resourceManagers := map[string]rmanagers.ResourceManager{
-		rmanagers.KnativeServing: rmanagers.KnativeServiceManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.DNSRecord:      rmanagers.DNSRecordManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.Certificate:    rmanagers.CertificateManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.DomainMapping:  rmanagers.KnativeDomainMappingManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.SyslogNGFlow:   rmanagers.SyslogNGFlowManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.SyslogNGOutput: rmanagers.SyslogNGOutputManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.NfsPVC:         rmanagers.NFSPVCManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
-		rmanagers.PingSource:     rmanagers.PingSourceManager{Ctx: ctx, Log: logger, K8sclient: r.Client, EventRecorder: r.EventRecorder},
+		rmanagers.KnativeServing: rmanagers.KnativeServiceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.DNSRecord:      rmanagers.DNSRecordManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.Certificate:    rmanagers.CertificateManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.DomainMapping:  rmanagers.KnativeDomainMappingManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.SyslogNGFlow:   rmanagers.SyslogNGFlowManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.SyslogNGOutput: rmanagers.SyslogNGOutputManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.NfsPVC:         rmanagers.NFSPVCManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.PingSource:     rmanagers.PingSourceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
 	}
 
 	err, deleted := finalizer.HandleResourceDeletion(ctx, capp, r.Client, resourceManagers)

--- a/internal/kinds/capp/finalizer/finalizer.go
+++ b/internal/kinds/capp/finalizer/finalizer.go
@@ -17,7 +17,7 @@ const CappCleanupFinalizer = "dana.io/capp-cleanup"
 func HandleResourceDeletion(ctx context.Context, capp cappv1alpha1.Capp, r client.Client, resourceManagers map[string]rmanagers.ResourceManager) (error, bool) {
 	if capp.DeletionTimestamp != nil {
 		if controllerutil.ContainsFinalizer(&capp, CappCleanupFinalizer) {
-			if err := finalizeCapp(capp, resourceManagers); err != nil {
+			if err := finalizeCapp(ctx, capp, resourceManagers); err != nil {
 				return err, false
 			}
 			return RemoveFinalizer(ctx, capp, r), true
@@ -37,9 +37,9 @@ func RemoveFinalizer(ctx context.Context, capp cappv1alpha1.Capp, r client.Clien
 }
 
 // finalizeCapp runs the cleanup of all the resource managers.
-func finalizeCapp(capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.ResourceManager) error {
+func finalizeCapp(ctx context.Context, capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.ResourceManager) error {
 	for _, manager := range resourceManagers {
-		if err := manager.CleanUp(capp); err != nil {
+		if err := manager.CleanUp(ctx, capp); err != nil {
 			return err
 		}
 	}

--- a/internal/kinds/capp/resourceclient/resourceclient.go
+++ b/internal/kinds/capp/resourceclient/resourceclient.go
@@ -9,7 +9,6 @@ import (
 )
 
 type ResourceManagerClient struct {
-	Ctx       context.Context
 	K8sclient client.Client
 	Log       logr.Logger
 }
@@ -32,27 +31,27 @@ func ObjectIdentityKeyVals(obj client.Object) []any {
 }
 
 // CreateResource creates a resource.
-func (r ResourceManagerClient) CreateResource(resource client.Object) error {
+func (r ResourceManagerClient) CreateResource(ctx context.Context, resource client.Object) error {
 	r.Log.Info("kubernetes API write create", ObjectIdentityKeyVals(resource)...)
-	if err := r.K8sclient.Create(r.Ctx, resource); err != nil {
+	if err := r.K8sclient.Create(ctx, resource); err != nil {
 		return fmt.Errorf("failed to create resource %s %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName(), err)
 	}
 	return nil
 }
 
 // UpdateResource updates a resource.
-func (r ResourceManagerClient) UpdateResource(resource client.Object) error {
+func (r ResourceManagerClient) UpdateResource(ctx context.Context, resource client.Object) error {
 	r.Log.Info("kubernetes API write update", ObjectIdentityKeyVals(resource)...)
-	if err := r.K8sclient.Update(r.Ctx, resource); err != nil {
+	if err := r.K8sclient.Update(ctx, resource); err != nil {
 		return fmt.Errorf("failed to update %s %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName(), err)
 	}
 	return nil
 }
 
 // DeleteResource deletes a resource.
-func (r ResourceManagerClient) DeleteResource(resource client.Object) error {
+func (r ResourceManagerClient) DeleteResource(ctx context.Context, resource client.Object) error {
 	r.Log.Info("kubernetes API write delete", ObjectIdentityKeyVals(resource)...)
-	if err := r.K8sclient.Delete(r.Ctx, resource); err != nil {
+	if err := r.K8sclient.Delete(ctx, resource); err != nil {
 		return fmt.Errorf("failed to delete %s %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName(), err)
 	}
 	return nil

--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -148,37 +148,7 @@ func (c CertificateManager) reconcileCertificate(capp cappv1alpha1.Capp) error {
 		return fmt.Errorf("update Certificate %q: %w", certificate.Name, err)
 	}
 
-	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
-		if err := c.handlePreviousCertificates(capp, certificateFromCapp.Name); err != nil {
-			return fmt.Errorf("failed to handle previous Certificates: %w", err)
-		}
-	}
-
 	return nil
-}
-
-// handlePreviousCertificates takes care of removing unneeded Certificate objects. If the DNSRecord
-// which corresponds to the latest Certificate object is not yet available then return early
-// and do not delete the previous Certificates.
-func (c CertificateManager) handlePreviousCertificates(capp cappv1alpha1.Capp, name string) error {
-	var available bool
-	var err error
-
-	available, err = utils.IsDNSRecordAvailable(c.Ctx, c.K8sclient, name, capp.Namespace)
-	if err != nil {
-		return err
-	}
-
-	if !available {
-		return nil
-	}
-
-	certificates, err := c.getPreviousCertificates(capp)
-	if err != nil {
-		return err
-	}
-
-	return c.deletePreviousCertificates(certificates, capp.Spec.RouteSpec.Hostname)
 }
 
 // getPreviousCertificates returns a list of all Certificate objects that are related to the given Capp.
@@ -195,17 +165,4 @@ func (c CertificateManager) getPreviousCertificates(capp cappv1alpha1.Capp) (cma
 	}
 
 	return certificates, nil
-}
-
-// deletePreviousCertificates deletes all previous Certificates associated with a Capp.
-func (c CertificateManager) deletePreviousCertificates(certificates cmapi.CertificateList, hostname string) error {
-	for _, certificate := range certificates.Items {
-		if certificate.Name != hostname {
-			cert := rclient.GetBareCertificate(certificate.Name, certificate.Namespace)
-			if err := c.DeleteResource(&cert); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }

--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -1,8 +1,6 @@
 package resourcemanagers
 
 import (
-	"context"
-
 	"fmt"
 
 	certv1alpha1 "github.com/dana-team/cert-external-issuer/api/v1alpha1"
@@ -11,17 +9,13 @@ import (
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
-	"github.com/go-logr/logr"
 	"k8s.io/client-go/tools/events"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -35,9 +29,7 @@ const (
 )
 
 type CertificateManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -88,8 +80,6 @@ func (c CertificateManager) prepareResource(capp cappv1alpha1.Capp) (cmapi.Certi
 
 // CleanUp attempts to delete all Certificates associated with a given Capp resource.
 func (c CertificateManager) CleanUp(capp cappv1alpha1.Capp) error {
-	resourceManager := rclient.ResourceManagerClient{Ctx: c.Ctx, K8sclient: c.K8sclient, Log: c.Log}
-
 	certificates, err := c.getPreviousCertificates(capp)
 	if err != nil {
 		return err
@@ -106,7 +96,7 @@ func (c CertificateManager) CleanUp(capp cappv1alpha1.Capp) error {
 			}
 		}
 		cert := rclient.GetBareCertificate(certificate.Name, certificate.Namespace)
-		if err := resourceManager.DeleteResource(&cert); err != nil {
+		if err := c.DeleteResource(&cert); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
@@ -140,34 +130,26 @@ func (c CertificateManager) reconcileCertificate(capp cappv1alpha1.Capp) error {
 	}
 
 	certificate := cmapi.Certificate{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: c.Ctx, K8sclient: c.K8sclient, Log: c.Log}
 
 	if err := c.K8sclient.Get(c.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: certificateFromCapp.Name}, &certificate); err != nil {
 		if errors.IsNotFound(err) {
-			if err := c.createCertificate(capp, certificateFromCapp, resourceManager); err != nil {
-				return err
-			}
-
-			return nil
+			return createManagedResource(c.K8sclient, c.CreateResource, c.EventRecorder, &capp, &certificateFromCapp,
+				"Certificate", eventCappCertificateCreated, eventCappCertificateCreationFailed)
 		}
 		return fmt.Errorf("failed to get Certificate %q: %w", certificateFromCapp.Name, err)
 	}
 
 	orig := certificate.DeepCopy()
-	if err := controllerutil.SetOwnerReference(&capp, &certificate, c.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set Certificate owner reference: %w", err)
-	}
 	certificate.Spec = *certificateFromCapp.Spec.DeepCopy()
-
-	if !equality.Semantic.DeepEqual(orig.Spec, certificate.Spec) ||
-		!equality.Semantic.DeepEqual(orig.OwnerReferences, certificate.OwnerReferences) {
-		if err := resourceManager.UpdateResource(&certificate); err != nil {
-			return fmt.Errorf("update Certificate %q: %w", certificate.Name, err)
-		}
+	if err := ensureOwnerReference(c.K8sclient, &capp, &certificate, "Certificate"); err != nil {
+		return err
+	}
+	if err := updateManagedResourceIfNeeded(c.UpdateResource, &certificate, orig.Spec, certificate.Spec, orig.OwnerReferences); err != nil {
+		return fmt.Errorf("update Certificate %q: %w", certificate.Name, err)
 	}
 
 	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
-		if err := c.handlePreviousCertificates(capp, resourceManager, certificateFromCapp.Name); err != nil {
+		if err := c.handlePreviousCertificates(capp, certificateFromCapp.Name); err != nil {
 			return fmt.Errorf("failed to handle previous Certificates: %w", err)
 		}
 	}
@@ -175,28 +157,10 @@ func (c CertificateManager) reconcileCertificate(capp cappv1alpha1.Capp) error {
 	return nil
 }
 
-// createCertificate creates a new Certificate and emits an event.
-func (c CertificateManager) createCertificate(capp cappv1alpha1.Capp, certificateFromCapp cmapi.Certificate, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(&capp, &certificateFromCapp, c.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set Certificate owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(&certificateFromCapp); err != nil {
-		c.EventRecorder.Eventf(&capp, nil, corev1.EventTypeWarning, eventCappCertificateCreationFailed, eventCappCertificateCreationFailed,
-			fmt.Sprintf("Failed to create Certificate %s", certificateFromCapp.Name))
-
-		return err
-	}
-
-	c.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappCertificateCreated, eventCappCertificateCreated,
-		fmt.Sprintf("Created Certificate %s", certificateFromCapp.Name))
-
-	return nil
-}
-
 // handlePreviousCertificates takes care of removing unneeded Certificate objects. If the DNSRecord
 // which corresponds to the latest Certificate object is not yet available then return early
 // and do not delete the previous Certificates.
-func (c CertificateManager) handlePreviousCertificates(capp cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient, name string) error {
+func (c CertificateManager) handlePreviousCertificates(capp cappv1alpha1.Capp, name string) error {
 	var available bool
 	var err error
 
@@ -214,7 +178,7 @@ func (c CertificateManager) handlePreviousCertificates(capp cappv1alpha1.Capp, r
 		return err
 	}
 
-	return c.deletePreviousCertificates(certificates, resourceManager, capp.Spec.RouteSpec.Hostname)
+	return c.deletePreviousCertificates(certificates, capp.Spec.RouteSpec.Hostname)
 }
 
 // getPreviousCertificates returns a list of all Certificate objects that are related to the given Capp.
@@ -234,11 +198,11 @@ func (c CertificateManager) getPreviousCertificates(capp cappv1alpha1.Capp) (cma
 }
 
 // deletePreviousCertificates deletes all previous Certificates associated with a Capp.
-func (c CertificateManager) deletePreviousCertificates(certificates cmapi.CertificateList, resourceManager rclient.ResourceManagerClient, hostname string) error {
+func (c CertificateManager) deletePreviousCertificates(certificates cmapi.CertificateList, hostname string) error {
 	for _, certificate := range certificates.Items {
 		if certificate.Name != hostname {
 			cert := rclient.GetBareCertificate(certificate.Name, certificate.Namespace)
-			if err := resourceManager.DeleteResource(&cert); err != nil {
+			if err := c.DeleteResource(&cert); err != nil {
 				return err
 			}
 		}

--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -1,6 +1,7 @@
 package resourcemanagers
 
 import (
+	"context"
 	"fmt"
 
 	certv1alpha1 "github.com/dana-team/cert-external-issuer/api/v1alpha1"
@@ -34,8 +35,8 @@ type CertificateManager struct {
 }
 
 // prepareResource prepares a Certificate resource based on the provided Capp.
-func (c CertificateManager) prepareResource(capp cappv1alpha1.Capp) (cmapi.Certificate, error) {
-	dnsConfig, err := utils.GetDNSConfig(c.Ctx, c.K8sclient)
+func (c CertificateManager) prepareResource(ctx context.Context, capp cappv1alpha1.Capp) (cmapi.Certificate, error) {
+	dnsConfig, err := utils.GetDNSConfig(ctx, c.K8sclient)
 	if err != nil {
 		return cmapi.Certificate{}, err
 	}
@@ -79,8 +80,8 @@ func (c CertificateManager) prepareResource(capp cappv1alpha1.Capp) (cmapi.Certi
 }
 
 // CleanUp attempts to delete all Certificates associated with a given Capp resource.
-func (c CertificateManager) CleanUp(capp cappv1alpha1.Capp) error {
-	certificates, err := c.getPreviousCertificates(capp)
+func (c CertificateManager) CleanUp(ctx context.Context, capp cappv1alpha1.Capp) error {
+	certificates, err := c.getPreviousCertificates(ctx, capp)
 	if err != nil {
 		return err
 	}
@@ -96,7 +97,7 @@ func (c CertificateManager) CleanUp(capp cappv1alpha1.Capp) error {
 			}
 		}
 		cert := rclient.GetBareCertificate(certificate.Name, certificate.Namespace)
-		if err := c.DeleteResource(&cert); err != nil {
+		if err := c.DeleteResource(ctx, &cert); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
@@ -114,26 +115,26 @@ func (c CertificateManager) IsRequired(capp cappv1alpha1.Capp) bool {
 
 // Manage creates or updates a Certificate resource based on the provided Capp if it's required.
 // If it's not, then it cleans up the resource if it exists.
-func (c CertificateManager) Manage(capp cappv1alpha1.Capp) error {
+func (c CertificateManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) error {
 	if c.IsRequired(capp) {
-		return c.reconcileCertificate(capp)
+		return c.reconcileCertificate(ctx, capp)
 	}
 
-	return c.CleanUp(capp)
+	return c.CleanUp(ctx, capp)
 }
 
 // reconcileCertificate reconciles the cert-manager Certificate for this Capp.
-func (c CertificateManager) reconcileCertificate(capp cappv1alpha1.Capp) error {
-	certificateFromCapp, err := c.prepareResource(capp)
+func (c CertificateManager) reconcileCertificate(ctx context.Context, capp cappv1alpha1.Capp) error {
+	certificateFromCapp, err := c.prepareResource(ctx, capp)
 	if err != nil {
 		return fmt.Errorf("failed to prepare Certificate: %w", err)
 	}
 
 	certificate := cmapi.Certificate{}
 
-	if err := c.K8sclient.Get(c.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: certificateFromCapp.Name}, &certificate); err != nil {
+	if err := c.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: certificateFromCapp.Name}, &certificate); err != nil {
 		if errors.IsNotFound(err) {
-			return createManagedResource(c.K8sclient, c.CreateResource, c.EventRecorder, &capp, &certificateFromCapp,
+			return createManagedResource(ctx, c.K8sclient, c.CreateResource, c.EventRecorder, &capp, &certificateFromCapp,
 				"Certificate", eventCappCertificateCreated, eventCappCertificateCreationFailed)
 		}
 		return fmt.Errorf("failed to get Certificate %q: %w", certificateFromCapp.Name, err)
@@ -144,7 +145,7 @@ func (c CertificateManager) reconcileCertificate(capp cappv1alpha1.Capp) error {
 	if err := ensureOwnerReference(c.K8sclient, &capp, &certificate, "Certificate"); err != nil {
 		return err
 	}
-	if err := updateManagedResourceIfNeeded(c.UpdateResource, &certificate, orig.Spec, certificate.Spec, orig.OwnerReferences); err != nil {
+	if err := updateManagedResourceIfNeeded(ctx, c.UpdateResource, &certificate, orig.Spec, certificate.Spec, orig.OwnerReferences); err != nil {
 		return fmt.Errorf("update Certificate %q: %w", certificate.Name, err)
 	}
 
@@ -152,7 +153,7 @@ func (c CertificateManager) reconcileCertificate(capp cappv1alpha1.Capp) error {
 }
 
 // getPreviousCertificates returns a list of all Certificate objects that are related to the given Capp.
-func (c CertificateManager) getPreviousCertificates(capp cappv1alpha1.Capp) (cmapi.CertificateList, error) {
+func (c CertificateManager) getPreviousCertificates(ctx context.Context, capp cappv1alpha1.Capp) (cmapi.CertificateList, error) {
 	certificates := cmapi.CertificateList{}
 
 	set := labels.Set{
@@ -160,7 +161,7 @@ func (c CertificateManager) getPreviousCertificates(capp cappv1alpha1.Capp) (cma
 	}
 	listOptions := utils.GetListOptions(set)
 
-	if err := c.K8sclient.List(c.Ctx, &certificates, &listOptions); err != nil {
+	if err := c.K8sclient.List(ctx, &certificates, &listOptions); err != nil {
 		return certificates, fmt.Errorf("unable to list Certificates of Capp %q: %w", capp.Name, err)
 	}
 

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -1,6 +1,7 @@
 package resourcemanagers
 
 import (
+	"context"
 	"fmt"
 
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
@@ -33,8 +34,8 @@ type DNSRecordManager struct {
 }
 
 // prepareResource prepares a DNSRecord resource based on the provided Capp.
-func (r DNSRecordManager) prepareResource(capp cappv1alpha1.Capp) (dnsrecordv1alpha1.CNAMERecord, error) {
-	dnsConfig, err := utils.GetDNSConfig(r.Ctx, r.K8sclient)
+func (r DNSRecordManager) prepareResource(ctx context.Context, capp cappv1alpha1.Capp) (dnsrecordv1alpha1.CNAMERecord, error) {
+	dnsConfig, err := utils.GetDNSConfig(ctx, r.K8sclient)
 	if err != nil {
 		return dnsrecordv1alpha1.CNAMERecord{}, err
 	}
@@ -68,8 +69,8 @@ func (r DNSRecordManager) prepareResource(capp cappv1alpha1.Capp) (dnsrecordv1al
 }
 
 // CleanUp attempts to delete all DNSRecords associated with a given Capp resource.
-func (r DNSRecordManager) CleanUp(capp cappv1alpha1.Capp) error {
-	dnsRecords, err := r.getPreviousDNSRecords(capp)
+func (r DNSRecordManager) CleanUp(ctx context.Context, capp cappv1alpha1.Capp) error {
+	dnsRecords, err := r.getPreviousDNSRecords(ctx, capp)
 	if err != nil {
 		return err
 	}
@@ -85,7 +86,7 @@ func (r DNSRecordManager) CleanUp(capp cappv1alpha1.Capp) error {
 			}
 		}
 		bareRecord := rclient.GetBareDNSRecord(dnsRecord.Name, dnsRecord.Namespace)
-		if err := r.DeleteResource(&bareRecord); err != nil {
+		if err := r.DeleteResource(ctx, &bareRecord); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
@@ -103,36 +104,36 @@ func (r DNSRecordManager) IsRequired(capp cappv1alpha1.Capp) bool {
 
 // Manage creates or updates a DNSRecord resource based on the provided Capp if it's required.
 // If it's not, then it cleans up the resource if it exists.
-func (r DNSRecordManager) Manage(capp cappv1alpha1.Capp) error {
+func (r DNSRecordManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) error {
 	if r.IsRequired(capp) {
-		return r.createOrUpdate(capp)
+		return r.createOrUpdate(ctx, capp)
 	}
 
-	return r.CleanUp(capp)
+	return r.CleanUp(ctx, capp)
 }
 
 // createOrUpdate creates or updates a DNSRecord resource.
-func (r DNSRecordManager) createOrUpdate(capp cappv1alpha1.Capp) error {
-	dnsRecordFromCapp, err := r.prepareResource(capp)
+func (r DNSRecordManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.Capp) error {
+	dnsRecordFromCapp, err := r.prepareResource(ctx, capp)
 	if err != nil {
 		return fmt.Errorf("failed to prepare DNSRecord: %w", err)
 	}
 
 	dnsRecord := dnsrecordv1alpha1.CNAMERecord{}
 
-	if err := r.K8sclient.Get(r.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: dnsRecordFromCapp.Name}, &dnsRecord); err != nil {
+	if err := r.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: dnsRecordFromCapp.Name}, &dnsRecord); err != nil {
 		if errors.IsNotFound(err) {
-			return createManagedResource(r.K8sclient, r.CreateResource, r.EventRecorder, &capp, &dnsRecordFromCapp,
+			return createManagedResource(ctx, r.K8sclient, r.CreateResource, r.EventRecorder, &capp, &dnsRecordFromCapp,
 				"DNSRecord", eventCappDNSRecordCreated, eventCappDNSRecordCreationFailed)
 		}
 		return fmt.Errorf("failed to get DNSRecord %q: %w", dnsRecordFromCapp.Name, err)
 	}
 
-	return r.updateDNSRecord(dnsRecord, dnsRecordFromCapp, &capp)
+	return r.updateDNSRecord(ctx, dnsRecord, dnsRecordFromCapp, &capp)
 }
 
 // updateDNSRecord checks if an update to the DNSRecord is necessary and performs the update to match desired state.
-func (r DNSRecordManager) updateDNSRecord(dnsRecord, dnsRecordFromCapp dnsrecordv1alpha1.CNAMERecord, capp *cappv1alpha1.Capp) error {
+func (r DNSRecordManager) updateDNSRecord(ctx context.Context, dnsRecord, dnsRecordFromCapp dnsrecordv1alpha1.CNAMERecord, capp *cappv1alpha1.Capp) error {
 	needs, err := r.dnsRecordNeedsUpdate(dnsRecord, dnsRecordFromCapp, capp)
 	if err != nil {
 		return err
@@ -142,7 +143,7 @@ func (r DNSRecordManager) updateDNSRecord(dnsRecord, dnsRecordFromCapp dnsrecord
 	}
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latestRecord := dnsrecordv1alpha1.CNAMERecord{}
-		if err := r.K8sclient.Get(r.Ctx, types.NamespacedName{Namespace: dnsRecord.Namespace, Name: dnsRecord.Name}, &latestRecord); err != nil {
+		if err := r.K8sclient.Get(ctx, types.NamespacedName{Namespace: dnsRecord.Namespace, Name: dnsRecord.Name}, &latestRecord); err != nil {
 			return err
 		}
 
@@ -169,7 +170,7 @@ func (r DNSRecordManager) updateDNSRecord(dnsRecord, dnsRecordFromCapp dnsrecord
 			return nil
 		}
 
-		return r.UpdateResource(&latestRecord)
+		return r.UpdateResource(ctx, &latestRecord)
 	})
 }
 
@@ -186,7 +187,7 @@ func (r DNSRecordManager) dnsRecordNeedsUpdate(current, desired dnsrecordv1alpha
 }
 
 // getPreviousDNSRecords returns a list of all DNSRecord objects that are related to the given Capp.
-func (r DNSRecordManager) getPreviousDNSRecords(capp cappv1alpha1.Capp) (dnsrecordv1alpha1.CNAMERecordList, error) {
+func (r DNSRecordManager) getPreviousDNSRecords(ctx context.Context, capp cappv1alpha1.Capp) (dnsrecordv1alpha1.CNAMERecordList, error) {
 	dnsRecords := dnsrecordv1alpha1.CNAMERecordList{}
 
 	set := labels.Set{
@@ -196,7 +197,7 @@ func (r DNSRecordManager) getPreviousDNSRecords(capp cappv1alpha1.Capp) (dnsreco
 	listOptions := utils.GetListOptions(set)
 	listOptions.Namespace = capp.Namespace
 
-	if err := r.K8sclient.List(r.Ctx, &dnsRecords, &listOptions); err != nil {
+	if err := r.K8sclient.List(ctx, &dnsRecords, &listOptions); err != nil {
 		return dnsRecords, fmt.Errorf("unable to list DNSRecords of Capp %q: %w", capp.Name, err)
 	}
 

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -128,12 +128,6 @@ func (r DNSRecordManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 		return fmt.Errorf("failed to get DNSRecord %q: %w", dnsRecordFromCapp.Name, err)
 	}
 
-	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
-		if err := r.handlePreviousDNSRecords(capp, dnsRecordFromCapp.Name); err != nil {
-			return fmt.Errorf("failed to delete previous DNSRecords: %w", err)
-		}
-	}
-
 	return r.updateDNSRecord(dnsRecord, dnsRecordFromCapp, &capp)
 }
 
@@ -191,26 +185,6 @@ func (r DNSRecordManager) dnsRecordNeedsUpdate(current, desired dnsrecordv1alpha
 	return !ok, nil
 }
 
-// handlePreviousDNSRecords takes care of removing unneeded DNSRecord objects. If the new DNSRecord
-// is not yet available then return early and do not delete the previous Records.
-func (r DNSRecordManager) handlePreviousDNSRecords(capp cappv1alpha1.Capp, name string) error {
-	available, err := utils.IsDNSRecordAvailable(r.Ctx, r.K8sclient, name, capp.Namespace)
-	if err != nil {
-		return err
-	}
-
-	if !available {
-		return nil
-	}
-
-	dnsRecords, err := r.getPreviousDNSRecords(capp)
-	if err != nil {
-		return err
-	}
-
-	return r.deletePreviousDNSRecords(dnsRecords, capp.Spec.RouteSpec.Hostname)
-}
-
 // getPreviousDNSRecords returns a list of all DNSRecord objects that are related to the given Capp.
 func (r DNSRecordManager) getPreviousDNSRecords(capp cappv1alpha1.Capp) (dnsrecordv1alpha1.CNAMERecordList, error) {
 	dnsRecords := dnsrecordv1alpha1.CNAMERecordList{}
@@ -227,17 +201,4 @@ func (r DNSRecordManager) getPreviousDNSRecords(capp cappv1alpha1.Capp) (dnsreco
 	}
 
 	return dnsRecords, nil
-}
-
-// deletePreviousDNSRecords deletes all previous DNSRecords associated with a Capp.
-func (r DNSRecordManager) deletePreviousDNSRecords(dnsRecords dnsrecordv1alpha1.CNAMERecordList, hostname string) error {
-	for _, dnsRecord := range dnsRecords.Items {
-		if dnsRecord.Name != hostname {
-			recordset := rclient.GetBareDNSRecord(dnsRecord.Name, dnsRecord.Namespace)
-			if err := r.DeleteResource(&recordset); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -1,7 +1,6 @@
 package resourcemanagers
 
 import (
-	"context"
 	"fmt"
 
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
@@ -10,8 +9,6 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
-	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,7 +17,6 @@ import (
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/retry"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -32,9 +28,7 @@ const (
 )
 
 type DNSRecordManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -75,8 +69,6 @@ func (r DNSRecordManager) prepareResource(capp cappv1alpha1.Capp) (dnsrecordv1al
 
 // CleanUp attempts to delete all DNSRecords associated with a given Capp resource.
 func (r DNSRecordManager) CleanUp(capp cappv1alpha1.Capp) error {
-	resourceManager := rclient.ResourceManagerClient{Ctx: r.Ctx, K8sclient: r.K8sclient, Log: r.Log}
-
 	dnsRecords, err := r.getPreviousDNSRecords(capp)
 	if err != nil {
 		return err
@@ -93,7 +85,7 @@ func (r DNSRecordManager) CleanUp(capp cappv1alpha1.Capp) error {
 			}
 		}
 		bareRecord := rclient.GetBareDNSRecord(dnsRecord.Name, dnsRecord.Namespace)
-		if err := resourceManager.DeleteResource(&bareRecord); err != nil {
+		if err := r.DeleteResource(&bareRecord); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
@@ -127,45 +119,26 @@ func (r DNSRecordManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 	}
 
 	dnsRecord := dnsrecordv1alpha1.CNAMERecord{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: r.Ctx, K8sclient: r.K8sclient, Log: r.Log}
 
 	if err := r.K8sclient.Get(r.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: dnsRecordFromCapp.Name}, &dnsRecord); err != nil {
 		if errors.IsNotFound(err) {
-			return r.createDNSRecord(capp, dnsRecordFromCapp, resourceManager)
-		} else {
-			return fmt.Errorf("failed to get DNSRecord %q: %w", dnsRecordFromCapp.Name, err)
+			return createManagedResource(r.K8sclient, r.CreateResource, r.EventRecorder, &capp, &dnsRecordFromCapp,
+				"DNSRecord", eventCappDNSRecordCreated, eventCappDNSRecordCreationFailed)
 		}
+		return fmt.Errorf("failed to get DNSRecord %q: %w", dnsRecordFromCapp.Name, err)
 	}
 
 	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
-		if err := r.handlePreviousDNSRecords(capp, resourceManager, dnsRecordFromCapp.Name); err != nil {
+		if err := r.handlePreviousDNSRecords(capp, dnsRecordFromCapp.Name); err != nil {
 			return fmt.Errorf("failed to delete previous DNSRecords: %w", err)
 		}
 	}
 
-	return r.updateDNSRecord(dnsRecord, dnsRecordFromCapp, &capp, resourceManager)
-}
-
-// createDNSRecord creates a new DNSRecord and emits an event.
-func (r DNSRecordManager) createDNSRecord(capp cappv1alpha1.Capp, dnsRecordFromCapp dnsrecordv1alpha1.CNAMERecord, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(&capp, &dnsRecordFromCapp, r.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set DNSRecord owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(&dnsRecordFromCapp); err != nil {
-		r.EventRecorder.Eventf(&capp, nil, corev1.EventTypeWarning, eventCappDNSRecordCreationFailed, eventCappDNSRecordCreationFailed,
-			fmt.Sprintf("Failed to create DNSRecord %s", dnsRecordFromCapp.Name))
-
-		return err
-	}
-
-	r.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappDNSRecordCreated, eventCappDNSRecordCreated,
-		fmt.Sprintf("Created DNSRecord %s", dnsRecordFromCapp.Name))
-
-	return nil
+	return r.updateDNSRecord(dnsRecord, dnsRecordFromCapp, &capp)
 }
 
 // updateDNSRecord checks if an update to the DNSRecord is necessary and performs the update to match desired state.
-func (r DNSRecordManager) updateDNSRecord(dnsRecord, dnsRecordFromCapp dnsrecordv1alpha1.CNAMERecord, capp *cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient) error {
+func (r DNSRecordManager) updateDNSRecord(dnsRecord, dnsRecordFromCapp dnsrecordv1alpha1.CNAMERecord, capp *cappv1alpha1.Capp) error {
 	needs, err := r.dnsRecordNeedsUpdate(dnsRecord, dnsRecordFromCapp, capp)
 	if err != nil {
 		return err
@@ -188,8 +161,8 @@ func (r DNSRecordManager) updateDNSRecord(dnsRecord, dnsRecordFromCapp dnsrecord
 		}
 
 		orig := latestRecord.DeepCopy()
-		if err := controllerutil.SetOwnerReference(capp, &latestRecord, r.K8sclient.Scheme()); err != nil {
-			return fmt.Errorf("set DNSRecord owner reference: %w", err)
+		if err := ensureOwnerReference(r.K8sclient, capp, &latestRecord, "DNSRecord"); err != nil {
+			return err
 		}
 		latestRecord.Spec.ForProvider = *dnsRecordFromCapp.Spec.ForProvider.DeepCopy()
 		if dnsRecordFromCapp.Spec.ProviderConfigReference != nil {
@@ -198,12 +171,11 @@ func (r DNSRecordManager) updateDNSRecord(dnsRecord, dnsRecordFromCapp dnsrecord
 			latestRecord.Spec.ProviderConfigReference = nil
 		}
 
-		if equality.Semantic.DeepEqual(orig.Spec, latestRecord.Spec) &&
-			equality.Semantic.DeepEqual(orig.OwnerReferences, latestRecord.OwnerReferences) {
+		if !managedResourceNeedsUpdate(orig.Spec, latestRecord.Spec, orig.OwnerReferences, latestRecord.OwnerReferences) {
 			return nil
 		}
 
-		return resourceManager.UpdateResource(&latestRecord)
+		return r.UpdateResource(&latestRecord)
 	})
 }
 
@@ -221,7 +193,7 @@ func (r DNSRecordManager) dnsRecordNeedsUpdate(current, desired dnsrecordv1alpha
 
 // handlePreviousDNSRecords takes care of removing unneeded DNSRecord objects. If the new DNSRecord
 // is not yet available then return early and do not delete the previous Records.
-func (r DNSRecordManager) handlePreviousDNSRecords(capp cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient, name string) error {
+func (r DNSRecordManager) handlePreviousDNSRecords(capp cappv1alpha1.Capp, name string) error {
 	available, err := utils.IsDNSRecordAvailable(r.Ctx, r.K8sclient, name, capp.Namespace)
 	if err != nil {
 		return err
@@ -236,7 +208,7 @@ func (r DNSRecordManager) handlePreviousDNSRecords(capp cappv1alpha1.Capp, resou
 		return err
 	}
 
-	return r.deletePreviousDNSRecords(dnsRecords, resourceManager, capp.Spec.RouteSpec.Hostname)
+	return r.deletePreviousDNSRecords(dnsRecords, capp.Spec.RouteSpec.Hostname)
 }
 
 // getPreviousDNSRecords returns a list of all DNSRecord objects that are related to the given Capp.
@@ -258,11 +230,11 @@ func (r DNSRecordManager) getPreviousDNSRecords(capp cappv1alpha1.Capp) (dnsreco
 }
 
 // deletePreviousDNSRecords deletes all previous DNSRecords associated with a Capp.
-func (r DNSRecordManager) deletePreviousDNSRecords(dnsRecords dnsrecordv1alpha1.CNAMERecordList, resourceManager rclient.ResourceManagerClient, hostname string) error {
+func (r DNSRecordManager) deletePreviousDNSRecords(dnsRecords dnsrecordv1alpha1.CNAMERecordList, hostname string) error {
 	for _, dnsRecord := range dnsRecords.Items {
 		if dnsRecord.Name != hostname {
 			recordset := rclient.GetBareDNSRecord(dnsRecord.Name, dnsRecord.Namespace)
-			if err := resourceManager.DeleteResource(&recordset); err != nil {
+			if err := r.DeleteResource(&recordset); err != nil {
 				return err
 			}
 		}

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -1,7 +1,6 @@
 package resourcemanagers
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
@@ -9,9 +8,7 @@ import (
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -32,9 +29,7 @@ const (
 )
 
 type KnativeDomainMappingManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -78,9 +73,8 @@ func (k KnativeDomainMappingManager) prepareResource(capp cappv1alpha1.Capp) (kn
 // setHTTPSKnativeDomainMapping sets the DomainMapping TLS based on Capp.
 func (k KnativeDomainMappingManager) setHTTPSKnativeDomainMapping(secretName, secretNamespace string, knativeDomainMapping *knativev1beta1.DomainMapping) error {
 	tlsSecret := corev1.Secret{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: k.Ctx, K8sclient: k.K8sclient, Log: k.Log}
 
-	if err := resourceManager.K8sclient.Get(resourceManager.Ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, &tlsSecret); err != nil {
+	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, &tlsSecret); err != nil {
 		if errors.IsNotFound(err) {
 			k.Log.Info("tlsSecret does not yet exist", "secretName", secretName)
 			return nil
@@ -97,8 +91,6 @@ func (k KnativeDomainMappingManager) setHTTPSKnativeDomainMapping(secretName, se
 
 // CleanUp attempts to delete the associated DomainMappings and tls secrets for a given Capp resource.
 func (k KnativeDomainMappingManager) CleanUp(capp cappv1alpha1.Capp) error {
-	resourceManager := rclient.ResourceManagerClient{Ctx: k.Ctx, K8sclient: k.K8sclient, Log: k.Log}
-
 	domainMappings, err := k.getPreviousDomainMappings(capp)
 	if err != nil {
 		return err
@@ -121,13 +113,13 @@ func (k KnativeDomainMappingManager) CleanUp(capp cappv1alpha1.Capp) error {
 				continue
 			}
 		}
-		if err := resourceManager.DeleteResource(&dm); err != nil {
+		if err := k.DeleteResource(&dm); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
 			return err
 		}
-		if err := deleteTLSSecret(resourceManager, utils.GenerateSecretName(dm.Name), dm.Namespace); err != nil {
+		if err := k.deleteTLSSecret(utils.GenerateSecretName(dm.Name), dm.Namespace); err != nil {
 			return err
 		}
 	}
@@ -158,61 +150,33 @@ func (k KnativeDomainMappingManager) createOrUpdate(capp cappv1alpha1.Capp) erro
 	}
 
 	domainMapping := knativev1beta1.DomainMapping{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: k.Ctx, K8sclient: k.K8sclient, Log: k.Log}
 
 	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: domainMappingFromCapp.Name}, &domainMapping); err != nil {
 		if errors.IsNotFound(err) {
-			return k.createDomainMapping(&capp, domainMappingFromCapp, resourceManager)
-		} else {
-			return fmt.Errorf("failed to get DomainMapping %q: %w", domainMappingFromCapp.Name, err)
+			return createManagedResource(k.K8sclient, k.CreateResource, k.EventRecorder, &capp, &domainMappingFromCapp,
+				"DomainMapping", eventCappDomainMappingCreated, eventCappDomainMappingCreationFailed)
 		}
+		return fmt.Errorf("failed to get DomainMapping %q: %w", domainMappingFromCapp.Name, err)
 	}
 
 	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
-		if err := k.handlePreviousDomainMappings(capp, resourceManager, domainMappingFromCapp.Name); err != nil {
+		if err := k.handlePreviousDomainMappings(capp, domainMappingFromCapp.Name); err != nil {
 			return fmt.Errorf("failed to delete previous DomainMappings: %w", err)
 		}
 	}
 
-	return k.updateDomainMapping(&domainMapping, domainMappingFromCapp, &capp, resourceManager)
-}
-
-// createDomainMapping creates a new DomainMapping and emits an event.
-func (k KnativeDomainMappingManager) createDomainMapping(capp *cappv1alpha1.Capp, domainMappingFromCapp knativev1beta1.DomainMapping, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(capp, &domainMappingFromCapp, k.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set DomainMapping owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(&domainMappingFromCapp); err != nil {
-		k.EventRecorder.Eventf(capp, nil, corev1.EventTypeWarning, eventCappDomainMappingCreationFailed, eventCappDomainMappingCreationFailed,
-			fmt.Sprintf("Failed to create DomainMapping %s", domainMappingFromCapp.Name))
-
+	orig := domainMapping.DeepCopy()
+	domainMapping.Spec = domainMappingFromCapp.Spec
+	if err := ensureOwnerReference(k.K8sclient, &capp, &domainMapping, "DomainMapping"); err != nil {
 		return err
 	}
-
-	k.EventRecorder.Eventf(capp, nil, corev1.EventTypeNormal, eventCappDomainMappingCreated, eventCappDomainMappingCreated,
-		fmt.Sprintf("Created DomainMapping %s", domainMappingFromCapp.Name))
-
-	return nil
-}
-
-// updateDomainMapping checks if an update to the DomainMapping is necessary and performs the update to match desired state.
-func (k KnativeDomainMappingManager) updateDomainMapping(knativeDomainMapping *knativev1beta1.DomainMapping, domainMappingFromCapp knativev1beta1.DomainMapping, capp *cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient) error {
-	orig := knativeDomainMapping.DeepCopy()
-	if err := controllerutil.SetOwnerReference(capp, knativeDomainMapping, k.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set DomainMapping owner reference: %w", err)
-	}
-	knativeDomainMapping.Spec = domainMappingFromCapp.Spec
-	if equality.Semantic.DeepEqual(orig.Spec, knativeDomainMapping.Spec) &&
-		equality.Semantic.DeepEqual(orig.OwnerReferences, knativeDomainMapping.OwnerReferences) {
-		return nil
-	}
-	return resourceManager.UpdateResource(knativeDomainMapping)
+	return updateManagedResourceIfNeeded(k.UpdateResource, &domainMapping, orig.Spec, domainMapping.Spec, orig.OwnerReferences)
 }
 
 // handlePreviousDomainMappings takes care of removing unneeded DomainMapping objects. If the DNSRecord
 // which corresponds to the latest DomainMapping object is not yet available then return early
 // and do not delete the previous DomainMappings.
-func (k KnativeDomainMappingManager) handlePreviousDomainMappings(capp cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient, name string) error {
+func (k KnativeDomainMappingManager) handlePreviousDomainMappings(capp cappv1alpha1.Capp, name string) error {
 	var available bool
 	var err error
 
@@ -230,7 +194,7 @@ func (k KnativeDomainMappingManager) handlePreviousDomainMappings(capp cappv1alp
 		return err
 	}
 
-	return k.deletePreviousDomainMappings(domainMappings, resourceManager, capp.Spec.RouteSpec.Hostname)
+	return k.deletePreviousDomainMappings(domainMappings, capp.Spec.RouteSpec.Hostname)
 }
 
 // getPreviousDomainMappings returns a list of all DomainMapping objects that are related to the given Capp.
@@ -250,14 +214,14 @@ func (k KnativeDomainMappingManager) getPreviousDomainMappings(capp cappv1alpha1
 }
 
 // deletePreviousDomainMappings deletes all previous DomainMappings associated with a Capp.
-func (k KnativeDomainMappingManager) deletePreviousDomainMappings(knativeDomainMappings knativev1beta1.DomainMappingList, resourceManager rclient.ResourceManagerClient, hostname string) error {
+func (k KnativeDomainMappingManager) deletePreviousDomainMappings(knativeDomainMappings knativev1beta1.DomainMappingList, hostname string) error {
 	for _, domainMapping := range knativeDomainMappings.Items {
 		if domainMapping.Name != hostname {
 			dm := rclient.GetBareDomainMapping(domainMapping.Name, domainMapping.Namespace)
-			if err := resourceManager.DeleteResource(&dm); err != nil {
+			if err := k.DeleteResource(&dm); err != nil {
 				return err
 			}
-			if err := deleteTLSSecret(resourceManager, utils.GenerateSecretName(domainMapping.Name), domainMapping.Namespace); err != nil {
+			if err := k.deleteTLSSecret(utils.GenerateSecretName(domainMapping.Name), domainMapping.Namespace); err != nil {
 				return err
 			}
 		}
@@ -266,13 +230,13 @@ func (k KnativeDomainMappingManager) deletePreviousDomainMappings(knativeDomainM
 }
 
 // deleteTLSSecret deletes the tls secret associated with the DomainMapping.
-func deleteTLSSecret(resourceManager rclient.ResourceManagerClient, secretName, namespace string) error {
+func (k KnativeDomainMappingManager) deleteTLSSecret(secretName, namespace string) error {
 	secret := corev1.Secret{}
-	if err := resourceManager.K8sclient.Get(resourceManager.Ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &secret); err != nil {
+	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &secret); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
-	return resourceManager.DeleteResource(&secret)
+	return k.DeleteResource(&secret)
 }

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -159,42 +159,12 @@ func (k KnativeDomainMappingManager) createOrUpdate(capp cappv1alpha1.Capp) erro
 		return fmt.Errorf("failed to get DomainMapping %q: %w", domainMappingFromCapp.Name, err)
 	}
 
-	if capp.Status.RouteStatus.DomainMappingObjectStatus.URL != nil {
-		if err := k.handlePreviousDomainMappings(capp, domainMappingFromCapp.Name); err != nil {
-			return fmt.Errorf("failed to delete previous DomainMappings: %w", err)
-		}
-	}
-
 	orig := domainMapping.DeepCopy()
 	domainMapping.Spec = domainMappingFromCapp.Spec
 	if err := ensureOwnerReference(k.K8sclient, &capp, &domainMapping, "DomainMapping"); err != nil {
 		return err
 	}
 	return updateManagedResourceIfNeeded(k.UpdateResource, &domainMapping, orig.Spec, domainMapping.Spec, orig.OwnerReferences)
-}
-
-// handlePreviousDomainMappings takes care of removing unneeded DomainMapping objects. If the DNSRecord
-// which corresponds to the latest DomainMapping object is not yet available then return early
-// and do not delete the previous DomainMappings.
-func (k KnativeDomainMappingManager) handlePreviousDomainMappings(capp cappv1alpha1.Capp, name string) error {
-	var available bool
-	var err error
-
-	available, err = utils.IsDNSRecordAvailable(k.Ctx, k.K8sclient, name, capp.Namespace)
-	if err != nil {
-		return err
-	}
-
-	if !available {
-		return nil
-	}
-
-	domainMappings, err := k.getPreviousDomainMappings(capp)
-	if err != nil {
-		return err
-	}
-
-	return k.deletePreviousDomainMappings(domainMappings, capp.Spec.RouteSpec.Hostname)
 }
 
 // getPreviousDomainMappings returns a list of all DomainMapping objects that are related to the given Capp.
@@ -211,22 +181,6 @@ func (k KnativeDomainMappingManager) getPreviousDomainMappings(capp cappv1alpha1
 	}
 
 	return knativeDomainMappings, nil
-}
-
-// deletePreviousDomainMappings deletes all previous DomainMappings associated with a Capp.
-func (k KnativeDomainMappingManager) deletePreviousDomainMappings(knativeDomainMappings knativev1beta1.DomainMappingList, hostname string) error {
-	for _, domainMapping := range knativeDomainMappings.Items {
-		if domainMapping.Name != hostname {
-			dm := rclient.GetBareDomainMapping(domainMapping.Name, domainMapping.Namespace)
-			if err := k.DeleteResource(&dm); err != nil {
-				return err
-			}
-			if err := k.deleteTLSSecret(utils.GenerateSecretName(domainMapping.Name), domainMapping.Namespace); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 // deleteTLSSecret deletes the tls secret associated with the DomainMapping.

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -1,6 +1,7 @@
 package resourcemanagers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
@@ -34,8 +35,8 @@ type KnativeDomainMappingManager struct {
 }
 
 // PrepareKnativeDomainMapping creates a new DomainMapping for a Knative service.
-func (k KnativeDomainMappingManager) prepareResource(capp cappv1alpha1.Capp) (knativev1beta1.DomainMapping, error) {
-	dnsConfig, err := utils.GetDNSConfig(k.Ctx, k.K8sclient)
+func (k KnativeDomainMappingManager) prepareResource(ctx context.Context, capp cappv1alpha1.Capp) (knativev1beta1.DomainMapping, error) {
+	dnsConfig, err := utils.GetDNSConfig(ctx, k.K8sclient)
 	if err != nil {
 		return knativev1beta1.DomainMapping{}, err
 	}
@@ -60,7 +61,7 @@ func (k KnativeDomainMappingManager) prepareResource(capp cappv1alpha1.Capp) (kn
 	}
 
 	if tlsEnabled := capp.Spec.RouteSpec.TlsEnabled; tlsEnabled {
-		if err := k.setHTTPSKnativeDomainMapping(secretName, capp.Namespace, knativeDomainMapping); err != nil {
+		if err := k.setHTTPSKnativeDomainMapping(ctx, secretName, capp.Namespace, knativeDomainMapping); err != nil {
 			if !errors.IsNotFound(err) {
 				return *knativeDomainMapping, err
 			}
@@ -71,10 +72,10 @@ func (k KnativeDomainMappingManager) prepareResource(capp cappv1alpha1.Capp) (kn
 }
 
 // setHTTPSKnativeDomainMapping sets the DomainMapping TLS based on Capp.
-func (k KnativeDomainMappingManager) setHTTPSKnativeDomainMapping(secretName, secretNamespace string, knativeDomainMapping *knativev1beta1.DomainMapping) error {
+func (k KnativeDomainMappingManager) setHTTPSKnativeDomainMapping(ctx context.Context, secretName, secretNamespace string, knativeDomainMapping *knativev1beta1.DomainMapping) error {
 	tlsSecret := corev1.Secret{}
 
-	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, &tlsSecret); err != nil {
+	if err := k.K8sclient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, &tlsSecret); err != nil {
 		if errors.IsNotFound(err) {
 			k.Log.Info("tlsSecret does not yet exist", "secretName", secretName)
 			return nil
@@ -90,15 +91,15 @@ func (k KnativeDomainMappingManager) setHTTPSKnativeDomainMapping(secretName, se
 }
 
 // CleanUp attempts to delete the associated DomainMappings and tls secrets for a given Capp resource.
-func (k KnativeDomainMappingManager) CleanUp(capp cappv1alpha1.Capp) error {
-	domainMappings, err := k.getPreviousDomainMappings(capp)
+func (k KnativeDomainMappingManager) CleanUp(ctx context.Context, capp cappv1alpha1.Capp) error {
+	domainMappings, err := k.getPreviousDomainMappings(ctx, capp)
 	if err != nil {
 		return err
 	}
 
 	for _, item := range domainMappings.Items {
 		var dm knativev1beta1.DomainMapping
-		if err := k.K8sclient.Get(k.Ctx, client.ObjectKeyFromObject(&item), &dm); err != nil {
+		if err := k.K8sclient.Get(ctx, client.ObjectKeyFromObject(&item), &dm); err != nil {
 			if err := client.IgnoreNotFound(err); err != nil {
 				return err
 			}
@@ -113,13 +114,13 @@ func (k KnativeDomainMappingManager) CleanUp(capp cappv1alpha1.Capp) error {
 				continue
 			}
 		}
-		if err := k.DeleteResource(&dm); err != nil {
+		if err := k.DeleteResource(ctx, &dm); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
 			return err
 		}
-		if err := k.deleteTLSSecret(utils.GenerateSecretName(dm.Name), dm.Namespace); err != nil {
+		if err := k.deleteTLSSecret(ctx, utils.GenerateSecretName(dm.Name), dm.Namespace); err != nil {
 			return err
 		}
 	}
@@ -134,26 +135,26 @@ func (k KnativeDomainMappingManager) IsRequired(capp cappv1alpha1.Capp) bool {
 
 // Manage creates or updates a DomainMapping resource based on the provided Capp if it's required.
 // If it's not, then it cleans up the resource if it exists.
-func (k KnativeDomainMappingManager) Manage(capp cappv1alpha1.Capp) error {
+func (k KnativeDomainMappingManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) error {
 	if k.IsRequired(capp) {
-		return k.createOrUpdate(capp)
+		return k.createOrUpdate(ctx, capp)
 	}
 
-	return k.CleanUp(capp)
+	return k.CleanUp(ctx, capp)
 }
 
 // createOrUpdate creates or updates a DomainMapping resource.
-func (k KnativeDomainMappingManager) createOrUpdate(capp cappv1alpha1.Capp) error {
-	domainMappingFromCapp, err := k.prepareResource(capp)
+func (k KnativeDomainMappingManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.Capp) error {
+	domainMappingFromCapp, err := k.prepareResource(ctx, capp)
 	if err != nil {
 		return fmt.Errorf("failed to prepare DomainMapping: %w", err)
 	}
 
 	domainMapping := knativev1beta1.DomainMapping{}
 
-	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: domainMappingFromCapp.Name}, &domainMapping); err != nil {
+	if err := k.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: domainMappingFromCapp.Name}, &domainMapping); err != nil {
 		if errors.IsNotFound(err) {
-			return createManagedResource(k.K8sclient, k.CreateResource, k.EventRecorder, &capp, &domainMappingFromCapp,
+			return createManagedResource(ctx, k.K8sclient, k.CreateResource, k.EventRecorder, &capp, &domainMappingFromCapp,
 				"DomainMapping", eventCappDomainMappingCreated, eventCappDomainMappingCreationFailed)
 		}
 		return fmt.Errorf("failed to get DomainMapping %q: %w", domainMappingFromCapp.Name, err)
@@ -164,11 +165,11 @@ func (k KnativeDomainMappingManager) createOrUpdate(capp cappv1alpha1.Capp) erro
 	if err := ensureOwnerReference(k.K8sclient, &capp, &domainMapping, "DomainMapping"); err != nil {
 		return err
 	}
-	return updateManagedResourceIfNeeded(k.UpdateResource, &domainMapping, orig.Spec, domainMapping.Spec, orig.OwnerReferences)
+	return updateManagedResourceIfNeeded(ctx, k.UpdateResource, &domainMapping, orig.Spec, domainMapping.Spec, orig.OwnerReferences)
 }
 
 // getPreviousDomainMappings returns a list of all DomainMapping objects that are related to the given Capp.
-func (k KnativeDomainMappingManager) getPreviousDomainMappings(capp cappv1alpha1.Capp) (knativev1beta1.DomainMappingList, error) {
+func (k KnativeDomainMappingManager) getPreviousDomainMappings(ctx context.Context, capp cappv1alpha1.Capp) (knativev1beta1.DomainMappingList, error) {
 	knativeDomainMappings := knativev1beta1.DomainMappingList{}
 
 	set := labels.Set{
@@ -176,7 +177,7 @@ func (k KnativeDomainMappingManager) getPreviousDomainMappings(capp cappv1alpha1
 	}
 
 	listOptions := utils.GetListOptions(set)
-	if err := k.K8sclient.List(k.Ctx, &knativeDomainMappings, &listOptions); err != nil {
+	if err := k.K8sclient.List(ctx, &knativeDomainMappings, &listOptions); err != nil {
 		return knativeDomainMappings, fmt.Errorf("unable to list DomainMappings of Capp %q: %w", capp.Name, err)
 	}
 
@@ -184,13 +185,13 @@ func (k KnativeDomainMappingManager) getPreviousDomainMappings(capp cappv1alpha1
 }
 
 // deleteTLSSecret deletes the tls secret associated with the DomainMapping.
-func (k KnativeDomainMappingManager) deleteTLSSecret(secretName, namespace string) error {
+func (k KnativeDomainMappingManager) deleteTLSSecret(ctx context.Context, secretName, namespace string) error {
 	secret := corev1.Secret{}
-	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &secret); err != nil {
+	if err := k.K8sclient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &secret); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
-	return k.DeleteResource(&secret)
+	return k.DeleteResource(ctx, &secret)
 }

--- a/internal/kinds/capp/resourcemanagers/helpers.go
+++ b/internal/kinds/capp/resourcemanagers/helpers.go
@@ -1,0 +1,53 @@
+package resourcemanagers
+
+import (
+	"fmt"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func ensureOwnerReference(k8s client.Client, capp *cappv1alpha1.Capp, obj client.Object, kind string) error {
+	if err := controllerutil.SetOwnerReference(capp, obj, k8s.Scheme()); err != nil {
+		return fmt.Errorf("set %s owner reference: %w", kind, err)
+	}
+	return nil
+}
+
+func createManagedResource(
+	k8s client.Client,
+	create func(client.Object) error,
+	recorder events.EventRecorder,
+	capp *cappv1alpha1.Capp,
+	obj client.Object,
+	kind, eventCreated, eventFailed string,
+) error {
+	if err := ensureOwnerReference(k8s, capp, obj, kind); err != nil {
+		return err
+	}
+	if err := create(obj); err != nil {
+		recorder.Eventf(capp, nil, corev1.EventTypeWarning, eventFailed, eventFailed,
+			fmt.Sprintf("Failed to create %s %s", kind, obj.GetName()))
+		return err
+	}
+	recorder.Eventf(capp, nil, corev1.EventTypeNormal, eventCreated, eventCreated,
+		fmt.Sprintf("Created %s %s", kind, obj.GetName()))
+	return nil
+}
+
+func managedResourceNeedsUpdate(origSpec, newSpec any, origOwners, newOwners []metav1.OwnerReference) bool {
+	return !equality.Semantic.DeepEqual(origSpec, newSpec) ||
+		!equality.Semantic.DeepEqual(origOwners, newOwners)
+}
+
+func updateManagedResourceIfNeeded(update func(client.Object) error, obj client.Object, origSpec, newSpec any, origOwners []metav1.OwnerReference) error {
+	if !managedResourceNeedsUpdate(origSpec, newSpec, origOwners, obj.GetOwnerReferences()) {
+		return nil
+	}
+	return update(obj)
+}

--- a/internal/kinds/capp/resourcemanagers/helpers.go
+++ b/internal/kinds/capp/resourcemanagers/helpers.go
@@ -1,6 +1,7 @@
 package resourcemanagers
 
 import (
+	"context"
 	"fmt"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
@@ -20,8 +21,9 @@ func ensureOwnerReference(k8s client.Client, capp *cappv1alpha1.Capp, obj client
 }
 
 func createManagedResource(
+	ctx context.Context,
 	k8s client.Client,
-	create func(client.Object) error,
+	create func(context.Context, client.Object) error,
 	recorder events.EventRecorder,
 	capp *cappv1alpha1.Capp,
 	obj client.Object,
@@ -30,7 +32,7 @@ func createManagedResource(
 	if err := ensureOwnerReference(k8s, capp, obj, kind); err != nil {
 		return err
 	}
-	if err := create(obj); err != nil {
+	if err := create(ctx, obj); err != nil {
 		recorder.Eventf(capp, nil, corev1.EventTypeWarning, eventFailed, eventFailed,
 			fmt.Sprintf("Failed to create %s %s", kind, obj.GetName()))
 		return err
@@ -45,9 +47,9 @@ func managedResourceNeedsUpdate(origSpec, newSpec any, origOwners, newOwners []m
 		!equality.Semantic.DeepEqual(origOwners, newOwners)
 }
 
-func updateManagedResourceIfNeeded(update func(client.Object) error, obj client.Object, origSpec, newSpec any, origOwners []metav1.OwnerReference) error {
+func updateManagedResourceIfNeeded(ctx context.Context, update func(context.Context, client.Object) error, obj client.Object, origSpec, newSpec any, origOwners []metav1.OwnerReference) error {
 	if !managedResourceNeedsUpdate(origSpec, newSpec, origOwners, obj.GetOwnerReferences()) {
 		return nil
 	}
-	return update(obj)
+	return update(ctx, obj)
 }

--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -10,9 +10,7 @@ import (
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,9 +35,7 @@ const (
 )
 
 type KnativeServiceManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -119,8 +115,7 @@ func (k KnativeServiceManager) CleanUp(capp cappv1alpha1.Capp) error {
 			return err
 		}
 	}
-	rm := rclient.ResourceManagerClient{Ctx: k.Ctx, K8sclient: k.K8sclient, Log: k.Log}
-	return client.IgnoreNotFound(rm.DeleteResource(&ksvc))
+	return client.IgnoreNotFound(k.DeleteResource(&ksvc))
 }
 
 // IsRequired determines if a Knative service (ksvc) is required based on the Capp's spec.
@@ -156,11 +151,11 @@ func (k KnativeServiceManager) Manage(capp cappv1alpha1.Capp) error {
 func (k KnativeServiceManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 	knativeServiceFromCapp := k.prepareResource(capp, k.Ctx)
 	knativeService := knativev1.Service{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: k.Ctx, K8sclient: k.K8sclient, Log: k.Log}
 
 	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, &knativeService); err != nil {
 		if errors.IsNotFound(err) {
-			if err := k.createKSVC(&capp, &knativeServiceFromCapp, resourceManager); err != nil {
+			if err := createManagedResource(k.K8sclient, k.CreateResource, k.EventRecorder, &capp, &knativeServiceFromCapp,
+				"KnativeService", eventCappKnativeServiceCreated, eventCappKnativeServiceCreationFailed); err != nil {
 				return err
 			}
 
@@ -169,48 +164,21 @@ func (k KnativeServiceManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 				k.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappEnabled, eventCappEnabled, fmt.Sprintf("Capp %q state changed to enabled", capp.Name))
 			}
 			return nil
-		} else {
-			return fmt.Errorf("failed to get KnativeService %q: %w", knativeService.Name, err)
 		}
+		return fmt.Errorf("failed to get KnativeService %q: %w", knativeService.Name, err)
 	}
 
-	return k.updateKSVC(&knativeService, &knativeServiceFromCapp, &capp, resourceManager)
-}
-
-// createKSVC creates a new knativeService and emits an event.
-func (k KnativeServiceManager) createKSVC(capp *cappv1alpha1.Capp, knativeServiceFromCapp *knativev1.Service, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(capp, knativeServiceFromCapp, k.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set Knative Service owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(knativeServiceFromCapp); err != nil {
-		k.EventRecorder.Eventf(capp, nil, corev1.EventTypeWarning, eventCappKnativeServiceCreationFailed, eventCappKnativeServiceCreationFailed,
-			fmt.Sprintf("Failed to create KnativeService %s", knativeServiceFromCapp.Name))
+	orig := knativeService.DeepCopy()
+	knativeService.Spec = knativeServiceFromCapp.Spec
+	if err := ensureOwnerReference(k.K8sclient, &capp, &knativeService, "Knative Service"); err != nil {
 		return err
 	}
-
-	k.EventRecorder.Eventf(capp, nil, corev1.EventTypeNormal, eventCappKnativeServiceCreated, eventCappKnativeServiceCreated,
-		fmt.Sprintf("Created KnativeService %s", knativeServiceFromCapp.Name))
-
-	return nil
-}
-
-// updateKSVC checks if an update to the KnativeService is necessary and performs the update to match desired state.
-func (k KnativeServiceManager) updateKSVC(knativeService, knativeServiceFromCapp *knativev1.Service, capp *cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient) error {
-	orig := knativeService.DeepCopy()
-	if err := controllerutil.SetOwnerReference(capp, knativeService, k.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set Knative Service owner reference: %w", err)
+	if managedResourceNeedsUpdate(orig.Spec, knativeService.Spec, orig.OwnerReferences, knativeService.OwnerReferences) {
+		k.Log.V(1).Info("KnativeService spec or owner metadata differs from desired; applying update",
+			"knativeService", knativeService.Name,
+			"namespace", knativeService.Namespace,
+			"resourceVersion", knativeService.ResourceVersion,
+			"generation", knativeService.Generation)
 	}
-	knativeService.Spec = knativeServiceFromCapp.Spec
-
-	if equality.Semantic.DeepEqual(orig.Spec, knativeService.Spec) &&
-		equality.Semantic.DeepEqual(orig.OwnerReferences, knativeService.OwnerReferences) {
-		return nil
-	}
-
-	k.Log.V(1).Info("KnativeService spec or owner metadata differs from desired; applying update",
-		"knativeService", knativeService.Name,
-		"namespace", knativeService.Namespace,
-		"resourceVersion", knativeService.ResourceVersion,
-		"generation", knativeService.Generation)
-	return resourceManager.UpdateResource(knativeService)
+	return updateManagedResourceIfNeeded(k.UpdateResource, &knativeService, orig.Spec, knativeService.Spec, orig.OwnerReferences)
 }

--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -105,9 +105,9 @@ func (k KnativeServiceManager) prepareVolumes(capp cappv1alpha1.Capp) []corev1.V
 }
 
 // CleanUp ensures the Knative Service is not left behind when it is no longer required for this Capp.
-func (k KnativeServiceManager) CleanUp(capp cappv1alpha1.Capp) error {
+func (k KnativeServiceManager) CleanUp(ctx context.Context, capp cappv1alpha1.Capp) error {
 	var ksvc knativev1.Service
-	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, &ksvc); err != nil {
+	if err := k.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, &ksvc); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 	if capp.DeletionTimestamp != nil {
@@ -115,7 +115,7 @@ func (k KnativeServiceManager) CleanUp(capp cappv1alpha1.Capp) error {
 			return err
 		}
 	}
-	return client.IgnoreNotFound(k.DeleteResource(&ksvc))
+	return client.IgnoreNotFound(k.DeleteResource(ctx, &ksvc))
 }
 
 // IsRequired determines if a Knative service (ksvc) is required based on the Capp's spec.
@@ -131,13 +131,13 @@ func (k KnativeServiceManager) isResumed(capp cappv1alpha1.Capp) bool {
 
 // Manage creates or updates a KnativeService resource based on the provided Capp if it's required.
 // If it's not, then it cleans up the resource if it exists.
-func (k KnativeServiceManager) Manage(capp cappv1alpha1.Capp) error {
+func (k KnativeServiceManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) error {
 	if k.IsRequired(capp) {
-		return k.createOrUpdate(capp)
+		return k.createOrUpdate(ctx, capp)
 	}
 
 	k.Log.Info("Attempting to disable Capp")
-	if err := k.CleanUp(capp); err != nil {
+	if err := k.CleanUp(ctx, capp); err != nil {
 		return err
 	}
 
@@ -148,13 +148,13 @@ func (k KnativeServiceManager) Manage(capp cappv1alpha1.Capp) error {
 }
 
 // createOrUpdate creates or updates a KSVC resource.
-func (k KnativeServiceManager) createOrUpdate(capp cappv1alpha1.Capp) error {
-	knativeServiceFromCapp := k.prepareResource(capp, k.Ctx)
+func (k KnativeServiceManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.Capp) error {
+	knativeServiceFromCapp := k.prepareResource(capp, ctx)
 	knativeService := knativev1.Service{}
 
-	if err := k.K8sclient.Get(k.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, &knativeService); err != nil {
+	if err := k.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, &knativeService); err != nil {
 		if errors.IsNotFound(err) {
-			if err := createManagedResource(k.K8sclient, k.CreateResource, k.EventRecorder, &capp, &knativeServiceFromCapp,
+			if err := createManagedResource(ctx, k.K8sclient, k.CreateResource, k.EventRecorder, &capp, &knativeServiceFromCapp,
 				"KnativeService", eventCappKnativeServiceCreated, eventCappKnativeServiceCreationFailed); err != nil {
 				return err
 			}
@@ -180,5 +180,5 @@ func (k KnativeServiceManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 			"resourceVersion", knativeService.ResourceVersion,
 			"generation", knativeService.Generation)
 	}
-	return updateManagedResourceIfNeeded(k.UpdateResource, &knativeService, orig.Spec, knativeService.Spec, orig.OwnerReferences)
+	return updateManagedResourceIfNeeded(ctx, k.UpdateResource, &knativeService, orig.Spec, knativeService.Spec, orig.OwnerReferences)
 }

--- a/internal/kinds/capp/resourcemanagers/nfspvc.go
+++ b/internal/kinds/capp/resourcemanagers/nfspvc.go
@@ -1,7 +1,6 @@
 package resourcemanagers
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
@@ -10,9 +9,7 @@ import (
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	nfspvcv1alpha1 "github.com/dana-team/nfspvc-operator/api/v1alpha1"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -29,9 +26,7 @@ const (
 )
 
 type NFSPVCManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -81,8 +76,6 @@ func (n NFSPVCManager) getPreviousNFSPVCs(capp cappv1alpha1.Capp) (nfspvcv1alpha
 
 // CleanUp attempts to delete the associated NFSPVCs for a given Capp resource.
 func (n NFSPVCManager) CleanUp(capp cappv1alpha1.Capp) error {
-	resourceManager := rclient.ResourceManagerClient{Ctx: n.Ctx, K8sclient: n.K8sclient, Log: n.Log}
-
 	nfsPvcs, err := n.getPreviousNFSPVCs(capp)
 	if err != nil {
 		return err
@@ -100,7 +93,7 @@ func (n NFSPVCManager) CleanUp(capp cappv1alpha1.Capp) error {
 		}
 		nfsPvcVolume := rclient.GetBareNFSPVC(nfsPvc.Name, nfsPvc.Namespace)
 
-		if err := resourceManager.DeleteResource(&nfsPvcVolume); err != nil {
+		if err := n.DeleteResource(&nfsPvcVolume); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
@@ -129,56 +122,30 @@ func (n NFSPVCManager) Manage(capp cappv1alpha1.Capp) error {
 // createOrUpdate creates or updates a NFSPVC resource.
 func (n NFSPVCManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 	generatedNFSPVCs := n.prepareResource(capp)
-	resourceManager := rclient.ResourceManagerClient{Ctx: n.Ctx, K8sclient: n.K8sclient, Log: n.Log}
 
 	for i := range generatedNFSPVCs {
 		nfspvc := &generatedNFSPVCs[i]
 		existingNFSPVC := nfspvcv1alpha1.NfsPvc{}
 		if err := n.K8sclient.Get(n.Ctx, client.ObjectKey{Namespace: nfspvc.Namespace, Name: nfspvc.Name}, &existingNFSPVC); err != nil {
 			if errors.IsNotFound(err) {
-				if err := n.createNFSPVC(&capp, nfspvc, resourceManager); err != nil {
+				if err := createManagedResource(n.K8sclient, n.CreateResource, n.EventRecorder, &capp, nfspvc,
+					"NFSPVC", eventNFSPVCCreated, eventNFSPVCCreationFailed); err != nil {
 					return err
 				}
 			} else {
 				return fmt.Errorf("failed to get NFSPVC %q: %w", nfspvc.Name, err)
 			}
-		} else if err := n.updateNFSPVC(&capp, existingNFSPVC, nfspvc, resourceManager); err != nil {
-			return err
+		} else {
+			orig := existingNFSPVC.DeepCopy()
+			existingNFSPVC.Spec = *nfspvc.Spec.DeepCopy()
+			if err := ensureOwnerReference(n.K8sclient, &capp, &existingNFSPVC, "NfsPvc"); err != nil {
+				return err
+			}
+			if err := updateManagedResourceIfNeeded(n.UpdateResource, &existingNFSPVC, orig.Spec, existingNFSPVC.Spec, orig.OwnerReferences); err != nil {
+				return err
+			}
 		}
 	}
 
 	return nil
-}
-
-// createNFSPVC creates a new NFSPVC and emits an event.
-func (n NFSPVCManager) createNFSPVC(capp *cappv1alpha1.Capp, nfspvc *nfspvcv1alpha1.NfsPvc, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(capp, nfspvc, n.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set NfsPvc owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(nfspvc); err != nil {
-		n.EventRecorder.Eventf(capp, nil, corev1.EventTypeWarning, eventNFSPVCCreationFailed, eventNFSPVCCreationFailed,
-			fmt.Sprintf("Failed to create NFSPVC %s", nfspvc.Name))
-		return err
-	}
-
-	n.EventRecorder.Eventf(capp, nil, corev1.EventTypeNormal, eventNFSPVCCreated, eventNFSPVCCreated,
-		fmt.Sprintf("Created NFSPVC %s", nfspvc.Name))
-
-	return nil
-}
-
-// updateNFSPVC checks if an update to the NFSPVC is necessary and performs the update to match desired state.
-func (n NFSPVCManager) updateNFSPVC(capp *cappv1alpha1.Capp, existingNFSPVC nfspvcv1alpha1.NfsPvc, nfspvc *nfspvcv1alpha1.NfsPvc, resourceManager rclient.ResourceManagerClient) error {
-	orig := existingNFSPVC.DeepCopy()
-	if err := controllerutil.SetOwnerReference(capp, &existingNFSPVC, n.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set NfsPvc owner reference: %w", err)
-	}
-	existingNFSPVC.Spec = *nfspvc.Spec.DeepCopy()
-
-	if equality.Semantic.DeepEqual(orig.Spec, existingNFSPVC.Spec) &&
-		equality.Semantic.DeepEqual(orig.OwnerReferences, existingNFSPVC.OwnerReferences) {
-		return nil
-	}
-
-	return resourceManager.UpdateResource(&existingNFSPVC)
 }

--- a/internal/kinds/capp/resourcemanagers/nfspvc.go
+++ b/internal/kinds/capp/resourcemanagers/nfspvc.go
@@ -1,6 +1,7 @@
 package resourcemanagers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
@@ -59,7 +60,7 @@ func (n NFSPVCManager) prepareResource(capp cappv1alpha1.Capp) []nfspvcv1alpha1.
 }
 
 // getPreviousNFSPVCs returns a list of all NFSPVC objects that are related to the given Capp.
-func (n NFSPVCManager) getPreviousNFSPVCs(capp cappv1alpha1.Capp) (nfspvcv1alpha1.NfsPvcList, error) {
+func (n NFSPVCManager) getPreviousNFSPVCs(ctx context.Context, capp cappv1alpha1.Capp) (nfspvcv1alpha1.NfsPvcList, error) {
 	nfsPvcs := nfspvcv1alpha1.NfsPvcList{}
 
 	set := labels.Set{
@@ -67,7 +68,7 @@ func (n NFSPVCManager) getPreviousNFSPVCs(capp cappv1alpha1.Capp) (nfspvcv1alpha
 	}
 	listOptions := utils.GetListOptions(set)
 
-	if err := n.K8sclient.List(n.Ctx, &nfsPvcs, &listOptions); err != nil {
+	if err := n.K8sclient.List(ctx, &nfsPvcs, &listOptions); err != nil {
 		return nfsPvcs, fmt.Errorf("unable to list NFSPVCs of Capp %q: %w", capp.Name, err)
 	}
 
@@ -75,8 +76,8 @@ func (n NFSPVCManager) getPreviousNFSPVCs(capp cappv1alpha1.Capp) (nfspvcv1alpha
 }
 
 // CleanUp attempts to delete the associated NFSPVCs for a given Capp resource.
-func (n NFSPVCManager) CleanUp(capp cappv1alpha1.Capp) error {
-	nfsPvcs, err := n.getPreviousNFSPVCs(capp)
+func (n NFSPVCManager) CleanUp(ctx context.Context, capp cappv1alpha1.Capp) error {
+	nfsPvcs, err := n.getPreviousNFSPVCs(ctx, capp)
 	if err != nil {
 		return err
 	}
@@ -93,7 +94,7 @@ func (n NFSPVCManager) CleanUp(capp cappv1alpha1.Capp) error {
 		}
 		nfsPvcVolume := rclient.GetBareNFSPVC(nfsPvc.Name, nfsPvc.Namespace)
 
-		if err := n.DeleteResource(&nfsPvcVolume); err != nil {
+		if err := n.DeleteResource(ctx, &nfsPvcVolume); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
@@ -111,24 +112,24 @@ func (n NFSPVCManager) IsRequired(capp cappv1alpha1.Capp) bool {
 
 // Manage creates or updates a NFSPVC resource based on the provided Capp if it's required.
 // If it's not, then it cleans up the resource if it exists.
-func (n NFSPVCManager) Manage(capp cappv1alpha1.Capp) error {
+func (n NFSPVCManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) error {
 	if n.IsRequired(capp) {
-		return n.createOrUpdate(capp)
+		return n.createOrUpdate(ctx, capp)
 	}
 
-	return n.CleanUp(capp)
+	return n.CleanUp(ctx, capp)
 }
 
 // createOrUpdate creates or updates a NFSPVC resource.
-func (n NFSPVCManager) createOrUpdate(capp cappv1alpha1.Capp) error {
+func (n NFSPVCManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.Capp) error {
 	generatedNFSPVCs := n.prepareResource(capp)
 
 	for i := range generatedNFSPVCs {
 		nfspvc := &generatedNFSPVCs[i]
 		existingNFSPVC := nfspvcv1alpha1.NfsPvc{}
-		if err := n.K8sclient.Get(n.Ctx, client.ObjectKey{Namespace: nfspvc.Namespace, Name: nfspvc.Name}, &existingNFSPVC); err != nil {
+		if err := n.K8sclient.Get(ctx, client.ObjectKey{Namespace: nfspvc.Namespace, Name: nfspvc.Name}, &existingNFSPVC); err != nil {
 			if errors.IsNotFound(err) {
-				if err := createManagedResource(n.K8sclient, n.CreateResource, n.EventRecorder, &capp, nfspvc,
+				if err := createManagedResource(ctx, n.K8sclient, n.CreateResource, n.EventRecorder, &capp, nfspvc,
 					"NFSPVC", eventNFSPVCCreated, eventNFSPVCCreationFailed); err != nil {
 					return err
 				}
@@ -141,7 +142,7 @@ func (n NFSPVCManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 			if err := ensureOwnerReference(n.K8sclient, &capp, &existingNFSPVC, "NfsPvc"); err != nil {
 				return err
 			}
-			if err := updateManagedResourceIfNeeded(n.UpdateResource, &existingNFSPVC, orig.Spec, existingNFSPVC.Spec, orig.OwnerReferences); err != nil {
+			if err := updateManagedResourceIfNeeded(ctx, n.UpdateResource, &existingNFSPVC, orig.Spec, existingNFSPVC.Spec, orig.OwnerReferences); err != nil {
 				return err
 			}
 		}

--- a/internal/kinds/capp/resourcemanagers/pingsource.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource.go
@@ -1,6 +1,7 @@
 package resourcemanagers
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -36,30 +37,30 @@ func (p PingSourceManager) IsRequired(capp cappv1alpha1.Capp) bool {
 	return len(capp.Spec.EventSourcesSpec.Sources) > 0
 }
 
-func (p PingSourceManager) Manage(capp cappv1alpha1.Capp) error {
+func (p PingSourceManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) error {
 	if p.IsRequired(capp) {
-		return p.reconcilePingSources(capp)
+		return p.reconcilePingSources(ctx, capp)
 	}
 
-	return p.CleanUp(capp)
+	return p.CleanUp(ctx, capp)
 }
 
-func (p PingSourceManager) CleanUp(capp cappv1alpha1.Capp) error {
-	pingSources, err := p.getPingSources(capp)
+func (p PingSourceManager) CleanUp(ctx context.Context, capp cappv1alpha1.Capp) error {
+	pingSources, err := p.getPingSources(ctx, capp)
 	if err != nil {
 		return err
 	}
 	for i := range pingSources.Items {
 		ps := &pingSources.Items[i]
-		if err := client.IgnoreNotFound(p.DeleteResource(ps)); err != nil {
+		if err := client.IgnoreNotFound(p.DeleteResource(ctx, ps)); err != nil {
 			return fmt.Errorf("failed to delete PingSource %q: %w", ps.Name, err)
 		}
 	}
 	return nil
 }
 
-func (p PingSourceManager) GetStatus(capp cappv1alpha1.Capp) (cappv1alpha1.EventingStatus, error) {
-	pingSources, err := p.getPingSources(capp)
+func (p PingSourceManager) GetStatus(ctx context.Context, capp cappv1alpha1.Capp) (cappv1alpha1.EventingStatus, error) {
+	pingSources, err := p.getPingSources(ctx, capp)
 	if err != nil {
 		return cappv1alpha1.EventingStatus{}, err
 	}
@@ -91,27 +92,27 @@ func (p PingSourceManager) GetStatus(capp cappv1alpha1.Capp) (cappv1alpha1.Event
 	return cappv1alpha1.EventingStatus{EventSources: statuses}, nil
 }
 
-func (p PingSourceManager) reconcilePingSources(capp cappv1alpha1.Capp) error {
+func (p PingSourceManager) reconcilePingSources(ctx context.Context, capp cappv1alpha1.Capp) error {
 	for _, source := range capp.Spec.EventSourcesSpec.Sources {
 		if source.PingSourceConfiguration == nil {
 			continue
 		}
-		if err := p.createOrUpdate(capp, source); err != nil {
+		if err := p.createOrUpdate(ctx, capp, source); err != nil {
 			return fmt.Errorf("failed to create or update PingSource %q: %w", source.Name, err)
 		}
 	}
-	return p.cleanUpOrphans(capp)
+	return p.cleanUpOrphans(ctx, capp)
 }
 
-func (p PingSourceManager) createOrUpdate(capp cappv1alpha1.Capp, source cappv1alpha1.SourceConfiguration) error {
+func (p PingSourceManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.Capp, source cappv1alpha1.SourceConfiguration) error {
 	desired := p.preparePingSource(capp, source)
 	existing := &sourcesv1.PingSource{}
-	err := p.K8sclient.Get(p.Ctx, client.ObjectKey{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	err := p.K8sclient.Get(ctx, client.ObjectKey{Name: desired.Name, Namespace: desired.Namespace}, existing)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get PingSource %q: %w", desired.Name, err)
 		}
-		return createManagedResource(p.K8sclient, p.CreateResource, p.EventRecorder, &capp, desired,
+		return createManagedResource(ctx, p.K8sclient, p.CreateResource, p.EventRecorder, &capp, desired,
 			"PingSource", eventPingSourceCreated, eventPingSourceCreationFailed)
 	}
 
@@ -123,24 +124,24 @@ func (p PingSourceManager) createOrUpdate(capp cappv1alpha1.Capp, source cappv1a
 	if managedResourceNeedsUpdate(orig.Spec, existing.Spec, orig.OwnerReferences, existing.OwnerReferences) {
 		p.Log.Info("Updating PingSource", "Name", existing.Name)
 	}
-	return updateManagedResourceIfNeeded(p.UpdateResource, existing, orig.Spec, existing.Spec, orig.OwnerReferences)
+	return updateManagedResourceIfNeeded(ctx, p.UpdateResource, existing, orig.Spec, existing.Spec, orig.OwnerReferences)
 }
 
-func (p PingSourceManager) cleanUpOrphans(capp cappv1alpha1.Capp) error {
+func (p PingSourceManager) cleanUpOrphans(ctx context.Context, capp cappv1alpha1.Capp) error {
 	desired := make(map[string]struct{})
 	for _, source := range capp.Spec.EventSourcesSpec.Sources {
 		if source.PingSourceConfiguration != nil {
 			desired[fmt.Sprintf("%s-%s", capp.Name, source.Name)] = struct{}{}
 		}
 	}
-	owned, err := p.getPingSources(capp)
+	owned, err := p.getPingSources(ctx, capp)
 	if err != nil {
 		return err
 	}
 	for i := range owned.Items {
 		ps := &owned.Items[i]
 		if _, keep := desired[ps.Name]; !keep {
-			if err := client.IgnoreNotFound(p.DeleteResource(ps)); err != nil {
+			if err := client.IgnoreNotFound(p.DeleteResource(ctx, ps)); err != nil {
 				return fmt.Errorf("failed to delete orphaned PingSource %q: %w", ps.Name, err)
 			}
 		}
@@ -175,12 +176,12 @@ func (p PingSourceManager) preparePingSource(capp cappv1alpha1.Capp, source capp
 	}
 }
 
-func (p PingSourceManager) getPingSources(capp cappv1alpha1.Capp) (sourcesv1.PingSourceList, error) {
+func (p PingSourceManager) getPingSources(ctx context.Context, capp cappv1alpha1.Capp) (sourcesv1.PingSourceList, error) {
 	list := sourcesv1.PingSourceList{}
 	set := labels.Set{utils.CappResourceKey: capp.Name}
 	listOpts := utils.GetListOptions(set)
 	listOpts.Namespace = capp.Namespace
-	if err := p.K8sclient.List(p.Ctx, &list, &listOpts); err != nil {
+	if err := p.K8sclient.List(ctx, &list, &listOpts); err != nil {
 		return list, fmt.Errorf("unable to list PingSources of Capp %q: %w", capp.Name, err)
 	}
 	return list, nil

--- a/internal/kinds/capp/resourcemanagers/pingsource.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource.go
@@ -1,17 +1,15 @@
 package resourcemanagers
 
 import (
-	"context"
 	"fmt"
 	"sort"
 
 	"github.com/cloudevents/sdk-go/v2/event"
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
-	"github.com/go-logr/logr"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -21,7 +19,6 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -31,9 +28,7 @@ const (
 )
 
 type PingSourceManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -56,7 +51,7 @@ func (p PingSourceManager) CleanUp(capp cappv1alpha1.Capp) error {
 	}
 	for i := range pingSources.Items {
 		ps := &pingSources.Items[i]
-		if err := p.K8sclient.Delete(p.Ctx, ps); client.IgnoreNotFound(err) != nil {
+		if err := client.IgnoreNotFound(p.DeleteResource(ps)); err != nil {
 			return fmt.Errorf("failed to delete PingSource %q: %w", ps.Name, err)
 		}
 	}
@@ -116,38 +111,19 @@ func (p PingSourceManager) createOrUpdate(capp cappv1alpha1.Capp, source cappv1a
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get PingSource %q: %w", desired.Name, err)
 		}
-		return p.createPingSource(&capp, desired)
+		return createManagedResource(p.K8sclient, p.CreateResource, p.EventRecorder, &capp, desired,
+			"PingSource", eventPingSourceCreated, eventPingSourceCreationFailed)
 	}
-	return p.updatePingSource(&capp, existing, desired)
-}
 
-func (p PingSourceManager) createPingSource(capp *cappv1alpha1.Capp, ps *sourcesv1.PingSource) error {
-	if err := controllerutil.SetOwnerReference(capp, ps, p.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set PingSource owner reference: %w", err)
-	}
-	p.Log.Info("Creating PingSource", "Name", ps.Name)
-	if err := p.K8sclient.Create(p.Ctx, ps); err != nil {
-		p.EventRecorder.Eventf(capp, nil, corev1.EventTypeWarning, eventPingSourceCreationFailed, eventPingSourceCreationFailed,
-			"Failed to create PingSource %s", ps.Name)
+	orig := existing.DeepCopy()
+	existing.Spec = desired.Spec
+	if err := ensureOwnerReference(p.K8sclient, &capp, existing, "PingSource"); err != nil {
 		return err
 	}
-	p.EventRecorder.Eventf(capp, nil, corev1.EventTypeNormal, eventPingSourceCreated, eventPingSourceCreated,
-		"Created PingSource %s", ps.Name)
-	return nil
-}
-
-func (p PingSourceManager) updatePingSource(capp *cappv1alpha1.Capp, existing, desired *sourcesv1.PingSource) error {
-	orig := existing.DeepCopy()
-	if err := controllerutil.SetOwnerReference(capp, existing, p.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set PingSource owner reference: %w", err)
+	if managedResourceNeedsUpdate(orig.Spec, existing.Spec, orig.OwnerReferences, existing.OwnerReferences) {
+		p.Log.Info("Updating PingSource", "Name", existing.Name)
 	}
-	existing.Spec = desired.Spec
-	if equality.Semantic.DeepEqual(orig.Spec, existing.Spec) &&
-		equality.Semantic.DeepEqual(orig.OwnerReferences, existing.OwnerReferences) {
-		return nil
-	}
-	p.Log.Info("Updating PingSource", "Name", existing.Name)
-	return p.K8sclient.Update(p.Ctx, existing)
+	return updateManagedResourceIfNeeded(p.UpdateResource, existing, orig.Spec, existing.Spec, orig.OwnerReferences)
 }
 
 func (p PingSourceManager) cleanUpOrphans(capp cappv1alpha1.Capp) error {
@@ -164,7 +140,7 @@ func (p PingSourceManager) cleanUpOrphans(capp cappv1alpha1.Capp) error {
 	for i := range owned.Items {
 		ps := &owned.Items[i]
 		if _, keep := desired[ps.Name]; !keep {
-			if err := p.K8sclient.Delete(p.Ctx, ps); client.IgnoreNotFound(err) != nil {
+			if err := client.IgnoreNotFound(p.DeleteResource(ps)); err != nil {
 				return fmt.Errorf("failed to delete orphaned PingSource %q: %w", ps.Name, err)
 			}
 		}

--- a/internal/kinds/capp/resourcemanagers/pingsource_test.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource_test.go
@@ -46,7 +46,7 @@ func newPingSourceScheme() *runtime.Scheme {
 
 func newPingSourceManager(k8sClient client.Client) PingSourceManager {
 	return PingSourceManager{
-		ResourceManagerClient: rclient.ResourceManagerClient{Ctx: context.Background(), K8sclient: k8sClient, Log: logr.Discard()},
+		ResourceManagerClient: rclient.ResourceManagerClient{K8sclient: k8sClient, Log: logr.Discard()},
 		EventRecorder:         events.NewFakeRecorder(10),
 	}
 }
@@ -115,7 +115,7 @@ func TestPingSourceCleanUpOrphans(t *testing.T) {
 			}
 			pm := newPingSourceManager(fakeClient)
 			capp := newCapp(cappName, cappNamespace, tt.sources)
-			assert.NoError(t, pm.cleanUpOrphans(capp))
+			assert.NoError(t, pm.cleanUpOrphans(ctx, capp))
 			for _, name := range tt.expectKept {
 				got := &sourcesv1.PingSource{}
 				assert.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: name, Namespace: cappNamespace}, got))
@@ -165,7 +165,7 @@ func TestPingSourceCreateOrUpdate(t *testing.T) {
 						Data:     tt.preData,
 					},
 				}
-				assert.NoError(t, pm.createOrUpdate(capp, src))
+				assert.NoError(t, pm.createOrUpdate(ctx, capp, src))
 			}
 
 			src := cappv1alpha1.SourceConfiguration{
@@ -175,7 +175,7 @@ func TestPingSourceCreateOrUpdate(t *testing.T) {
 					Data:     tt.data,
 				},
 			}
-			assert.NoError(t, pm.createOrUpdate(capp, src))
+			assert.NoError(t, pm.createOrUpdate(ctx, capp, src))
 			got := &sourcesv1.PingSource{}
 			assert.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: pingSourceName(sourceName), Namespace: cappNamespace}, got))
 			assert.Equal(t, tt.expectedData, got.Spec.Data)
@@ -220,7 +220,7 @@ func TestPingSourceGetStatus(t *testing.T) {
 			}
 			pm := newPingSourceManager(fakeClient)
 			capp := newCapp(cappName, cappNamespace, nil)
-			result, err := pm.GetStatus(capp)
+			result, err := pm.GetStatus(ctx, capp)
 			assert.NoError(t, err)
 			if tt.expectedNames == nil {
 				assert.Nil(t, result.EventSources)
@@ -234,7 +234,6 @@ func TestPingSourceGetStatus(t *testing.T) {
 				assert.Equal(t, corev1.ConditionUnknown, result.EventSources[0].Condition.Status)
 				assert.Equal(t, "Source readiness not known", result.EventSources[0].Condition.Message)
 			}
-			_ = ctx
 		})
 	}
 }

--- a/internal/kinds/capp/resourcemanagers/pingsource_test.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -45,10 +46,8 @@ func newPingSourceScheme() *runtime.Scheme {
 
 func newPingSourceManager(k8sClient client.Client) PingSourceManager {
 	return PingSourceManager{
-		Ctx:           context.Background(),
-		K8sclient:     k8sClient,
-		Log:           logr.Discard(),
-		EventRecorder: events.NewFakeRecorder(10),
+		ResourceManagerClient: rclient.ResourceManagerClient{Ctx: context.Background(), K8sclient: k8sClient, Log: logr.Discard()},
+		EventRecorder:         events.NewFakeRecorder(10),
 	}
 }
 

--- a/internal/kinds/capp/resourcemanagers/resourcemanagers.go
+++ b/internal/kinds/capp/resourcemanagers/resourcemanagers.go
@@ -1,10 +1,14 @@
 package resourcemanagers
 
-import cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+import (
+	"context"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+)
 
 // ResourceManager is an interface for every resource managed by Capp.
 type ResourceManager interface {
-	Manage(capp cappv1alpha1.Capp) error
-	CleanUp(capp cappv1alpha1.Capp) error
+	Manage(ctx context.Context, capp cappv1alpha1.Capp) error
+	CleanUp(ctx context.Context, capp cappv1alpha1.Capp) error
 	IsRequired(capp cappv1alpha1.Capp) bool
 }

--- a/internal/kinds/capp/resourcemanagers/syslogngflow.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngflow.go
@@ -1,18 +1,14 @@
 package resourcemanagers
 
 import (
-	"context"
 	"fmt"
 
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
-	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
-	"github.com/go-logr/logr"
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/filter"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,9 +26,7 @@ const (
 )
 
 type SyslogNGFlowManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -72,8 +66,7 @@ func (f SyslogNGFlowManager) CleanUp(capp cappv1alpha1.Capp) error {
 			return err
 		}
 	}
-	resourceManager := rclient.ResourceManagerClient{Ctx: f.Ctx, K8sclient: f.K8sclient, Log: f.Log}
-	return client.IgnoreNotFound(resourceManager.DeleteResource(&syslogNGFlow))
+	return client.IgnoreNotFound(f.DeleteResource(&syslogNGFlow))
 }
 
 // IsRequired is responsible to determine if resource logging operator SyslogNGFlow is required.
@@ -95,48 +88,19 @@ func (f SyslogNGFlowManager) Manage(capp cappv1alpha1.Capp) error {
 func (f SyslogNGFlowManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 	syslogNGFlowFromCapp := f.prepareResource(capp)
 	syslogNGFlow := loggingv1beta1.SyslogNGFlow{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: f.Ctx, K8sclient: f.K8sclient, Log: f.Log}
 
 	if err := f.K8sclient.Get(f.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: syslogNGFlowFromCapp.Name}, &syslogNGFlow); err != nil {
 		if errors.IsNotFound(err) {
-			return f.createSyslogNGFlow(syslogNGFlowFromCapp, capp, resourceManager)
-		} else {
-			return fmt.Errorf("failed to get SyslogNGFlow %q: %w", syslogNGFlow.Name, err)
+			return createManagedResource(f.K8sclient, f.CreateResource, f.EventRecorder, &capp, &syslogNGFlowFromCapp,
+				"SyslogNGFlow", eventCappSyslogNGFlowCreated, eventCappSyslogNGFlowCreationFailed)
 		}
+		return fmt.Errorf("failed to get SyslogNGFlow %q: %w", syslogNGFlow.Name, err)
 	}
 
-	return f.updateSyslogNGFlow(&capp, &syslogNGFlow, &syslogNGFlowFromCapp, resourceManager)
-}
-
-// createSyslogNGFlow creates a new SyslogNGFlow and emits an event.
-func (f SyslogNGFlowManager) createSyslogNGFlow(syslogNGFlowFromCapp loggingv1beta1.SyslogNGFlow, capp cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(&capp, &syslogNGFlowFromCapp, f.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set SyslogNGFlow owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(&syslogNGFlowFromCapp); err != nil {
-		f.EventRecorder.Eventf(&capp, nil, corev1.EventTypeWarning, eventCappSyslogNGFlowCreationFailed, eventCappSyslogNGFlowCreationFailed,
-			fmt.Sprintf("Failed to create SyslogNGFlow %s", syslogNGFlowFromCapp.Name))
+	orig := syslogNGFlow.DeepCopy()
+	syslogNGFlow.Spec = *syslogNGFlowFromCapp.Spec.DeepCopy()
+	if err := ensureOwnerReference(f.K8sclient, &capp, &syslogNGFlow, "SyslogNGFlow"); err != nil {
 		return err
 	}
-
-	f.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappSyslogNGFlowCreated, eventCappSyslogNGFlowCreated,
-		fmt.Sprintf("Created SyslogNGFlow %s", syslogNGFlowFromCapp.Name))
-
-	return nil
-}
-
-// updateSyslogNGFlow checks if an update to the SyslogNGFlow is necessary and performs the update to match desired state.
-func (f SyslogNGFlowManager) updateSyslogNGFlow(capp *cappv1alpha1.Capp, syslogNGFlow, syslogNGFlowFromCapp *loggingv1beta1.SyslogNGFlow, resourceManager rclient.ResourceManagerClient) error {
-	orig := syslogNGFlow.DeepCopy()
-	if err := controllerutil.SetOwnerReference(capp, syslogNGFlow, f.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set SyslogNGFlow owner reference: %w", err)
-	}
-	syslogNGFlow.Spec = *syslogNGFlowFromCapp.Spec.DeepCopy()
-
-	if equality.Semantic.DeepEqual(orig.Spec, syslogNGFlow.Spec) &&
-		equality.Semantic.DeepEqual(orig.OwnerReferences, syslogNGFlow.OwnerReferences) {
-		return nil
-	}
-
-	return resourceManager.UpdateResource(syslogNGFlow)
+	return updateManagedResourceIfNeeded(f.UpdateResource, &syslogNGFlow, orig.Spec, syslogNGFlow.Spec, orig.OwnerReferences)
 }

--- a/internal/kinds/capp/resourcemanagers/syslogngflow.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngflow.go
@@ -1,6 +1,7 @@
 package resourcemanagers
 
 import (
+	"context"
 	"fmt"
 
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
@@ -56,9 +57,9 @@ func (f SyslogNGFlowManager) prepareResource(capp cappv1alpha1.Capp) loggingv1be
 }
 
 // CleanUp attempts to delete the associated SyslogNGFlow for a given Capp resource.
-func (f SyslogNGFlowManager) CleanUp(capp cappv1alpha1.Capp) error {
+func (f SyslogNGFlowManager) CleanUp(ctx context.Context, capp cappv1alpha1.Capp) error {
 	var syslogNGFlow loggingv1beta1.SyslogNGFlow
-	if err := f.K8sclient.Get(f.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, &syslogNGFlow); err != nil {
+	if err := f.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, &syslogNGFlow); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 	if capp.DeletionTimestamp != nil {
@@ -66,7 +67,7 @@ func (f SyslogNGFlowManager) CleanUp(capp cappv1alpha1.Capp) error {
 			return err
 		}
 	}
-	return client.IgnoreNotFound(f.DeleteResource(&syslogNGFlow))
+	return client.IgnoreNotFound(f.DeleteResource(ctx, &syslogNGFlow))
 }
 
 // IsRequired is responsible to determine if resource logging operator SyslogNGFlow is required.
@@ -76,22 +77,22 @@ func (f SyslogNGFlowManager) IsRequired(capp cappv1alpha1.Capp) bool {
 
 // Manage creates or updates a SyslogNGFlow resource based on the provided Capp if it's required.
 // If it's not, then it cleans up the resource if it exists.
-func (f SyslogNGFlowManager) Manage(capp cappv1alpha1.Capp) error {
+func (f SyslogNGFlowManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) error {
 	if f.IsRequired(capp) {
-		return f.createOrUpdate(capp)
+		return f.createOrUpdate(ctx, capp)
 	}
 
-	return f.CleanUp(capp)
+	return f.CleanUp(ctx, capp)
 }
 
 // createOrUpdate creates or updates a SyslogNGFlow resource.
-func (f SyslogNGFlowManager) createOrUpdate(capp cappv1alpha1.Capp) error {
+func (f SyslogNGFlowManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.Capp) error {
 	syslogNGFlowFromCapp := f.prepareResource(capp)
 	syslogNGFlow := loggingv1beta1.SyslogNGFlow{}
 
-	if err := f.K8sclient.Get(f.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: syslogNGFlowFromCapp.Name}, &syslogNGFlow); err != nil {
+	if err := f.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: syslogNGFlowFromCapp.Name}, &syslogNGFlow); err != nil {
 		if errors.IsNotFound(err) {
-			return createManagedResource(f.K8sclient, f.CreateResource, f.EventRecorder, &capp, &syslogNGFlowFromCapp,
+			return createManagedResource(ctx, f.K8sclient, f.CreateResource, f.EventRecorder, &capp, &syslogNGFlowFromCapp,
 				"SyslogNGFlow", eventCappSyslogNGFlowCreated, eventCappSyslogNGFlowCreationFailed)
 		}
 		return fmt.Errorf("failed to get SyslogNGFlow %q: %w", syslogNGFlow.Name, err)
@@ -102,5 +103,5 @@ func (f SyslogNGFlowManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 	if err := ensureOwnerReference(f.K8sclient, &capp, &syslogNGFlow, "SyslogNGFlow"); err != nil {
 		return err
 	}
-	return updateManagedResourceIfNeeded(f.UpdateResource, &syslogNGFlow, orig.Spec, syslogNGFlow.Spec, orig.OwnerReferences)
+	return updateManagedResourceIfNeeded(ctx, f.UpdateResource, &syslogNGFlow, orig.Spec, syslogNGFlow.Spec, orig.OwnerReferences)
 }

--- a/internal/kinds/capp/resourcemanagers/syslogngoutput.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngoutput.go
@@ -1,7 +1,6 @@
 package resourcemanagers
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
@@ -9,12 +8,10 @@ import (
 	"github.com/cisco-open/operator-tools/pkg/secret"
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
-	"github.com/go-logr/logr"
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/output"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,9 +32,7 @@ const (
 )
 
 type SyslogNGOutputManager struct {
-	Ctx           context.Context
-	K8sclient     client.Client
-	Log           logr.Logger
+	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
 }
 
@@ -150,8 +145,7 @@ func (o SyslogNGOutputManager) CleanUp(capp cappv1alpha1.Capp) error {
 			return err
 		}
 	}
-	resourceManager := rclient.ResourceManagerClient{Ctx: o.Ctx, K8sclient: o.K8sclient, Log: o.Log}
-	return client.IgnoreNotFound(resourceManager.DeleteResource(&syslogNGOutput))
+	return client.IgnoreNotFound(o.DeleteResource(&syslogNGOutput))
 }
 
 // IsRequired is responsible to determine if resource logging operator is required.
@@ -176,48 +170,19 @@ func (o SyslogNGOutputManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 		return fmt.Errorf("unsupported log type %q", capp.Spec.LogSpec.Type)
 	}
 	syslogNGOutput := loggingv1beta1.SyslogNGOutput{}
-	resourceManager := rclient.ResourceManagerClient{Ctx: o.Ctx, K8sclient: o.K8sclient, Log: o.Log}
 
 	if err := o.K8sclient.Get(o.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: syslogNGOutputFromCapp.Name}, &syslogNGOutput); err != nil {
 		if errors.IsNotFound(err) {
-			return o.createSyslogNGOutput(syslogNGOutputFromCapp, capp, resourceManager)
-		} else {
-			return fmt.Errorf("failed to get SyslogNGOutput %q: %w", syslogNGOutputFromCapp.Name, err)
+			return createManagedResource(o.K8sclient, o.CreateResource, o.EventRecorder, &capp, &syslogNGOutputFromCapp,
+				"SyslogNGOutput", eventCappSyslogNGOutputCreated, eventCappSyslogNGOutputCreationFailed)
 		}
+		return fmt.Errorf("failed to get SyslogNGOutput %q: %w", syslogNGOutputFromCapp.Name, err)
 	}
 
-	return o.updateSyslogNGOutput(&capp, &syslogNGOutput, &syslogNGOutputFromCapp, resourceManager)
-}
-
-// createSyslogNGOutput creates a new SyslogNGOutput and emits an event.
-func (o SyslogNGOutputManager) createSyslogNGOutput(syslogNGOutputFromCapp loggingv1beta1.SyslogNGOutput, capp cappv1alpha1.Capp, resourceManager rclient.ResourceManagerClient) error {
-	if err := controllerutil.SetOwnerReference(&capp, &syslogNGOutputFromCapp, o.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set SyslogNGOutput owner reference: %w", err)
-	}
-	if err := resourceManager.CreateResource(&syslogNGOutputFromCapp); err != nil {
-		o.EventRecorder.Eventf(&capp, nil, corev1.EventTypeWarning, eventCappSyslogNGOutputCreationFailed, eventCappSyslogNGOutputCreationFailed,
-			fmt.Sprintf("Failed to create SyslogNGOutput %s", syslogNGOutputFromCapp.Name))
+	orig := syslogNGOutput.DeepCopy()
+	syslogNGOutput.Spec = *syslogNGOutputFromCapp.Spec.DeepCopy()
+	if err := ensureOwnerReference(o.K8sclient, &capp, &syslogNGOutput, "SyslogNGOutput"); err != nil {
 		return err
 	}
-
-	o.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappSyslogNGOutputCreated, eventCappSyslogNGOutputCreated,
-		fmt.Sprintf("Created SyslogNGOutput %s", syslogNGOutputFromCapp.Name))
-
-	return nil
-}
-
-// updateSyslogNGOutput checks if an update to the SyslogNGOutput is necessary and performs the update to match desired state.
-func (o SyslogNGOutputManager) updateSyslogNGOutput(capp *cappv1alpha1.Capp, syslogNGOutput, syslogNGOutputFromCapp *loggingv1beta1.SyslogNGOutput, resourceManager rclient.ResourceManagerClient) error {
-	orig := syslogNGOutput.DeepCopy()
-	if err := controllerutil.SetOwnerReference(capp, syslogNGOutput, o.K8sclient.Scheme()); err != nil {
-		return fmt.Errorf("set SyslogNGOutput owner reference: %w", err)
-	}
-	syslogNGOutput.Spec = *syslogNGOutputFromCapp.Spec.DeepCopy()
-
-	if equality.Semantic.DeepEqual(orig.Spec, syslogNGOutput.Spec) &&
-		equality.Semantic.DeepEqual(orig.OwnerReferences, syslogNGOutput.OwnerReferences) {
-		return nil
-	}
-
-	return resourceManager.UpdateResource(syslogNGOutput)
+	return updateManagedResourceIfNeeded(o.UpdateResource, &syslogNGOutput, orig.Spec, syslogNGOutput.Spec, orig.OwnerReferences)
 }

--- a/internal/kinds/capp/resourcemanagers/syslogngoutput.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngoutput.go
@@ -1,6 +1,7 @@
 package resourcemanagers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
@@ -135,9 +136,9 @@ func (o SyslogNGOutputManager) prepareResource(capp cappv1alpha1.Capp) loggingv1
 }
 
 // CleanUp attempts to delete the associated SyslogNGOutput for a given Capp resource.
-func (o SyslogNGOutputManager) CleanUp(capp cappv1alpha1.Capp) error {
+func (o SyslogNGOutputManager) CleanUp(ctx context.Context, capp cappv1alpha1.Capp) error {
 	var syslogNGOutput loggingv1beta1.SyslogNGOutput
-	if err := o.K8sclient.Get(o.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, &syslogNGOutput); err != nil {
+	if err := o.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, &syslogNGOutput); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 	if capp.DeletionTimestamp != nil {
@@ -145,7 +146,7 @@ func (o SyslogNGOutputManager) CleanUp(capp cappv1alpha1.Capp) error {
 			return err
 		}
 	}
-	return client.IgnoreNotFound(o.DeleteResource(&syslogNGOutput))
+	return client.IgnoreNotFound(o.DeleteResource(ctx, &syslogNGOutput))
 }
 
 // IsRequired is responsible to determine if resource logging operator is required.
@@ -155,25 +156,25 @@ func (o SyslogNGOutputManager) IsRequired(capp cappv1alpha1.Capp) bool {
 
 // Manage creates or updates a SyslogNGOutput resource based on the provided Capp if it's required.
 // If it's not, then it cleans up the resource if it exists.
-func (o SyslogNGOutputManager) Manage(capp cappv1alpha1.Capp) error {
+func (o SyslogNGOutputManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) error {
 	if o.IsRequired(capp) {
-		return o.createOrUpdate(capp)
+		return o.createOrUpdate(ctx, capp)
 	}
 
-	return o.CleanUp(capp)
+	return o.CleanUp(ctx, capp)
 }
 
 // createOrUpdate creates or updates a SyslogNGOutput resource.
-func (o SyslogNGOutputManager) createOrUpdate(capp cappv1alpha1.Capp) error {
+func (o SyslogNGOutputManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.Capp) error {
 	syslogNGOutputFromCapp := o.prepareResource(capp)
 	if !isSupportedLogType(capp.Spec.LogSpec.Type) {
 		return fmt.Errorf("unsupported log type %q", capp.Spec.LogSpec.Type)
 	}
 	syslogNGOutput := loggingv1beta1.SyslogNGOutput{}
 
-	if err := o.K8sclient.Get(o.Ctx, types.NamespacedName{Namespace: capp.Namespace, Name: syslogNGOutputFromCapp.Name}, &syslogNGOutput); err != nil {
+	if err := o.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: syslogNGOutputFromCapp.Name}, &syslogNGOutput); err != nil {
 		if errors.IsNotFound(err) {
-			return createManagedResource(o.K8sclient, o.CreateResource, o.EventRecorder, &capp, &syslogNGOutputFromCapp,
+			return createManagedResource(ctx, o.K8sclient, o.CreateResource, o.EventRecorder, &capp, &syslogNGOutputFromCapp,
 				"SyslogNGOutput", eventCappSyslogNGOutputCreated, eventCappSyslogNGOutputCreationFailed)
 		}
 		return fmt.Errorf("failed to get SyslogNGOutput %q: %w", syslogNGOutputFromCapp.Name, err)
@@ -184,5 +185,5 @@ func (o SyslogNGOutputManager) createOrUpdate(capp cappv1alpha1.Capp) error {
 	if err := ensureOwnerReference(o.K8sclient, &capp, &syslogNGOutput, "SyslogNGOutput"); err != nil {
 		return err
 	}
-	return updateManagedResourceIfNeeded(o.UpdateResource, &syslogNGOutput, orig.Spec, syslogNGOutput.Spec, orig.OwnerReferences)
+	return updateManagedResourceIfNeeded(ctx, o.UpdateResource, &syslogNGOutput, orig.Spec, syslogNGOutput.Spec, orig.OwnerReferences)
 }

--- a/internal/kinds/capp/status/capp.go
+++ b/internal/kinds/capp/status/capp.go
@@ -68,7 +68,7 @@ func SyncStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Logger, r 
 	cappObject.Status.VolumesStatus = volumesStatus
 
 	if psm, ok := resourceManagers[rmanagers.PingSource].(rmanagers.PingSourceManager); ok {
-		eventingStatus, err := psm.GetStatus(capp)
+		eventingStatus, err := psm.GetStatus(ctx, capp)
 		if err != nil {
 			return err
 		}

--- a/internal/kinds/capp/utils/route.go
+++ b/internal/kinds/capp/utils/route.go
@@ -6,11 +6,6 @@ import (
 	"strings"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
-
-	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
-
-	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -19,23 +14,6 @@ const (
 	dot                 = "."
 	maxCommonNameLength = 64
 )
-
-// IsDNSRecordAvailable returns a boolean indicating whether a CNAMERecord is currently available.
-func IsDNSRecordAvailable(ctx context.Context, k8sClient client.Client, name, namespace string) (bool, error) {
-	var available bool
-
-	dnsRecord := dnsrecordv1alpha1.CNAMERecord{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &dnsRecord); err != nil {
-		return false, fmt.Errorf("failed getting DNSRecord: %w", err)
-	}
-
-	if dnsRecord.Status.Conditions != nil {
-		readyCondition := dnsRecord.Status.GetCondition(xpv1.TypeReady)
-		available = readyCondition.Status == corev1.ConditionTrue && readyCondition.Reason == xpv1.ReasonAvailable
-	}
-
-	return available, nil
-}
 
 // GetDNSConfig returns the data of the DNS for the CappConfig CRD.
 func GetDNSConfig(ctx context.Context, k8sClient client.Client) (cappv1alpha1.DNSConfig, error) {


### PR DESCRIPTION
Stop embedding reconcile context on ResourceManagerClient and managers.
ResourceManager.Manage/CleanUp and client CRUD now take ctx per call so
cancellation and timeouts propagate correctly