### PR TITLE
test(resourcemanagers): add ksvc unit tests and shared fixtures

### DIFF
--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
@@ -150,15 +149,8 @@ func (c CertificateManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) 
 // getPreviousCertificates returns a list of all Certificate objects that are related to the given Capp.
 func (c CertificateManager) getPreviousCertificates(ctx context.Context, capp cappv1alpha1.Capp) (cmapi.CertificateList, error) {
 	certificates := cmapi.CertificateList{}
-
-	set := labels.Set{
-		utils.CappResourceKey: capp.Name,
+	if err := listManagedResources(ctx, c.K8sclient, capp, &certificates, "Certificate", nil); err != nil {
+		return certificates, err
 	}
-	listOptions := utils.GetListOptions(set)
-
-	if err := c.K8sclient.List(ctx, &certificates, &listOptions); err != nil {
-		return certificates, fmt.Errorf("unable to list Certificates of Capp %q: %w", capp.Name, err)
-	}
-
 	return certificates, nil
 }

--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -117,39 +117,34 @@ func (c CertificateManager) IsRequired(capp cappv1alpha1.Capp) bool {
 // If it's not, then it cleans up the resource if it exists.
 func (c CertificateManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) error {
 	if c.IsRequired(capp) {
-		return c.reconcileCertificate(ctx, capp)
+		certificateFromCapp, err := c.prepareResource(ctx, capp)
+		if err != nil {
+			return fmt.Errorf("failed to prepare Certificate: %w", err)
+		}
+
+		certificate := cmapi.Certificate{}
+
+		if err := c.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: certificateFromCapp.Name}, &certificate); err != nil {
+			if errors.IsNotFound(err) {
+				return createManagedResource(ctx, c.K8sclient, c.CreateResource, c.EventRecorder, &capp, &certificateFromCapp,
+					"Certificate", eventCappCertificateCreated, eventCappCertificateCreationFailed)
+			}
+			return fmt.Errorf("failed to get Certificate %q: %w", certificateFromCapp.Name, err)
+		}
+
+		orig := certificate.DeepCopy()
+		certificate.Spec = *certificateFromCapp.Spec.DeepCopy()
+		if err := ensureOwnerReference(c.K8sclient, &capp, &certificate, "Certificate"); err != nil {
+			return err
+		}
+		if err := updateManagedResourceIfNeeded(ctx, c.UpdateResource, &certificate, orig.Spec, certificate.Spec, orig.OwnerReferences); err != nil {
+			return fmt.Errorf("update Certificate %q: %w", certificate.Name, err)
+		}
+
+		return nil
 	}
 
 	return c.CleanUp(ctx, capp)
-}
-
-// reconcileCertificate reconciles the cert-manager Certificate for this Capp.
-func (c CertificateManager) reconcileCertificate(ctx context.Context, capp cappv1alpha1.Capp) error {
-	certificateFromCapp, err := c.prepareResource(ctx, capp)
-	if err != nil {
-		return fmt.Errorf("failed to prepare Certificate: %w", err)
-	}
-
-	certificate := cmapi.Certificate{}
-
-	if err := c.K8sclient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: certificateFromCapp.Name}, &certificate); err != nil {
-		if errors.IsNotFound(err) {
-			return createManagedResource(ctx, c.K8sclient, c.CreateResource, c.EventRecorder, &capp, &certificateFromCapp,
-				"Certificate", eventCappCertificateCreated, eventCappCertificateCreationFailed)
-		}
-		return fmt.Errorf("failed to get Certificate %q: %w", certificateFromCapp.Name, err)
-	}
-
-	orig := certificate.DeepCopy()
-	certificate.Spec = *certificateFromCapp.Spec.DeepCopy()
-	if err := ensureOwnerReference(c.K8sclient, &capp, &certificate, "Certificate"); err != nil {
-		return err
-	}
-	if err := updateManagedResourceIfNeeded(ctx, c.UpdateResource, &certificate, orig.Spec, certificate.Spec, orig.OwnerReferences); err != nil {
-		return fmt.Errorf("update Certificate %q: %w", certificate.Name, err)
-	}
-
-	return nil
 }
 
 // getPreviousCertificates returns a list of all Certificate objects that are related to the given Capp.

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -184,17 +184,10 @@ func (r DNSRecordManager) dnsRecordNeedsUpdate(current, desired dnsrecordv1alpha
 // getPreviousDNSRecords returns a list of all DNSRecord objects that are related to the given Capp.
 func (r DNSRecordManager) getPreviousDNSRecords(ctx context.Context, capp cappv1alpha1.Capp) (dnsrecordv1alpha1.CNAMERecordList, error) {
 	dnsRecords := dnsrecordv1alpha1.CNAMERecordList{}
-
-	set := labels.Set{
-		utils.CappResourceKey:  capp.Name,
+	if err := listManagedResources(ctx, r.K8sclient, capp, &dnsRecords, "DNSRecord", labels.Set{
 		utils.CappNamespaceKey: capp.Namespace,
+	}); err != nil {
+		return dnsRecords, err
 	}
-	listOptions := utils.GetListOptions(set)
-	listOptions.Namespace = capp.Namespace
-
-	if err := r.K8sclient.List(ctx, &dnsRecords, &listOptions); err != nil {
-		return dnsRecords, fmt.Errorf("unable to list DNSRecords of Capp %q: %w", capp.Name, err)
-	}
-
 	return dnsRecords, nil
 }

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -129,12 +129,7 @@ func (r DNSRecordManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.
 		return fmt.Errorf("failed to get DNSRecord %q: %w", dnsRecordFromCapp.Name, err)
 	}
 
-	return r.updateDNSRecord(ctx, dnsRecord, dnsRecordFromCapp, &capp)
-}
-
-// updateDNSRecord checks if an update to the DNSRecord is necessary and performs the update to match desired state.
-func (r DNSRecordManager) updateDNSRecord(ctx context.Context, dnsRecord, dnsRecordFromCapp dnsrecordv1alpha1.CNAMERecord, capp *cappv1alpha1.Capp) error {
-	needs, err := r.dnsRecordNeedsUpdate(dnsRecord, dnsRecordFromCapp, capp)
+	needs, err := r.dnsRecordNeedsUpdate(dnsRecord, dnsRecordFromCapp, &capp)
 	if err != nil {
 		return err
 	}
@@ -147,7 +142,7 @@ func (r DNSRecordManager) updateDNSRecord(ctx context.Context, dnsRecord, dnsRec
 			return err
 		}
 
-		needs, err := r.dnsRecordNeedsUpdate(latestRecord, dnsRecordFromCapp, capp)
+		needs, err := r.dnsRecordNeedsUpdate(latestRecord, dnsRecordFromCapp, &capp)
 		if err != nil {
 			return err
 		}
@@ -156,7 +151,7 @@ func (r DNSRecordManager) updateDNSRecord(ctx context.Context, dnsRecord, dnsRec
 		}
 
 		orig := latestRecord.DeepCopy()
-		if err := ensureOwnerReference(r.K8sclient, capp, &latestRecord, "DNSRecord"); err != nil {
+		if err := ensureOwnerReference(r.K8sclient, &capp, &latestRecord, "DNSRecord"); err != nil {
 			return err
 		}
 		latestRecord.Spec.ForProvider = *dnsRecordFromCapp.Spec.ForProvider.DeepCopy()

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -164,15 +163,8 @@ func (k KnativeDomainMappingManager) createOrUpdate(ctx context.Context, capp ca
 // getPreviousDomainMappings returns a list of all DomainMapping objects that are related to the given Capp.
 func (k KnativeDomainMappingManager) getPreviousDomainMappings(ctx context.Context, capp cappv1alpha1.Capp) (knativev1beta1.DomainMappingList, error) {
 	knativeDomainMappings := knativev1beta1.DomainMappingList{}
-
-	set := labels.Set{
-		utils.CappResourceKey: capp.Name,
+	if err := listManagedResources(ctx, k.K8sclient, capp, &knativeDomainMappings, "DomainMapping", nil); err != nil {
+		return knativeDomainMappings, err
 	}
-
-	listOptions := utils.GetListOptions(set)
-	if err := k.K8sclient.List(ctx, &knativeDomainMappings, &listOptions); err != nil {
-		return knativeDomainMappings, fmt.Errorf("unable to list DomainMappings of Capp %q: %w", capp.Name, err)
-	}
-
 	return knativeDomainMappings, nil
 }

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -61,33 +61,20 @@ func (k KnativeDomainMappingManager) prepareResource(ctx context.Context, capp c
 	}
 
 	if tlsEnabled := capp.Spec.RouteSpec.TlsEnabled; tlsEnabled {
-		if err := k.setHTTPSKnativeDomainMapping(ctx, secretName, capp.Namespace, knativeDomainMapping); err != nil {
+		tlsSecret := corev1.Secret{}
+		if err := k.K8sclient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: capp.Namespace}, &tlsSecret); err != nil {
 			if !errors.IsNotFound(err) {
-				return *knativeDomainMapping, err
+				return *knativeDomainMapping, fmt.Errorf("failed to get tlsSecret %s for DomainMapping: %w", secretName, err)
+			}
+			k.Log.Info("tlsSecret does not yet exist", "secretName", secretName)
+		} else {
+			knativeDomainMapping.Spec.TLS = &knativev1beta1.SecretTLS{
+				SecretName: secretName,
 			}
 		}
 	}
 
 	return *knativeDomainMapping, nil
-}
-
-// setHTTPSKnativeDomainMapping sets the DomainMapping TLS based on Capp.
-func (k KnativeDomainMappingManager) setHTTPSKnativeDomainMapping(ctx context.Context, secretName, secretNamespace string, knativeDomainMapping *knativev1beta1.DomainMapping) error {
-	tlsSecret := corev1.Secret{}
-
-	if err := k.K8sclient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, &tlsSecret); err != nil {
-		if errors.IsNotFound(err) {
-			k.Log.Info("tlsSecret does not yet exist", "secretName", secretName)
-			return nil
-		}
-		return fmt.Errorf("failed to get tlsSecret %s for DomainMapping: %w", secretName, err)
-	}
-
-	knativeDomainMapping.Spec.TLS = &knativev1beta1.SecretTLS{
-		SecretName: secretName,
-	}
-
-	return nil
 }
 
 // CleanUp attempts to delete the associated DomainMappings and tls secrets for a given Capp resource.
@@ -120,7 +107,13 @@ func (k KnativeDomainMappingManager) CleanUp(ctx context.Context, capp cappv1alp
 			}
 			return err
 		}
-		if err := k.deleteTLSSecret(ctx, utils.GenerateSecretName(dm.Name), dm.Namespace); err != nil {
+		secretName := utils.GenerateSecretName(dm.Name)
+		secret := corev1.Secret{}
+		if err := k.K8sclient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: dm.Namespace}, &secret); err != nil {
+			if !errors.IsNotFound(err) {
+				return err
+			}
+		} else if err := k.DeleteResource(ctx, &secret); err != nil {
 			return err
 		}
 	}
@@ -182,16 +175,4 @@ func (k KnativeDomainMappingManager) getPreviousDomainMappings(ctx context.Conte
 	}
 
 	return knativeDomainMappings, nil
-}
-
-// deleteTLSSecret deletes the tls secret associated with the DomainMapping.
-func (k KnativeDomainMappingManager) deleteTLSSecret(ctx context.Context, secretName, namespace string) error {
-	secret := corev1.Secret{}
-	if err := k.K8sclient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &secret); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	return k.DeleteResource(ctx, &secret)
 }

--- a/internal/kinds/capp/resourcemanagers/fixtures_test.go
+++ b/internal/kinds/capp/resourcemanagers/fixtures_test.go
@@ -1,0 +1,52 @@
+package resourcemanagers
+
+import (
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+const (
+	cappName      = "my-capp"
+	cappNamespace = "my-ns"
+	testCappUID   = types.UID("test-uid")
+)
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(cappv1alpha1.AddToScheme(s))
+	return s
+}
+
+func newBaseCapp() cappv1alpha1.Capp {
+	return cappv1alpha1.Capp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cappName,
+			Namespace: cappNamespace,
+			UID:       testCappUID,
+		},
+	}
+}
+
+func newCappConfig() *cappv1alpha1.CappConfig {
+	return &cappv1alpha1.CappConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.CappConfigName,
+			Namespace: utils.CappNS,
+		},
+		Spec: cappv1alpha1.CappConfigSpec{
+			AutoscaleConfig: cappv1alpha1.AutoscaleConfig{
+				RPS:             200,
+				CPU:             80,
+				Memory:          70,
+				Concurrency:     10,
+				ActivationScale: 3,
+			},
+		},
+	}
+}

--- a/internal/kinds/capp/resourcemanagers/helpers.go
+++ b/internal/kinds/capp/resourcemanagers/helpers.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -52,4 +54,24 @@ func updateManagedResourceIfNeeded(ctx context.Context, update func(context.Cont
 		return nil
 	}
 	return update(ctx, obj)
+}
+
+func listManagedResources(
+	ctx context.Context,
+	k8s client.Client,
+	capp cappv1alpha1.Capp,
+	list client.ObjectList,
+	kind string,
+	extraLabels labels.Set,
+) error {
+	set := labels.Set{utils.CappResourceKey: capp.Name}
+	for key, value := range extraLabels {
+		set[key] = value
+	}
+	listOptions := utils.GetListOptions(set)
+	listOptions.Namespace = capp.Namespace
+	if err := k8s.List(ctx, list, &listOptions); err != nil {
+		return fmt.Errorf("unable to list %ss of Capp %q: %w", kind, capp.Name, err)
+	}
+	return nil
 }

--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -73,8 +73,16 @@ func (k KnativeServiceManager) prepareResource(capp cappv1alpha1.Capp, ctx conte
 	knativeService.Spec.Template.Spec.SetDefaults(ctx)
 	knativeService.Spec.Template.Spec.TimeoutSeconds = capp.Spec.RouteSpec.RouteTimeoutSeconds
 
-	volumes := k.prepareVolumes(capp)
-	knativeService.Spec.Template.Spec.Volumes = append(knativeService.Spec.Template.Spec.Volumes, volumes...)
+	for _, nfsVolume := range capp.Spec.VolumesSpec.NFSVolumes {
+		knativeService.Spec.Template.Spec.Volumes = append(knativeService.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: nfsVolume.Name,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: nfsVolume.Name,
+				},
+			},
+		})
+	}
 
 	cappConfig, err := utils.GetCappConfig(ctx, k.K8sclient)
 	if err != nil {
@@ -85,23 +93,6 @@ func (k KnativeServiceManager) prepareResource(capp cappv1alpha1.Capp, ctx conte
 	knativeService.Spec.Template.Labels = knativeServiceLabels
 
 	return knativeService
-}
-
-// prepareVolumes generates a list of volumes to be used in a Knative Service definition from a given Capp resource.
-func (k KnativeServiceManager) prepareVolumes(capp cappv1alpha1.Capp) []corev1.Volume {
-	//nolint:prealloc
-	var volumes []corev1.Volume
-	for _, nfsVolume := range capp.Spec.VolumesSpec.NFSVolumes {
-		volumes = append(volumes, corev1.Volume{
-			Name: nfsVolume.Name,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: nfsVolume.Name,
-				},
-			},
-		})
-	}
-	return volumes
 }
 
 // CleanUp ensures the Knative Service is not left behind when it is no longer required for this Capp.
@@ -121,12 +112,6 @@ func (k KnativeServiceManager) CleanUp(ctx context.Context, capp cappv1alpha1.Ca
 // IsRequired determines if a Knative service (ksvc) is required based on the Capp's spec.
 func (k KnativeServiceManager) IsRequired(capp cappv1alpha1.Capp) bool {
 	return capp.Spec.State == cappEnabledState
-}
-
-// isResumed checks whether the state changed from disabled to enabled.
-func (k KnativeServiceManager) isResumed(capp cappv1alpha1.Capp) bool {
-	return capp.Status.StateStatus.State == cappDisabledState && k.IsRequired(capp) &&
-		!capp.Status.StateStatus.LastChange.IsZero()
 }
 
 // Manage creates or updates a KnativeService resource based on the provided Capp if it's required.
@@ -159,7 +144,8 @@ func (k KnativeServiceManager) createOrUpdate(ctx context.Context, capp cappv1al
 				return err
 			}
 
-			if k.isResumed(capp) {
+			if capp.Status.StateStatus.State == cappDisabledState && k.IsRequired(capp) &&
+				!capp.Status.StateStatus.LastChange.IsZero() {
 				k.Log.Info("Capp resumed to enabled state")
 				k.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappEnabled, eventCappEnabled, fmt.Sprintf("Capp %q state changed to enabled", capp.Name))
 			}

--- a/internal/kinds/capp/resourcemanagers/ksvc_test.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc_test.go
@@ -1,0 +1,273 @@
+package resourcemanagers
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/events"
+	kautoscaling "knative.dev/serving/pkg/apis/autoscaling"
+	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func newKsvcScheme() *runtime.Scheme {
+	s := newScheme()
+	utilruntime.Must(knativev1.AddToScheme(s))
+	return s
+}
+
+func newKsvcManager(k8sClient client.Client) (KnativeServiceManager, *events.FakeRecorder) {
+	recorder := events.NewFakeRecorder(10)
+	return KnativeServiceManager{
+		ResourceManagerClient: rclient.ResourceManagerClient{K8sclient: k8sClient, Log: logr.Discard()},
+		EventRecorder:         recorder,
+	}, recorder
+}
+
+func newKsvcCapp() cappv1alpha1.Capp {
+	capp := newBaseCapp()
+	capp.Spec.State = cappEnabledState
+	capp.Spec.ScaleSpec = cappv1alpha1.ScaleSpec{Metric: kautoscaling.CPU}
+	capp.Spec.ConfigurationSpec = knativev1.ConfigurationSpec{
+		Template: knativev1.RevisionTemplateSpec{
+			Spec: knativev1.RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "example.com/app:v1",
+					}},
+				},
+			},
+		},
+	}
+	return capp
+}
+
+func newKsvcClient(objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(newKsvcScheme()).
+		WithObjects(objects...).
+		Build()
+}
+
+func TestKnativeServiceManagerPrepareResource(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("filters internal annotations and propagates allowed metadata", func(t *testing.T) {
+		const (
+			allowedAnnotationKey    = "example.com/propagate"
+			allowedAnnotationValue  = "propagated"
+			strippedAnnotationValue = "drop-me"
+		)
+		internalAnnotationKey := utils.CappAPIGroup + "/internal"
+
+		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		capp := newKsvcCapp()
+		capp.Annotations = map[string]string{
+			allowedAnnotationKey:  allowedAnnotationValue,
+			internalAnnotationKey: strippedAnnotationValue,
+			kubectlKubernetesIOAnnotationPrefix + "last-applied-configuration": strippedAnnotationValue,
+		}
+
+		got := km.prepareResource(capp, ctx)
+
+		require.Equal(t, allowedAnnotationValue, got.Annotations[allowedAnnotationKey])
+		require.NotContains(t, got.Annotations, internalAnnotationKey)
+		require.NotContains(t, got.Annotations, kubectlKubernetesIOAnnotationPrefix+"last-applied-configuration")
+		require.Equal(t, allowedAnnotationValue, got.Spec.Template.Annotations[allowedAnnotationKey])
+	})
+
+	t.Run("propagates user labels and sets capp resource key on template", func(t *testing.T) {
+		const (
+			userLabelKey   = "team"
+			userLabelValue = "platform"
+		)
+
+		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		capp := newKsvcCapp()
+		capp.Labels = map[string]string{
+			userLabelKey:          userLabelValue,
+			utils.CappResourceKey: "user-override",
+		}
+
+		got := km.prepareResource(capp, ctx)
+
+		require.Equal(t, userLabelValue, got.Spec.Template.Labels[userLabelKey])
+		require.Equal(t, cappName, got.Spec.Template.Labels[utils.CappResourceKey])
+		require.Equal(t, cappName, got.Labels[utils.CappResourceKey])
+		require.Equal(t, utils.CappKey, got.Labels[utils.ManagedByLabelKey])
+	})
+
+	t.Run("sets route timeout on template", func(t *testing.T) {
+		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		capp := newKsvcCapp()
+		routeTimeout := int64(30)
+		capp.Spec.RouteSpec.RouteTimeoutSeconds = &routeTimeout
+
+		got := km.prepareResource(capp, ctx)
+
+		require.NotNil(t, got.Spec.Template.Spec.TimeoutSeconds)
+		require.Equal(t, routeTimeout, *got.Spec.Template.Spec.TimeoutSeconds)
+	})
+
+	t.Run("appends nfs volumes as pvc volume sources", func(t *testing.T) {
+		const nfsVolumeName = "data-vol"
+
+		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		capp := newKsvcCapp()
+		capp.Spec.VolumesSpec.NFSVolumes = []cappv1alpha1.NFSVolume{{
+			Name:     nfsVolumeName,
+			Server:   "nfs.example.com",
+			Path:     "/export",
+			Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+		}}
+
+		got := km.prepareResource(capp, ctx)
+
+		require.Len(t, got.Spec.Template.Spec.Volumes, 1)
+		require.Equal(t, nfsVolumeName, got.Spec.Template.Spec.Volumes[0].Name)
+		require.Equal(t, nfsVolumeName, got.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName)
+	})
+
+	t.Run("merges autoscale annotations from capp and cappConfig", func(t *testing.T) {
+		cappConfig := newCappConfig()
+
+		km, _ := newKsvcManager(newKsvcClient(cappConfig))
+		capp := newKsvcCapp()
+
+		got := km.prepareResource(capp, ctx)
+
+		require.Equal(t, kautoscaling.HPA, got.Spec.Template.Annotations[kautoscaling.ClassAnnotationKey])
+		require.Equal(t, kautoscaling.CPU, got.Spec.Template.Annotations[kautoscaling.MetricAnnotationKey])
+		require.Equal(t, strconv.Itoa(cappConfig.Spec.AutoscaleConfig.CPU), got.Spec.Template.Annotations[kautoscaling.TargetAnnotationKey])
+		require.Equal(t, strconv.Itoa(cappConfig.Spec.AutoscaleConfig.ActivationScale), got.Spec.Template.Annotations[kautoscaling.ActivationScaleKey])
+	})
+}
+
+func TestKnativeServiceManagerManage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("creates ksvc with owner reference when enabled", func(t *testing.T) {
+		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		capp := newKsvcCapp()
+
+		require.NoError(t, km.Manage(ctx, capp))
+
+		got := &knativev1.Service{}
+		require.NoError(t, km.K8sclient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got))
+		require.Len(t, got.OwnerReferences, 1)
+		require.Equal(t, cappName, got.OwnerReferences[0].Name)
+		require.Equal(t, cappName, got.Labels[utils.CappResourceKey])
+	})
+
+	t.Run("updates ksvc when spec changes", func(t *testing.T) {
+		const updatedContainerImage = "example.com/app:v2"
+
+		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		capp := newKsvcCapp()
+		require.NoError(t, km.Manage(ctx, capp))
+
+		capp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Image = updatedContainerImage
+		require.NoError(t, km.Manage(ctx, capp))
+
+		got := &knativev1.Service{}
+		require.NoError(t, km.K8sclient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got))
+		require.Equal(t, updatedContainerImage, got.Spec.Template.Spec.Containers[0].Image)
+	})
+
+	t.Run("skips update when spec is unchanged", func(t *testing.T) {
+		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		capp := newKsvcCapp()
+		require.NoError(t, km.Manage(ctx, capp))
+
+		before := &knativev1.Service{}
+		require.NoError(t, km.K8sclient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, before))
+		beforeRV := before.ResourceVersion
+
+		require.NoError(t, km.Manage(ctx, capp))
+
+		after := &knativev1.Service{}
+		require.NoError(t, km.K8sclient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, after))
+		require.Equal(t, beforeRV, after.ResourceVersion)
+	})
+
+	t.Run("deletes ksvc and emits disabled event when state is disabled", func(t *testing.T) {
+		km, recorder := newKsvcManager(newKsvcClient(newCappConfig()))
+		capp := newKsvcCapp()
+		require.NoError(t, km.Manage(ctx, capp))
+		require.Contains(t, <-recorder.Events, eventCappKnativeServiceCreated)
+
+		capp.Spec.State = cappDisabledState
+		require.NoError(t, km.Manage(ctx, capp))
+
+		got := &knativev1.Service{}
+		getErr := km.K8sclient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got)
+		require.Error(t, getErr)
+		require.True(t, errors.IsNotFound(getErr))
+
+		require.Contains(t, <-recorder.Events, eventCappDisabled)
+	})
+
+	t.Run("recreates ksvc and emits enabled event when resuming from disabled", func(t *testing.T) {
+		km, recorder := newKsvcManager(newKsvcClient(newCappConfig()))
+		capp := newKsvcCapp()
+		capp.Status.StateStatus = cappv1alpha1.StateStatus{
+			State:      cappDisabledState,
+			LastChange: metav1.Now(),
+		}
+
+		require.NoError(t, km.Manage(ctx, capp))
+
+		got := &knativev1.Service{}
+		require.NoError(t, km.K8sclient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got))
+		require.Len(t, got.OwnerReferences, 1)
+		require.Equal(t, cappName, got.OwnerReferences[0].Name)
+
+		require.Contains(t, <-recorder.Events, eventCappKnativeServiceCreated)
+		require.Contains(t, <-recorder.Events, eventCappEnabled)
+	})
+}
+
+func TestKnativeServiceManagerCleanUp(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("succeeds when ksvc does not exist", func(t *testing.T) {
+		km, _ := newKsvcManager(newKsvcClient())
+		require.NoError(t, km.CleanUp(ctx, newKsvcCapp()))
+	})
+
+	t.Run("skips delete when capp is deleting and ksvc has owner reference", func(t *testing.T) {
+		capp := newKsvcCapp()
+		now := metav1.Now()
+		capp.DeletionTimestamp = &now
+
+		ksvc := &knativev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cappName,
+				Namespace: cappNamespace,
+			},
+		}
+		require.NoError(t, controllerutil.SetOwnerReference(&capp, ksvc, newKsvcScheme()))
+
+		km, _ := newKsvcManager(newKsvcClient(ksvc))
+		require.NoError(t, km.CleanUp(ctx, capp))
+
+		got := &knativev1.Service{}
+		require.NoError(t, km.K8sclient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got))
+	})
+}

--- a/internal/kinds/capp/resourcemanagers/nfspvc.go
+++ b/internal/kinds/capp/resourcemanagers/nfspvc.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/events"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,16 +61,9 @@ func (n NFSPVCManager) prepareResource(capp cappv1alpha1.Capp) []nfspvcv1alpha1.
 // getPreviousNFSPVCs returns a list of all NFSPVC objects that are related to the given Capp.
 func (n NFSPVCManager) getPreviousNFSPVCs(ctx context.Context, capp cappv1alpha1.Capp) (nfspvcv1alpha1.NfsPvcList, error) {
 	nfsPvcs := nfspvcv1alpha1.NfsPvcList{}
-
-	set := labels.Set{
-		utils.CappResourceKey: capp.Name,
+	if err := listManagedResources(ctx, n.K8sclient, capp, &nfsPvcs, "NFSPVC", nil); err != nil {
+		return nfsPvcs, err
 	}
-	listOptions := utils.GetListOptions(set)
-
-	if err := n.K8sclient.List(ctx, &nfsPvcs, &listOptions); err != nil {
-		return nfsPvcs, fmt.Errorf("unable to list NFSPVCs of Capp %q: %w", capp.Name, err)
-	}
-
 	return nfsPvcs, nil
 }
 

--- a/internal/kinds/capp/resourcemanagers/pingsource.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/events"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	kapis "knative.dev/pkg/apis"
@@ -170,11 +169,8 @@ func (p PingSourceManager) cleanUpOrphans(ctx context.Context, capp cappv1alpha1
 
 func (p PingSourceManager) getPingSources(ctx context.Context, capp cappv1alpha1.Capp) (sourcesv1.PingSourceList, error) {
 	list := sourcesv1.PingSourceList{}
-	set := labels.Set{utils.CappResourceKey: capp.Name}
-	listOpts := utils.GetListOptions(set)
-	listOpts.Namespace = capp.Namespace
-	if err := p.K8sclient.List(ctx, &list, &listOpts); err != nil {
-		return list, fmt.Errorf("unable to list PingSources of Capp %q: %w", capp.Name, err)
+	if err := listManagedResources(ctx, p.K8sclient, capp, &list, "PingSource", nil); err != nil {
+		return list, err
 	}
 	return list, nil
 }

--- a/internal/kinds/capp/resourcemanagers/pingsource.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource.go
@@ -39,7 +39,15 @@ func (p PingSourceManager) IsRequired(capp cappv1alpha1.Capp) bool {
 
 func (p PingSourceManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) error {
 	if p.IsRequired(capp) {
-		return p.reconcilePingSources(ctx, capp)
+		for _, source := range capp.Spec.EventSourcesSpec.Sources {
+			if source.PingSourceConfiguration == nil {
+				continue
+			}
+			if err := p.createOrUpdate(ctx, capp, source); err != nil {
+				return fmt.Errorf("failed to create or update PingSource %q: %w", source.Name, err)
+			}
+		}
+		return p.cleanUpOrphans(ctx, capp)
 	}
 
 	return p.CleanUp(ctx, capp)
@@ -92,20 +100,31 @@ func (p PingSourceManager) GetStatus(ctx context.Context, capp cappv1alpha1.Capp
 	return cappv1alpha1.EventingStatus{EventSources: statuses}, nil
 }
 
-func (p PingSourceManager) reconcilePingSources(ctx context.Context, capp cappv1alpha1.Capp) error {
-	for _, source := range capp.Spec.EventSourcesSpec.Sources {
-		if source.PingSourceConfiguration == nil {
-			continue
-		}
-		if err := p.createOrUpdate(ctx, capp, source); err != nil {
-			return fmt.Errorf("failed to create or update PingSource %q: %w", source.Name, err)
-		}
-	}
-	return p.cleanUpOrphans(ctx, capp)
-}
-
 func (p PingSourceManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.Capp, source cappv1alpha1.SourceConfiguration) error {
-	desired := p.preparePingSource(capp, source)
+	cfg := source.PingSourceConfiguration
+	desired := &sourcesv1.PingSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", capp.Name, source.Name),
+			Namespace: capp.Namespace,
+			Labels:    utils.ManagedResourceLabels(capp.Name),
+		},
+		Spec: sourcesv1.PingSourceSpec{
+			Schedule:    cfg.Schedule,
+			Data:        cfg.Data,
+			ContentType: event.ApplicationJSON,
+			SourceSpec: duckv1.SourceSpec{
+				Sink: duckv1.Destination{
+					Ref: &duckv1.KReference{
+						Name:       capp.Name,
+						Namespace:  capp.Namespace,
+						Kind:       knativeServiceKind,
+						APIVersion: servingv1.SchemeGroupVersion.String(),
+					},
+					URI: source.URI,
+				},
+			},
+		},
+	}
 	existing := &sourcesv1.PingSource{}
 	err := p.K8sclient.Get(ctx, client.ObjectKey{Name: desired.Name, Namespace: desired.Namespace}, existing)
 	if err != nil {
@@ -147,33 +166,6 @@ func (p PingSourceManager) cleanUpOrphans(ctx context.Context, capp cappv1alpha1
 		}
 	}
 	return nil
-}
-
-func (p PingSourceManager) preparePingSource(capp cappv1alpha1.Capp, source cappv1alpha1.SourceConfiguration) *sourcesv1.PingSource {
-	cfg := source.PingSourceConfiguration
-	return &sourcesv1.PingSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", capp.Name, source.Name),
-			Namespace: capp.Namespace,
-			Labels:    utils.ManagedResourceLabels(capp.Name),
-		},
-		Spec: sourcesv1.PingSourceSpec{
-			Schedule:    cfg.Schedule,
-			Data:        cfg.Data,
-			ContentType: event.ApplicationJSON,
-			SourceSpec: duckv1.SourceSpec{
-				Sink: duckv1.Destination{
-					Ref: &duckv1.KReference{
-						Name:       capp.Name,
-						Namespace:  capp.Namespace,
-						Kind:       knativeServiceKind,
-						APIVersion: servingv1.SchemeGroupVersion.String(),
-					},
-					URI: source.URI,
-				},
-			},
-		},
-	}
 }
 
 func (p PingSourceManager) getPingSources(ctx context.Context, capp cappv1alpha1.Capp) (sourcesv1.PingSourceList, error) {

--- a/internal/kinds/capp/resourcemanagers/pingsource_test.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource_test.go
@@ -23,13 +23,11 @@ import (
 )
 
 const (
-	cappName      = "my-capp"
-	cappNamespace = "my-ns"
-	sourceName    = "ping"
-	schedule      = "* * * * *"
-	sourceA       = "ping-a"
-	sourceB       = "ping-b"
-	sourceC       = "ping-c"
+	sourceName = "ping"
+	schedule   = "* * * * *"
+	sourceA    = "ping-a"
+	sourceB    = "ping-b"
+	sourceC    = "ping-c"
 )
 
 func pingSourceName(source string) string {
@@ -37,8 +35,7 @@ func pingSourceName(source string) string {
 }
 
 func newPingSourceScheme() *runtime.Scheme {
-	s := runtime.NewScheme()
-	utilruntime.Must(cappv1alpha1.AddToScheme(s))
+	s := newScheme()
 	utilruntime.Must(sourcesv1.AddToScheme(s))
 	utilruntime.Must(servingv1.AddToScheme(s))
 	return s
@@ -51,17 +48,10 @@ func newPingSourceManager(k8sClient client.Client) PingSourceManager {
 	}
 }
 
-func newCapp(name, namespace string, sources []cappv1alpha1.SourceConfiguration) cappv1alpha1.Capp {
-	return cappv1alpha1.Capp{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			UID:       types.UID("test-uid"),
-		},
-		Spec: cappv1alpha1.CappSpec{
-			EventSourcesSpec: cappv1alpha1.EventSourcesSpec{Sources: sources},
-		},
-	}
+func newPingCapp(sources []cappv1alpha1.SourceConfiguration) cappv1alpha1.Capp {
+	capp := newBaseCapp()
+	capp.Spec.EventSourcesSpec.Sources = sources
+	return capp
 }
 
 func newPingSource(source string) *sourcesv1.PingSource {
@@ -114,7 +104,7 @@ func TestPingSourceCleanUpOrphans(t *testing.T) {
 				assert.NoError(t, fakeClient.Create(ctx, ps))
 			}
 			pm := newPingSourceManager(fakeClient)
-			capp := newCapp(cappName, cappNamespace, tt.sources)
+			capp := newPingCapp(tt.sources)
 			assert.NoError(t, pm.cleanUpOrphans(ctx, capp))
 			for _, name := range tt.expectKept {
 				got := &sourcesv1.PingSource{}
@@ -155,7 +145,7 @@ func TestPingSourceCreateOrUpdate(t *testing.T) {
 			ctx := context.Background()
 			fakeClient := fake.NewClientBuilder().WithScheme(newPingSourceScheme()).Build()
 			pm := newPingSourceManager(fakeClient)
-			capp := newCapp(cappName, cappNamespace, nil)
+			capp := newPingCapp(nil)
 
 			if tt.preCreate {
 				src := cappv1alpha1.SourceConfiguration{
@@ -219,7 +209,7 @@ func TestPingSourceGetStatus(t *testing.T) {
 				assert.NoError(t, fakeClient.Create(ctx, ps))
 			}
 			pm := newPingSourceManager(fakeClient)
-			capp := newCapp(cappName, cappNamespace, nil)
+			capp := newPingCapp(nil)
 			result, err := pm.GetStatus(ctx, capp)
 			assert.NoError(t, err)
 			if tt.expectedNames == nil {


### PR DESCRIPTION
Establish unit test coverage for the Knative Service manager and
share common test setup across resourcemanagers.