### PR TITLE
test: collapse redundant ksvc update e2e into revision check

### DIFF
--- a/test/e2e/knative_test.go
+++ b/test/e2e/knative_test.go
@@ -274,35 +274,6 @@ var _ = Describe("Validate knative functionality", func() {
 		}, consts.Timeout, consts.Interval).Should(Equal("666"))
 	})
 
-	It("Should propagate Capp labels to the underlying KSVC", func() {
-		By("Creating a capp instance")
-		testCapp := mocks.CreateBaseCapp()
-		labels := map[string]string{
-			consts.TestLabelKey:    consts.TestIndex,
-			consts.CappResourceKey: consts.TestIndex,
-		}
-		testCapp.Labels = labels
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
-		assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-
-		By("Checking if user-defined labels were propagated to the ksvc")
-		Eventually(func() string {
-			ksvc := utils.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return ksvc.Spec.ConfigurationSpec.Template.Labels[consts.TestLabelKey]
-		}, consts.Timeout, consts.Interval).Should(Equal(consts.TestIndex))
-
-		By("Checking if labels set by the controller cannot be overridden by users")
-		Consistently(func() string {
-			ksvc := utils.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return ksvc.Spec.ConfigurationSpec.Template.Labels[consts.CappResourceKey]
-		}, consts.DefaultConsistently, consts.Interval).ShouldNot(Equal(consts.TestIndex))
-
-		Eventually(func() string {
-			ksvc := utils.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return ksvc.Spec.ConfigurationSpec.Template.Labels[consts.CappResourceKey]
-		}, consts.Timeout, consts.Interval).Should(Equal(assertionCapp.Name))
-	})
-
 	It("Should check the default ksvc annotation is equal to the cappConfig's concurrency value", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()

--- a/test/e2e/ksvc_test.go
+++ b/test/e2e/ksvc_test.go
@@ -66,11 +66,6 @@ var _ = Describe("Validate KSVC functionality", func() {
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 		checkRevisionReadiness(assertionCapp.Name + consts.FirstRevisionSuffix)
 
-		By("Checking the ksvc has the needed labels")
-		ksvcObject = utils.GetKSVC(k8sClient, assertionCapp.Name, consts.NSName)
-		Expect(ksvcObject.Labels[consts.CappResourceKey]).Should(Equal(assertionCapp.Name))
-		Expect(ksvcObject.Labels[consts.ManagedByLabelKey]).Should(Equal(consts.CappKey))
-
 		By("Deleting the capp instance")
 		utils.DeleteCapp(k8sClient, assertionCapp)
 		Eventually(func() bool {

--- a/test/e2e/ksvc_test.go
+++ b/test/e2e/ksvc_test.go
@@ -38,7 +38,7 @@ func checkRevisionReadiness(revisionName string) {
 	}, consts.Timeout, consts.Interval).Should(BeTrue())
 }
 
-var _ = Describe("Validate knative functionality", func() {
+var _ = Describe("Validate KSVC functionality", func() {
 	It("Should create a ksvc with memory metric annotation when creating a capp with memory scale metric", func() {
 		By("Creating a capp instance with memory scale metric")
 		testCapp := mocks.CreateBaseCapp()

--- a/test/e2e/ksvc_test.go
+++ b/test/e2e/ksvc_test.go
@@ -84,63 +84,12 @@ var _ = Describe("Validate KSVC functionality", func() {
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
-	It("Should update ksvc metric annotation and create a new revision when updating the capp scale metric", func() {
-		By("Creating a capp instance")
-		testCapp := mocks.CreateBaseCapp()
-		testCapp.Spec.ScaleSpec.Metric = consts.CPUScaleMetric
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
-
-		By("Updating the Capp scale metric")
-		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
-
-			assertionCapp.Spec.ScaleSpec.Metric = consts.MemoryScaleMetric
-			return utils.UpdateResource(k8sClient, assertionCapp)
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		verifyLatestReadyRevision(createdCapp.Name, createdCapp.Namespace, latestReadyRevisionBeforeUpdate)
-
-		By("Checking if the ksvc was updated successfully")
-		Eventually(func() string {
-			ksvc := utils.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			return ksvc.Spec.Template.Annotations[consts.KnativeMetricAnnotation]
-		}, consts.Timeout, consts.Interval).Should(Equal("memory"))
-	})
-
-	It("Should update ksvc container name and create a new revision when updating a capp container name", func() {
+	It("Should create a new ready revision when updating capp spec", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
 		createdCapp := utils.CreateCapp(k8sClient, testCapp)
 
-		By("Updating the a capp container name")
-		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
-
-			assertionCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Name = consts.TestContainerName
-			return utils.UpdateResource(k8sClient, assertionCapp)
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		verifyLatestReadyRevision(createdCapp.Name, createdCapp.Namespace, latestReadyRevisionBeforeUpdate)
-
-		By("Checking if the ksvc was updated successfully")
-		Eventually(func() string {
-			ksvc := utils.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			return ksvc.Spec.ConfigurationSpec.Template.Spec.Containers[0].Name
-		}, consts.Timeout, consts.Interval).Should(Equal(consts.TestContainerName))
-	})
-
-	It("Should update ksvc container image and create a new revision when updating a capp container image", func() {
-		By("Creating a capp instance")
-		testCapp := mocks.CreateBaseCapp()
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
-
-		By("Updating capp's container image")
+		By("Updating capp container image")
 		var latestReadyRevisionBeforeUpdate string
 		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
 			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
@@ -152,67 +101,6 @@ var _ = Describe("Validate KSVC functionality", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		verifyLatestReadyRevision(createdCapp.Name, createdCapp.Namespace, latestReadyRevisionBeforeUpdate)
-
-		By("Checking if the ksvc's container image was updated successfully")
-		Eventually(func() string {
-			ksvc := utils.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			return ksvc.Spec.ConfigurationSpec.Template.Spec.Containers[0].Image
-		}, consts.Timeout, consts.Interval).Should(Equal(consts.ImageExample))
-	})
-
-	It("Should update ksvc when updating a propagating Capp metadata annotation", func() {
-		const propagationAnnKey = "example.com/e2e-propagation"
-
-		By("Creating a capp instance")
-		testCapp := mocks.CreateBaseCapp()
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
-
-		By("Updating capp metadata annotation that is copied to the Knative Service")
-		cappAnnotations := map[string]string{}
-		cappAnnotations[propagationAnnKey] = consts.ExampleAppName
-
-		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
-
-			assertionCapp.Annotations = cappAnnotations
-			return utils.UpdateResource(k8sClient, assertionCapp)
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		verifyLatestReadyRevision(createdCapp.Name, createdCapp.Namespace, latestReadyRevisionBeforeUpdate)
-
-		By("Checking if the ksvc template annotation was updated successfully")
-		Eventually(func() string {
-			ksvc := utils.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			return ksvc.Spec.Template.Annotations[propagationAnnKey]
-		}, consts.Timeout, consts.Interval).Should(Equal(consts.ExampleAppName))
-	})
-
-	It("Should update ksvc environment variable and create a new revision when updating a capp container environment variable", func() {
-		By("Creating a capp instance")
-		testCapp := mocks.CreateBaseCapp()
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
-
-		By("Updating capp's container environment variable")
-		var latestReadyRevisionBeforeUpdate string
-		err := retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
-			assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			latestReadyRevisionBeforeUpdate = assertionCapp.Status.KnativeObjectStatus.LatestReadyRevisionName
-
-			assertionCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Env[0].Value = consts.ExampleAppName
-			return utils.UpdateResource(k8sClient, assertionCapp)
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		verifyLatestReadyRevision(createdCapp.Name, createdCapp.Namespace, latestReadyRevisionBeforeUpdate)
-
-		By("Checking if the ksvc's container environment variable was updated successfully")
-		Eventually(func() string {
-			ksvc := utils.GetKSVC(k8sClient, createdCapp.Name, createdCapp.Namespace)
-			return ksvc.Spec.ConfigurationSpec.Template.Spec.Containers[0].Env[0].Value
-		}, consts.Timeout, consts.Interval).Should(Equal(consts.ExampleAppName))
 	})
 
 	It("Should create a new revision in ready state when updating capp's secret environment variable", func() {


### PR DESCRIPTION
Replace five field-specific update tests with one spec-change test
that only verifies a new ready revision; spec sync stays in unit tests.