### PR TITLE
feat: add unit tests for CappRevision controllers and action managers

### DIFF
--- a/internal/kinds/capprevision/actionmanagers/create_test.go
+++ b/internal/kinds/capprevision/actionmanagers/create_test.go
@@ -1,0 +1,77 @@
+package actionmanagers
+
+import (
+	"context"
+	"testing"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleCappCreation(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	t.Run("creates first revision with revision number 1", func(t *testing.T) {
+		capp := newBaseCapp()
+		k8sClient := newFakeClient()
+
+		require.NoError(t, HandleCappCreation(ctx, k8sClient, capp, logger))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		require.Len(t, revList.Items, 1)
+		require.Equal(t, 1, revList.Items[0].Spec.RevisionNumber)
+	})
+
+	t.Run("revision captures capp spec", func(t *testing.T) {
+		capp := newBaseCapp()
+		capp.Spec.State = stateDisabled
+		k8sClient := newFakeClient()
+
+		require.NoError(t, HandleCappCreation(ctx, k8sClient, capp, logger))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		require.Equal(t, capp.Spec, revList.Items[0].Spec.CappTemplate.Spec)
+	})
+
+	t.Run("revision captures capp labels and annotations", func(t *testing.T) {
+		capp := newBaseCapp()
+		capp.Labels = map[string]string{labelTeamKey: labelTeamPlatform}
+		capp.Annotations = map[string]string{annotationNoteKey: annotationNoteHi}
+		k8sClient := newFakeClient()
+
+		require.NoError(t, HandleCappCreation(ctx, k8sClient, capp, logger))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		require.Equal(t, capp.Labels, revList.Items[0].Spec.CappTemplate.Labels)
+		require.Equal(t, capp.Annotations, revList.Items[0].Spec.CappTemplate.Annotations)
+	})
+
+	t.Run("revision has owner reference to capp", func(t *testing.T) {
+		capp := newBaseCapp()
+		k8sClient := newFakeClient()
+
+		require.NoError(t, HandleCappCreation(ctx, k8sClient, capp, logger))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		require.Len(t, revList.Items[0].OwnerReferences, 1)
+		require.Equal(t, cappName, revList.Items[0].OwnerReferences[0].Name)
+	})
+
+	t.Run("revision has capp name label", func(t *testing.T) {
+		capp := newBaseCapp()
+		k8sClient := newFakeClient()
+
+		require.NoError(t, HandleCappCreation(ctx, k8sClient, capp, logger))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		labelKey := cappv1alpha1.GroupVersion.Group + "/cappName"
+		require.Equal(t, cappName, revList.Items[0].Labels[labelKey])
+	})
+}

--- a/internal/kinds/capprevision/actionmanagers/fixtures_test.go
+++ b/internal/kinds/capprevision/actionmanagers/fixtures_test.go
@@ -1,0 +1,108 @@
+package actionmanagers
+
+import (
+	"time"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	cappName      = "my-capp"
+	cappNamespace = "my-ns"
+	testCappUID   = types.UID("test-uid")
+
+	stateDisabled      = "disabled"
+	labelTeamKey       = "team"
+	labelTeamPlatform  = "platform"
+	labelTeamInfra     = "infra"
+	annotationNoteKey  = "note"
+	annotationNoteHi   = "hello"
+	annotationUserA    = "user-a"
+	annotationUserB    = "user-b"
+	annotationKeyKey   = "key"
+	annotationKeyVal   = "val"
+	annotationKeyValA  = "val-a"
+	annotationKeyValB  = "val-b"
+	annotationOtherKey = "other"
+	annotationSameVal  = "same"
+)
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(cappv1alpha1.AddToScheme(s))
+	return s
+}
+
+func newFakeClient(objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithObjects(objects...).
+		Build()
+}
+
+func newBaseCapp() cappv1alpha1.Capp {
+	return cappv1alpha1.Capp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cappName,
+			Namespace: cappNamespace,
+			UID:       testCappUID,
+		},
+		Spec: cappv1alpha1.CappSpec{
+			ConfigurationSpec: knativev1.ConfigurationSpec{
+				Template: knativev1.RevisionTemplateSpec{
+					Spec: knativev1.RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "app",
+								Image: "example.com/app:v1",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newCappConfig(revisionHistoryLimit int) *cappv1alpha1.CappConfig {
+	return &cappv1alpha1.CappConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.CappConfigName,
+			Namespace: utils.CappNS,
+		},
+		Spec: cappv1alpha1.CappConfigSpec{
+			RevisionHistoryLimit: revisionHistoryLimit,
+		},
+	}
+}
+
+func newCappRevision(name string, revisionNumber int, capp cappv1alpha1.Capp, creationTime time.Time) *cappv1alpha1.CappRevision {
+	return &cappv1alpha1.CappRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         capp.Namespace,
+			CreationTimestamp: metav1.NewTime(creationTime),
+			Labels: map[string]string{
+				cappv1alpha1.GroupVersion.Group + "/cappName": capp.Name,
+			},
+		},
+		Spec: cappv1alpha1.CappRevisionSpec{
+			RevisionNumber: revisionNumber,
+			CappTemplate: cappv1alpha1.CappTemplate{
+				Spec:        *capp.Spec.DeepCopy(),
+				Labels:      capp.Labels,
+				Annotations: capp.Annotations,
+			},
+		},
+	}
+}

--- a/internal/kinds/capprevision/actionmanagers/update_test.go
+++ b/internal/kinds/capprevision/actionmanagers/update_test.go
@@ -1,0 +1,330 @@
+package actionmanagers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSplitRevisionsAtIndex(t *testing.T) {
+	revisions := []cappv1alpha1.CappRevision{
+		{ObjectMeta: metav1.ObjectMeta{Name: "rev-1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "rev-2"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "rev-3"}},
+	}
+
+	tests := []struct {
+		name          string
+		index         int
+		wantBeforeLen int
+		wantAfterLen  int
+	}{
+		{
+			name:          "split in the middle",
+			index:         2,
+			wantBeforeLen: 2,
+			wantAfterLen:  1,
+		},
+		{
+			name:          "split at zero returns all in after",
+			index:         0,
+			wantBeforeLen: 0,
+			wantAfterLen:  3,
+		},
+		{
+			name:          "split at negative returns all in after",
+			index:         -1,
+			wantBeforeLen: 0,
+			wantAfterLen:  3,
+		},
+		{
+			name:          "split beyond length returns all in before",
+			index:         5,
+			wantBeforeLen: 3,
+			wantAfterLen:  0,
+		},
+		{
+			name:          "split at exact length returns all in before",
+			index:         3,
+			wantBeforeLen: 3,
+			wantAfterLen:  0,
+		},
+		{
+			name:          "split at one",
+			index:         1,
+			wantBeforeLen: 1,
+			wantAfterLen:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before, after := splitRevisionsAtIndex(revisions, tt.index)
+			require.Len(t, before, tt.wantBeforeLen)
+			require.Len(t, after, tt.wantAfterLen)
+		})
+	}
+}
+
+func TestSortByCreationTime(t *testing.T) {
+	now := time.Now()
+	revisions := []cappv1alpha1.CappRevision{
+		{ObjectMeta: metav1.ObjectMeta{Name: "oldest", CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Hour))}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "newest", CreationTimestamp: metav1.NewTime(now)}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "middle", CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour))}},
+	}
+
+	sortByCreationTime(revisions)
+
+	require.Equal(t, "newest", revisions[0].Name)
+	require.Equal(t, "middle", revisions[1].Name)
+	require.Equal(t, "oldest", revisions[2].Name)
+}
+
+func TestEqualSpec(t *testing.T) {
+	capp := newBaseCapp()
+
+	t.Run("returns true for identical specs", func(t *testing.T) {
+		revisionSpec := *capp.Spec.DeepCopy()
+		require.True(t, equalSpec(capp.Spec, revisionSpec))
+	})
+
+	t.Run("returns false when spec differs", func(t *testing.T) {
+		revisionSpec := *capp.Spec.DeepCopy()
+		revisionSpec.State = stateDisabled
+		require.False(t, equalSpec(capp.Spec, revisionSpec))
+	})
+}
+
+func TestEqualAnnotations(t *testing.T) {
+	t.Run("returns true for identical annotations", func(t *testing.T) {
+		a := map[string]string{annotationKeyKey: annotationKeyVal}
+		b := map[string]string{annotationKeyKey: annotationKeyVal}
+		require.True(t, equalAnnotations(a, b, annotationToIgnore))
+	})
+
+	t.Run("returns false when annotations differ", func(t *testing.T) {
+		a := map[string]string{annotationKeyKey: annotationKeyValA}
+		b := map[string]string{annotationKeyKey: annotationKeyValB}
+		require.False(t, equalAnnotations(a, b, annotationToIgnore))
+	})
+
+	t.Run("ignores the last-updated-by annotation", func(t *testing.T) {
+		a := map[string]string{annotationToIgnore: annotationUserA, annotationOtherKey: annotationSameVal}
+		b := map[string]string{annotationToIgnore: annotationUserB, annotationOtherKey: annotationSameVal}
+		require.True(t, equalAnnotations(a, b, annotationToIgnore))
+	})
+
+	t.Run("returns true for both nil", func(t *testing.T) {
+		require.True(t, equalAnnotations(nil, nil, annotationToIgnore))
+	})
+
+	t.Run("returns true when only ignored key present on one side", func(t *testing.T) {
+		a := map[string]string{annotationToIgnore: annotationUserA}
+		b := map[string]string{}
+		require.True(t, equalAnnotations(a, b, annotationToIgnore))
+	})
+}
+
+func TestEqualLabels(t *testing.T) {
+	t.Run("returns true for identical labels", func(t *testing.T) {
+		a := map[string]string{labelTeamKey: labelTeamPlatform}
+		b := map[string]string{labelTeamKey: labelTeamPlatform}
+		require.True(t, equalLabels(a, b))
+	})
+
+	t.Run("returns false when labels differ", func(t *testing.T) {
+		a := map[string]string{labelTeamKey: labelTeamPlatform}
+		b := map[string]string{labelTeamKey: labelTeamInfra}
+		require.False(t, equalLabels(a, b))
+	})
+
+	t.Run("returns true for both nil", func(t *testing.T) {
+		require.True(t, equalLabels(nil, nil))
+	})
+}
+
+func TestIsEqual(t *testing.T) {
+	capp := newBaseCapp()
+	capp.Labels = map[string]string{labelTeamKey: labelTeamPlatform}
+	capp.Annotations = map[string]string{annotationNoteKey: annotationNoteHi}
+
+	t.Run("returns true when capp matches revision", func(t *testing.T) {
+		rev := *newCappRevision("rev-1", 1, capp, time.Now())
+		require.True(t, isEqual(capp, rev))
+	})
+
+	t.Run("returns false when spec differs", func(t *testing.T) {
+		rev := *newCappRevision("rev-1", 1, capp, time.Now())
+		rev.Spec.CappTemplate.Spec.State = stateDisabled
+		require.False(t, isEqual(capp, rev))
+	})
+
+	t.Run("returns false when labels differ", func(t *testing.T) {
+		rev := *newCappRevision("rev-1", 1, capp, time.Now())
+		rev.Spec.CappTemplate.Labels = map[string]string{labelTeamKey: labelTeamInfra}
+		require.False(t, isEqual(capp, rev))
+	})
+
+	t.Run("returns false when annotations differ", func(t *testing.T) {
+		rev := *newCappRevision("rev-1", 1, capp, time.Now())
+		rev.Spec.CappTemplate.Annotations = map[string]string{annotationNoteKey: "changed"}
+		require.False(t, isEqual(capp, rev))
+	})
+
+	t.Run("ignores last-updated-by annotation difference", func(t *testing.T) {
+		cappWithUpdatedBy := capp.DeepCopy()
+		cappWithUpdatedBy.Annotations = map[string]string{annotationNoteKey: annotationNoteHi, annotationToIgnore: annotationUserA}
+
+		rev := *newCappRevision("rev-1", 1, *cappWithUpdatedBy, time.Now())
+		rev.Spec.CappTemplate.Annotations[annotationToIgnore] = annotationUserB
+		require.True(t, isEqual(*cappWithUpdatedBy, rev))
+	})
+}
+
+func TestHandleCappUpdate(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+	now := time.Now()
+
+	t.Run("no-op when capp equals latest revision", func(t *testing.T) {
+		capp := newBaseCapp()
+		rev := newCappRevision("rev-00001", 1, capp, now)
+
+		k8sClient := newFakeClient(newCappConfig(10), rev)
+		revisions := []cappv1alpha1.CappRevision{*rev}
+
+		require.NoError(t, HandleCappUpdate(ctx, k8sClient, capp, logger, revisions))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		require.Len(t, revList.Items, 1)
+	})
+
+	t.Run("creates new revision when spec changes and under limit", func(t *testing.T) {
+		capp := newBaseCapp()
+		rev := newCappRevision("rev-00001", 1, capp, now)
+
+		k8sClient := newFakeClient(newCappConfig(10), rev)
+		revisions := []cappv1alpha1.CappRevision{*rev}
+
+		capp.Spec.State = stateDisabled
+		require.NoError(t, HandleCappUpdate(ctx, k8sClient, capp, logger, revisions))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		require.Len(t, revList.Items, 2)
+	})
+
+	t.Run("creates new revision when labels change", func(t *testing.T) {
+		capp := newBaseCapp()
+		capp.Labels = map[string]string{labelTeamKey: labelTeamPlatform}
+		rev := newCappRevision("rev-00001", 1, capp, now)
+
+		k8sClient := newFakeClient(newCappConfig(10), rev)
+		revisions := []cappv1alpha1.CappRevision{*rev}
+
+		capp.Labels = map[string]string{labelTeamKey: labelTeamInfra}
+		require.NoError(t, HandleCappUpdate(ctx, k8sClient, capp, logger, revisions))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		require.Len(t, revList.Items, 2)
+	})
+
+	t.Run("creates new revision when annotations change", func(t *testing.T) {
+		capp := newBaseCapp()
+		capp.Annotations = map[string]string{annotationNoteKey: "v1"}
+		rev := newCappRevision("rev-00001", 1, capp, now)
+
+		k8sClient := newFakeClient(newCappConfig(10), rev)
+		revisions := []cappv1alpha1.CappRevision{*rev}
+
+		capp.Annotations = map[string]string{annotationNoteKey: "v2"}
+		require.NoError(t, HandleCappUpdate(ctx, k8sClient, capp, logger, revisions))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		require.Len(t, revList.Items, 2)
+	})
+
+	t.Run("prunes oldest revisions when at limit", func(t *testing.T) {
+		capp := newBaseCapp()
+		limit := 3
+
+		rev1 := newCappRevision("rev-00001", 1, capp, now.Add(-2*time.Hour))
+		rev2 := newCappRevision("rev-00002", 2, capp, now.Add(-1*time.Hour))
+		rev3 := newCappRevision("rev-00003", 3, capp, now)
+
+		k8sClient := newFakeClient(newCappConfig(limit), rev1, rev2, rev3)
+		revisions := []cappv1alpha1.CappRevision{*rev1, *rev2, *rev3}
+
+		capp.Spec.State = stateDisabled
+		require.NoError(t, HandleCappUpdate(ctx, k8sClient, capp, logger, revisions))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		require.Len(t, revList.Items, limit)
+	})
+
+	t.Run("prunes excess revisions when over limit", func(t *testing.T) {
+		capp := newBaseCapp()
+		limit := 2
+
+		rev1 := newCappRevision("rev-00001", 1, capp, now.Add(-3*time.Hour))
+		rev2 := newCappRevision("rev-00002", 2, capp, now.Add(-2*time.Hour))
+		rev3 := newCappRevision("rev-00003", 3, capp, now.Add(-1*time.Hour))
+		rev4 := newCappRevision("rev-00004", 4, capp, now)
+
+		k8sClient := newFakeClient(newCappConfig(limit), rev1, rev2, rev3, rev4)
+		revisions := []cappv1alpha1.CappRevision{*rev1, *rev2, *rev3, *rev4}
+
+		capp.Spec.State = stateDisabled
+		require.NoError(t, HandleCappUpdate(ctx, k8sClient, capp, logger, revisions))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		require.Len(t, revList.Items, limit)
+	})
+
+	t.Run("new revision number is based on latest kept revision", func(t *testing.T) {
+		capp := newBaseCapp()
+		limit := 2
+
+		rev1 := newCappRevision("rev-00001", 1, capp, now.Add(-1*time.Hour))
+		rev2 := newCappRevision("rev-00002", 2, capp, now)
+
+		k8sClient := newFakeClient(newCappConfig(limit), rev1, rev2)
+		revisions := []cappv1alpha1.CappRevision{*rev1, *rev2}
+
+		capp.Spec.State = stateDisabled
+		require.NoError(t, HandleCappUpdate(ctx, k8sClient, capp, logger, revisions))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+
+		var maxRevNum int
+		for _, r := range revList.Items {
+			if r.Spec.RevisionNumber > maxRevNum {
+				maxRevNum = r.Spec.RevisionNumber
+			}
+		}
+		require.Equal(t, 3, maxRevNum)
+	})
+
+	t.Run("returns error when capp config is missing", func(t *testing.T) {
+		capp := newBaseCapp()
+		rev := newCappRevision("rev-00001", 1, capp, now)
+
+		k8sClient := newFakeClient(rev)
+		revisions := []cappv1alpha1.CappRevision{*rev}
+
+		capp.Spec.State = stateDisabled
+		require.Error(t, HandleCappUpdate(ctx, k8sClient, capp, logger, revisions))
+	})
+}

--- a/internal/kinds/capprevision/controllers/controller_test.go
+++ b/internal/kinds/capprevision/controllers/controller_test.go
@@ -1,0 +1,239 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	cappName      = "my-capp"
+	cappNamespace = "my-ns"
+	testCappUID   = types.UID("test-uid")
+
+	stateDisabled       = "disabled"
+	defaultHistoryLimit = 10
+	defaultRevisionName = "rev-00001"
+)
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(cappv1alpha1.AddToScheme(s))
+	return s
+}
+
+func newFakeClient(objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithObjects(objects...).
+		Build()
+}
+
+func newBaseCapp() *cappv1alpha1.Capp {
+	return &cappv1alpha1.Capp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cappName,
+			Namespace: cappNamespace,
+			UID:       testCappUID,
+		},
+		Spec: cappv1alpha1.CappSpec{
+			ConfigurationSpec: knativev1.ConfigurationSpec{
+				Template: knativev1.RevisionTemplateSpec{
+					Spec: knativev1.RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "app",
+								Image: "example.com/app:v1",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newDefaultCappConfig() *cappv1alpha1.CappConfig {
+	return &cappv1alpha1.CappConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.CappConfigName,
+			Namespace: utils.CappNS,
+		},
+		Spec: cappv1alpha1.CappConfigSpec{
+			RevisionHistoryLimit: defaultHistoryLimit,
+		},
+	}
+}
+
+func newCappRevision(capp *cappv1alpha1.Capp, creationTime time.Time) *cappv1alpha1.CappRevision {
+	return &cappv1alpha1.CappRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              defaultRevisionName,
+			Namespace:         capp.Namespace,
+			CreationTimestamp: metav1.NewTime(creationTime),
+			Labels: map[string]string{
+				cappv1alpha1.GroupVersion.Group + "/cappName": capp.Name,
+			},
+		},
+		Spec: cappv1alpha1.CappRevisionSpec{
+			RevisionNumber: 1,
+			CappTemplate: cappv1alpha1.CappTemplate{
+				Spec:        *capp.Spec.DeepCopy(),
+				Labels:      capp.Labels,
+				Annotations: capp.Annotations,
+			},
+		},
+	}
+}
+
+func newReconciler(k8sClient client.Client) *CappRevisionReconciler {
+	return &CappRevisionReconciler{
+		Log:    logr.Discard(),
+		Client: k8sClient,
+		Scheme: newScheme(),
+	}
+}
+
+func newRequest() reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      cappName,
+			Namespace: cappNamespace,
+		},
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns empty result when capp not found", func(t *testing.T) {
+		r := newReconciler(newFakeClient())
+
+		result, err := r.Reconcile(ctx, newRequest())
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+	})
+
+	t.Run("returns empty result when capp is deleting", func(t *testing.T) {
+		capp := newBaseCapp()
+		now := metav1.Now()
+		capp.DeletionTimestamp = &now
+		capp.Finalizers = []string{"test-finalizer"}
+
+		r := newReconciler(newFakeClient(capp))
+
+		result, err := r.Reconcile(ctx, newRequest())
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+	})
+
+	t.Run("creates first revision for new capp", func(t *testing.T) {
+		capp := newBaseCapp()
+		r := newReconciler(newFakeClient(capp, newDefaultCappConfig()))
+
+		result, err := r.Reconcile(ctx, newRequest())
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, r.List(ctx, revList))
+		require.Len(t, revList.Items, 1)
+		require.Equal(t, 1, revList.Items[0].Spec.RevisionNumber)
+	})
+
+	t.Run("creates new revision when capp spec changes", func(t *testing.T) {
+		capp := newBaseCapp()
+		rev := newCappRevision(capp, time.Now())
+		r := newReconciler(newFakeClient(capp, rev, newDefaultCappConfig()))
+
+		capp.Spec.State = stateDisabled
+		require.NoError(t, r.Update(ctx, capp))
+
+		result, err := r.Reconcile(ctx, newRequest())
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, r.List(ctx, revList))
+		require.Len(t, revList.Items, 2)
+	})
+
+	t.Run("no-op when capp matches latest revision", func(t *testing.T) {
+		capp := newBaseCapp()
+		rev := newCappRevision(capp, time.Now())
+		r := newReconciler(newFakeClient(capp, rev, newDefaultCappConfig()))
+
+		result, err := r.Reconcile(ctx, newRequest())
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, r.List(ctx, revList))
+		require.Len(t, revList.Items, 1)
+	})
+
+	t.Run("returns error when capp config is missing with existing revisions", func(t *testing.T) {
+		capp := newBaseCapp()
+		rev := newCappRevision(capp, time.Now())
+		r := newReconciler(newFakeClient(capp, rev))
+
+		capp.Spec.State = stateDisabled
+		require.NoError(t, r.Update(ctx, capp))
+
+		_, err := r.Reconcile(ctx, newRequest())
+
+		require.Error(t, err)
+	})
+}
+
+func TestSyncCappRevision(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	t.Run("creates first revision when no revisions exist", func(t *testing.T) {
+		capp := newBaseCapp()
+		k8sClient := newFakeClient(capp)
+
+		require.NoError(t, syncCappRevision(ctx, k8sClient, *capp, logger))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		require.Len(t, revList.Items, 1)
+	})
+
+	t.Run("calls update flow when revisions exist", func(t *testing.T) {
+		capp := newBaseCapp()
+		rev := newCappRevision(capp, time.Now())
+		k8sClient := newFakeClient(capp, rev, newDefaultCappConfig())
+
+		capp.Spec.State = stateDisabled
+		require.NoError(t, k8sClient.Update(ctx, capp))
+
+		require.NoError(t, syncCappRevision(ctx, k8sClient, *capp, logger))
+
+		revList := &cappv1alpha1.CappRevisionList{}
+		require.NoError(t, k8sClient.List(ctx, revList))
+		require.Len(t, revList.Items, 2)
+	})
+}


### PR DESCRIPTION
Add comprehensive unit tests for the CappRevision reconciler and action managers, which previously had no unit test coverage (only E2E tests).

New test files:
- actionmanagers/fixtures_test.go: shared test fixtures and helpers
- actionmanagers/create_test.go: HandleCappCreation tests
- actionmanagers/update_test.go: pure logic tests (splitRevisionsAtIndex, sortByCreationTime, equalSpec, equalAnnotations, equalLabels, isEqual) and HandleCappUpdate integration tests (no-op, create, prune, limit)
- controllers/controller_test.go: Reconcile flow tests (not found, deleting, new capp, spec change, no-op) and syncCappRevision tests

Ref: dana-team/container-app-operator#518