### PR TITLE
chore: sync chart CappConfig CRD with generated base

### DIFF
--- a/charts/container-app-operator/crds/rcs.dana.io_cappconfigs.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_cappconfigs.yaml
@@ -65,8 +65,9 @@ spec:
               autoscaleConfig:
                 properties:
                   activationScale:
-                    description: ActivationScale is the default scale.
-                    minimum: 1
+                    description: ActivationScale is the default number of replicas
+                      used when a scale-to-zero Capp scales up from idle.
+                    minimum: 2
                     type: integer
                   concurrency:
                     description: Concurrency is the maximum concurrency of a Capp.


### PR DESCRIPTION
Chart copy of rcs.dana.io_cappconfigs.yaml lagged config/crd/bases.