### PR TITLE
refactor(resourcemanagers): inline single-call-site helpers

### DIFF
--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -117,39 +117,34 @@ func (c CertificateManager) IsRequired(capp cappv1alpha1.Capp) bool {
 // If it's not, then it cleans up the resource if it exists.
 func (c CertificateManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) error {
 	if c.IsRequired(capp) {
-		return c.reconcileCertificate(ctx, capp)
+		certificateFromCapp, err := c.prepareResource(ctx, capp)
+		if err != nil {
+			return fmt.Errorf("failed to prepare Certificate: %w", err)
+		}
+
+		certificate := cmapi.Certificate{}
+
+		if err := c.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: certificateFromCapp.Name}, &certificate); err != nil {
+			if errors.IsNotFound(err) {
+				return createManagedResource(ctx, c.K8sclient, c.CreateResource, c.EventRecorder, &capp, &certificateFromCapp,
+					"Certificate", eventCappCertificateCreated, eventCappCertificateCreationFailed)
+			}
+			return fmt.Errorf("failed to get Certificate %q: %w", certificateFromCapp.Name, err)
+		}
+
+		orig := certificate.DeepCopy()
+		certificate.Spec = *certificateFromCapp.Spec.DeepCopy()
+		if err := ensureOwnerReference(c.K8sclient, &capp, &certificate, "Certificate"); err != nil {
+			return err
+		}
+		if err := updateManagedResourceIfNeeded(ctx, c.UpdateResource, &certificate, orig.Spec, certificate.Spec, orig.OwnerReferences); err != nil {
+			return fmt.Errorf("update Certificate %q: %w", certificate.Name, err)
+		}
+
+		return nil
 	}
 
 	return c.CleanUp(ctx, capp)
-}
-
-// reconcileCertificate reconciles the cert-manager Certificate for this Capp.
-func (c CertificateManager) reconcileCertificate(ctx context.Context, capp cappv1alpha1.Capp) error {
-	certificateFromCapp, err := c.prepareResource(ctx, capp)
-	if err != nil {
-		return fmt.Errorf("failed to prepare Certificate: %w", err)
-	}
-
-	certificate := cmapi.Certificate{}
-
-	if err := c.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: certificateFromCapp.Name}, &certificate); err != nil {
-		if errors.IsNotFound(err) {
-			return createManagedResource(ctx, c.K8sclient, c.CreateResource, c.EventRecorder, &capp, &certificateFromCapp,
-				"Certificate", eventCappCertificateCreated, eventCappCertificateCreationFailed)
-		}
-		return fmt.Errorf("failed to get Certificate %q: %w", certificateFromCapp.Name, err)
-	}
-
-	orig := certificate.DeepCopy()
-	certificate.Spec = *certificateFromCapp.Spec.DeepCopy()
-	if err := ensureOwnerReference(c.K8sclient, &capp, &certificate, "Certificate"); err != nil {
-		return err
-	}
-	if err := updateManagedResourceIfNeeded(ctx, c.UpdateResource, &certificate, orig.Spec, certificate.Spec, orig.OwnerReferences); err != nil {
-		return fmt.Errorf("update Certificate %q: %w", certificate.Name, err)
-	}
-
-	return nil
 }
 
 // getPreviousCertificates returns a list of all Certificate objects that are related to the given Capp.

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -129,12 +129,7 @@ func (r DNSRecordManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.
 		return fmt.Errorf("failed to get DNSRecord %q: %w", dnsRecordFromCapp.Name, err)
 	}
 
-	return r.updateDNSRecord(ctx, dnsRecord, dnsRecordFromCapp, &capp)
-}
-
-// updateDNSRecord checks if an update to the DNSRecord is necessary and performs the update to match desired state.
-func (r DNSRecordManager) updateDNSRecord(ctx context.Context, dnsRecord, dnsRecordFromCapp dnsrecordv1alpha1.CNAMERecord, capp *cappv1alpha1.Capp) error {
-	needs, err := r.dnsRecordNeedsUpdate(dnsRecord, dnsRecordFromCapp, capp)
+	needs, err := r.dnsRecordNeedsUpdate(dnsRecord, dnsRecordFromCapp, &capp)
 	if err != nil {
 		return err
 	}
@@ -147,7 +142,7 @@ func (r DNSRecordManager) updateDNSRecord(ctx context.Context, dnsRecord, dnsRec
 			return err
 		}
 
-		needs, err := r.dnsRecordNeedsUpdate(latestRecord, dnsRecordFromCapp, capp)
+		needs, err := r.dnsRecordNeedsUpdate(latestRecord, dnsRecordFromCapp, &capp)
 		if err != nil {
 			return err
 		}
@@ -156,7 +151,7 @@ func (r DNSRecordManager) updateDNSRecord(ctx context.Context, dnsRecord, dnsRec
 		}
 
 		orig := latestRecord.DeepCopy()
-		if err := ensureOwnerReference(r.K8sclient, capp, &latestRecord, "DNSRecord"); err != nil {
+		if err := ensureOwnerReference(r.K8sclient, &capp, &latestRecord, "DNSRecord"); err != nil {
 			return err
 		}
 		latestRecord.Spec.ForProvider = *dnsRecordFromCapp.Spec.ForProvider.DeepCopy()

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -61,33 +61,20 @@ func (k KnativeDomainMappingManager) prepareResource(ctx context.Context, capp c
 	}
 
 	if tlsEnabled := capp.Spec.RouteSpec.TlsEnabled; tlsEnabled {
-		if err := k.setHTTPSKnativeDomainMapping(ctx, secretName, capp.Namespace, knativeDomainMapping); err != nil {
+		tlsSecret := corev1.Secret{}
+		if err := k.K8sclient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: capp.Namespace}, &tlsSecret); err != nil {
 			if !errors.IsNotFound(err) {
-				return *knativeDomainMapping, err
+				return *knativeDomainMapping, fmt.Errorf("failed to get tlsSecret %s for DomainMapping: %w", secretName, err)
+			}
+			k.Log.Info("tlsSecret does not yet exist", "secretName", secretName)
+		} else {
+			knativeDomainMapping.Spec.TLS = &knativev1beta1.SecretTLS{
+				SecretName: secretName,
 			}
 		}
 	}
 
 	return *knativeDomainMapping, nil
-}
-
-// setHTTPSKnativeDomainMapping sets the DomainMapping TLS based on Capp.
-func (k KnativeDomainMappingManager) setHTTPSKnativeDomainMapping(ctx context.Context, secretName, secretNamespace string, knativeDomainMapping *knativev1beta1.DomainMapping) error {
-	tlsSecret := corev1.Secret{}
-
-	if err := k.K8sclient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, &tlsSecret); err != nil {
-		if errors.IsNotFound(err) {
-			k.Log.Info("tlsSecret does not yet exist", "secretName", secretName)
-			return nil
-		}
-		return fmt.Errorf("failed to get tlsSecret %s for DomainMapping: %w", secretName, err)
-	}
-
-	knativeDomainMapping.Spec.TLS = &knativev1beta1.SecretTLS{
-		SecretName: secretName,
-	}
-
-	return nil
 }
 
 // CleanUp attempts to delete the associated DomainMappings and tls secrets for a given Capp resource.
@@ -120,7 +107,13 @@ func (k KnativeDomainMappingManager) CleanUp(ctx context.Context, capp cappv1alp
 			}
 			return err
 		}
-		if err := k.deleteTLSSecret(ctx, utils.GenerateSecretName(dm.Name), dm.Namespace); err != nil {
+		secretName := utils.GenerateSecretName(dm.Name)
+		secret := corev1.Secret{}
+		if err := k.K8sclient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: dm.Namespace}, &secret); err != nil {
+			if !errors.IsNotFound(err) {
+				return err
+			}
+		} else if err := k.DeleteResource(ctx, &secret); err != nil {
 			return err
 		}
 	}
@@ -182,16 +175,4 @@ func (k KnativeDomainMappingManager) getPreviousDomainMappings(ctx context.Conte
 	}
 
 	return knativeDomainMappings, nil
-}
-
-// deleteTLSSecret deletes the tls secret associated with the DomainMapping.
-func (k KnativeDomainMappingManager) deleteTLSSecret(ctx context.Context, secretName, namespace string) error {
-	secret := corev1.Secret{}
-	if err := k.K8sclient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &secret); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	return k.DeleteResource(ctx, &secret)
 }

--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -73,8 +73,16 @@ func (k KnativeServiceManager) prepareResource(capp cappv1alpha1.Capp, ctx conte
 	knativeService.Spec.Template.Spec.SetDefaults(ctx)
 	knativeService.Spec.Template.Spec.TimeoutSeconds = capp.Spec.RouteSpec.RouteTimeoutSeconds
 
-	volumes := k.prepareVolumes(capp)
-	knativeService.Spec.Template.Spec.Volumes = append(knativeService.Spec.Template.Spec.Volumes, volumes...)
+	for _, nfsVolume := range capp.Spec.VolumesSpec.NFSVolumes {
+		knativeService.Spec.Template.Spec.Volumes = append(knativeService.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: nfsVolume.Name,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: nfsVolume.Name,
+				},
+			},
+		})
+	}
 
 	cappConfig, err := utils.GetCappConfig(ctx, k.K8sclient)
 	if err != nil {
@@ -85,23 +93,6 @@ func (k KnativeServiceManager) prepareResource(capp cappv1alpha1.Capp, ctx conte
 	knativeService.Spec.Template.Labels = knativeServiceLabels
 
 	return knativeService
-}
-
-// prepareVolumes generates a list of volumes to be used in a Knative Service definition from a given Capp resource.
-func (k KnativeServiceManager) prepareVolumes(capp cappv1alpha1.Capp) []corev1.Volume {
-	//nolint:prealloc
-	var volumes []corev1.Volume
-	for _, nfsVolume := range capp.Spec.VolumesSpec.NFSVolumes {
-		volumes = append(volumes, corev1.Volume{
-			Name: nfsVolume.Name,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: nfsVolume.Name,
-				},
-			},
-		})
-	}
-	return volumes
 }
 
 // CleanUp ensures the Knative Service is not left behind when it is no longer required for this Capp.
@@ -121,12 +112,6 @@ func (k KnativeServiceManager) CleanUp(ctx context.Context, capp cappv1alpha1.Ca
 // IsRequired determines if a Knative service (ksvc) is required based on the Capp's spec.
 func (k KnativeServiceManager) IsRequired(capp cappv1alpha1.Capp) bool {
 	return capp.Spec.State == cappEnabledState
-}
-
-// isResumed checks whether the state changed from disabled to enabled.
-func (k KnativeServiceManager) isResumed(capp cappv1alpha1.Capp) bool {
-	return capp.Status.StateStatus.State == cappDisabledState && k.IsRequired(capp) &&
-		!capp.Status.StateStatus.LastChange.IsZero()
 }
 
 // Manage creates or updates a KnativeService resource based on the provided Capp if it's required.
@@ -159,7 +144,8 @@ func (k KnativeServiceManager) createOrUpdate(ctx context.Context, capp cappv1al
 				return err
 			}
 
-			if k.isResumed(capp) {
+			if capp.Status.StateStatus.State == cappDisabledState && k.IsRequired(capp) &&
+				!capp.Status.StateStatus.LastChange.IsZero() {
 				k.Log.Info("Capp resumed to enabled state")
 				k.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappEnabled, eventCappEnabled, fmt.Sprintf("Capp %q state changed to enabled", capp.Name))
 			}

--- a/internal/kinds/capp/resourcemanagers/pingsource.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource.go
@@ -39,7 +39,15 @@ func (p PingSourceManager) IsRequired(capp cappv1alpha1.Capp) bool {
 
 func (p PingSourceManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) error {
 	if p.IsRequired(capp) {
-		return p.reconcilePingSources(ctx, capp)
+		for _, source := range capp.Spec.EventSourcesSpec.Sources {
+			if source.PingSourceConfiguration == nil {
+				continue
+			}
+			if err := p.createOrUpdate(ctx, capp, source); err != nil {
+				return fmt.Errorf("failed to create or update PingSource %q: %w", source.Name, err)
+			}
+		}
+		return p.cleanUpOrphans(ctx, capp)
 	}
 
 	return p.CleanUp(ctx, capp)
@@ -92,20 +100,31 @@ func (p PingSourceManager) GetStatus(ctx context.Context, capp cappv1alpha1.Capp
 	return cappv1alpha1.EventingStatus{EventSources: statuses}, nil
 }
 
-func (p PingSourceManager) reconcilePingSources(ctx context.Context, capp cappv1alpha1.Capp) error {
-	for _, source := range capp.Spec.EventSourcesSpec.Sources {
-		if source.PingSourceConfiguration == nil {
-			continue
-		}
-		if err := p.createOrUpdate(ctx, capp, source); err != nil {
-			return fmt.Errorf("failed to create or update PingSource %q: %w", source.Name, err)
-		}
-	}
-	return p.cleanUpOrphans(ctx, capp)
-}
-
 func (p PingSourceManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.Capp, source cappv1alpha1.SourceConfiguration) error {
-	desired := p.preparePingSource(capp, source)
+	cfg := source.PingSourceConfiguration
+	desired := &sourcesv1.PingSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", capp.Name, source.Name),
+			Namespace: capp.Namespace,
+			Labels:    utils.ManagedResourceLabels(capp.Name),
+		},
+		Spec: sourcesv1.PingSourceSpec{
+			Schedule:    cfg.Schedule,
+			Data:        cfg.Data,
+			ContentType: event.ApplicationJSON,
+			SourceSpec: duckv1.SourceSpec{
+				Sink: duckv1.Destination{
+					Ref: &duckv1.KReference{
+						Name:       capp.Name,
+						Namespace:  capp.Namespace,
+						Kind:       knativeServiceKind,
+						APIVersion: servingv1.SchemeGroupVersion.String(),
+					},
+					URI: source.URI,
+				},
+			},
+		},
+	}
 	existing := &sourcesv1.PingSource{}
 	err := p.K8sclient.Get(ctx, client.ObjectKey{Name: desired.Name, Namespace: desired.Namespace}, existing)
 	if err != nil {
@@ -147,33 +166,6 @@ func (p PingSourceManager) cleanUpOrphans(ctx context.Context, capp cappv1alpha1
 		}
 	}
 	return nil
-}
-
-func (p PingSourceManager) preparePingSource(capp cappv1alpha1.Capp, source cappv1alpha1.SourceConfiguration) *sourcesv1.PingSource {
-	cfg := source.PingSourceConfiguration
-	return &sourcesv1.PingSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", capp.Name, source.Name),
-			Namespace: capp.Namespace,
-			Labels:    utils.ManagedResourceLabels(capp.Name),
-		},
-		Spec: sourcesv1.PingSourceSpec{
-			Schedule:    cfg.Schedule,
-			Data:        cfg.Data,
-			ContentType: event.ApplicationJSON,
-			SourceSpec: duckv1.SourceSpec{
-				Sink: duckv1.Destination{
-					Ref: &duckv1.KReference{
-						Name:       capp.Name,
-						Namespace:  capp.Namespace,
-						Kind:       knativeServiceKind,
-						APIVersion: servingv1.SchemeGroupVersion.String(),
-					},
-					URI: source.URI,
-				},
-			},
-		},
-	}
 }
 
 func (p PingSourceManager) getPingSources(ctx context.Context, capp cappv1alpha1.Capp) (sourcesv1.PingSourceList, error) {


### PR DESCRIPTION
Remove thin private wrappers that only forwarded to one caller and fold their logic into the existing Manage / createOrUpdate paths. This reduces indirection and keeps the real seams (prepare vs reconcile) without changing behavior.

With fewer one-off hops, the package reads more linearly and leaves a clearer base for a follow-up shared list/reconcile helper extraction.