### PR TITLE
feat: validate PasswordSecret existence and required key at admission

### DIFF
--- a/internal/webhook/rcs/v1alpha1/validator.go
+++ b/internal/webhook/rcs/v1alpha1/validator.go
@@ -13,6 +13,9 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/internal/webhook/rcs/common"
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -24,7 +27,8 @@ import (
 )
 
 const (
-	eventSourcePath = "spec.eventSourcesSpec.sources"
+	eventSourcePath  = "spec.eventSourcesSpec.sources"
+	elasticSecretKey = "elastic"
 )
 
 type CappValidator struct {
@@ -90,6 +94,10 @@ func (c *CappValidator) handle(ctx context.Context, operation admissionv1.Operat
 		return admission.Denied(err.Error())
 	}
 
+	if err := c.validatePasswordSecret(ctx, capp); err != nil {
+		return admission.Denied(err.Error())
+	}
+
 	if err := validateEventSources(ctx, capp); err != nil {
 		return admission.Denied(err.Error())
 	}
@@ -149,6 +157,27 @@ func validateNFSVolumeMounts(capp cappv1alpha1.Capp) error {
 	slices.Sort(missingVolumeNames)
 
 	return fmt.Errorf("invalid nfsVolumes: volumes [%s] must be mounted by at least one container", strings.Join(missingVolumeNames, ", "))
+}
+
+func (c *CappValidator) validatePasswordSecret(ctx context.Context, capp cappv1alpha1.Capp) error {
+	if capp.Spec.LogSpec.PasswordSecret == "" {
+		return nil
+	}
+
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Namespace: capp.Namespace, Name: capp.Spec.LogSpec.PasswordSecret}
+	if err := c.Client.Get(ctx, key, secret); err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("passwordSecret %q not found in namespace %q", capp.Spec.LogSpec.PasswordSecret, capp.Namespace)
+		}
+		return fmt.Errorf("failed to look up passwordSecret %q: %w", capp.Spec.LogSpec.PasswordSecret, err)
+	}
+
+	if _, ok := secret.Data[elasticSecretKey]; !ok {
+		return fmt.Errorf("passwordSecret %q is missing required key %q", capp.Spec.LogSpec.PasswordSecret, elasticSecretKey)
+	}
+
+	return nil
 }
 
 func validateEventSources(ctx context.Context, capp cappv1alpha1.Capp) error {

--- a/internal/webhook/rcs/v1alpha1/validator_test.go
+++ b/internal/webhook/rcs/v1alpha1/validator_test.go
@@ -390,6 +390,79 @@ func TestValidateEventSources(t *testing.T) {
 	}
 }
 
+func TestValidatePasswordSecret(t *testing.T) {
+	scheme := newScheme(t)
+
+	tests := []struct {
+		name            string
+		secretName      string
+		secretData      map[string][]byte
+		createSecret    bool
+		wantErrContains []string
+	}{
+		{
+			name:       "allows empty passwordSecret field",
+			secretName: "",
+		},
+		{
+			name:         "allows secret with required key",
+			secretName:   "my-secret",
+			createSecret: true,
+			secretData:   map[string][]byte{"elastic": []byte("password123")},
+		},
+		{
+			name:            "denies when secret does not exist",
+			secretName:      "missing-secret",
+			createSecret:    false,
+			wantErrContains: []string{"passwordSecret", "missing-secret", "not found"},
+		},
+		{
+			name:            "denies when secret exists but missing required key",
+			secretName:      "bad-secret",
+			createSecret:    true,
+			secretData:      map[string][]byte{"wrong-key": []byte("value")},
+			wantErrContains: []string{"passwordSecret", "bad-secret", "missing required key", "elastic"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tc.createSecret {
+				builder = builder.WithObjects(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tc.secretName,
+						Namespace: nsName,
+					},
+					Data: tc.secretData,
+				})
+			}
+			fakeClient := builder.Build()
+
+			validator := &CappValidator{Client: fakeClient}
+			capp := cappv1alpha1.Capp{
+				ObjectMeta: metav1.ObjectMeta{Namespace: nsName},
+				Spec: cappv1alpha1.CappSpec{
+					LogSpec: cappv1alpha1.LogSpec{
+						PasswordSecret: tc.secretName,
+					},
+				},
+			}
+
+			err := validator.validatePasswordSecret(context.Background(), capp)
+			if len(tc.wantErrContains) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			for _, s := range tc.wantErrContains {
+				assert.Contains(t, err.Error(), s)
+			}
+		})
+	}
+}
+
 func newScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 


### PR DESCRIPTION
Check that the Secret referenced by LogSpec.PasswordSecret exists and contains the required "elastic" key. This catches misconfigured secrets at apply time instead of silently failing at runtime.