### PR TITLE
test: drop redundant ksvc label asserts in create-delete e2e

### DIFF
--- a/test/e2e/knative_test.go
+++ b/test/e2e/knative_test.go
@@ -274,35 +274,6 @@ var _ = Describe("Validate knative functionality", func() {
 		}, consts.Timeout, consts.Interval).Should(Equal("666"))
 	})
 
-	It("Should propagate Capp labels to the underlying KSVC", func() {
-		By("Creating a capp instance")
-		testCapp := mocks.CreateBaseCapp()
-		labels := map[string]string{
-			consts.TestLabelKey:    consts.TestIndex,
-			consts.CappResourceKey: consts.TestIndex,
-		}
-		testCapp.Labels = labels
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
-		assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-
-		By("Checking if user-defined labels were propagated to the ksvc")
-		Eventually(func() string {
-			ksvc := utils.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return ksvc.Spec.ConfigurationSpec.Template.Labels[consts.TestLabelKey]
-		}, consts.Timeout, consts.Interval).Should(Equal(consts.TestIndex))
-
-		By("Checking if labels set by the controller cannot be overridden by users")
-		Consistently(func() string {
-			ksvc := utils.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return ksvc.Spec.ConfigurationSpec.Template.Labels[consts.CappResourceKey]
-		}, consts.DefaultConsistently, consts.Interval).ShouldNot(Equal(consts.TestIndex))
-
-		Eventually(func() string {
-			ksvc := utils.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return ksvc.Spec.ConfigurationSpec.Template.Labels[consts.CappResourceKey]
-		}, consts.Timeout, consts.Interval).Should(Equal(assertionCapp.Name))
-	})
-
 	It("Should check the default ksvc annotation is equal to the cappConfig's concurrency value", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()

--- a/test/e2e/ksvc_test.go
+++ b/test/e2e/ksvc_test.go
@@ -66,11 +66,6 @@ var _ = Describe("Validate KSVC functionality", func() {
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 		checkRevisionReadiness(assertionCapp.Name + consts.FirstRevisionSuffix)
 
-		By("Checking the ksvc has the needed labels")
-		ksvcObject = utils.GetKSVC(k8sClient, assertionCapp.Name, consts.NSName)
-		Expect(ksvcObject.Labels[consts.CappResourceKey]).Should(Equal(assertionCapp.Name))
-		Expect(ksvcObject.Labels[consts.ManagedByLabelKey]).Should(Equal(consts.CappKey))
-
 		By("Deleting the capp instance")
 		utils.DeleteCapp(k8sClient, assertionCapp)
 		Eventually(func() bool {

--- a/test/e2e/ksvc_test.go
+++ b/test/e2e/ksvc_test.go
@@ -38,7 +38,7 @@ func checkRevisionReadiness(revisionName string) {
 	}, consts.Timeout, consts.Interval).Should(BeTrue())
 }
 
-var _ = Describe("Validate knative functionality", func() {
+var _ = Describe("Validate KSVC functionality", func() {
 	It("Should create a ksvc with memory metric annotation when creating a capp with memory scale metric", func() {
 		By("Creating a capp instance with memory scale metric")
 		testCapp := mocks.CreateBaseCapp()


### PR DESCRIPTION
Managed labels on create are covered by KnativeServiceManager unit
tests; keep revision readiness and delete cascade in e2e.