### PR TITLE
test(resourcemanagers): add SyslogNGFlow unit tests

### DIFF
--- a/internal/kinds/capp/resourcemanagers/fixtures_test.go
+++ b/internal/kinds/capp/resourcemanagers/fixtures_test.go
@@ -3,6 +3,7 @@ package resourcemanagers
 import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
+	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,7 +14,10 @@ import (
 const (
 	cappName      = "my-capp"
 	cappNamespace = "my-ns"
-	testCappUID   = types.UID("test-uid")
+
+	elasticHost        = "https://elastic.example:9200/_bulk"
+	elasticIndex       = "my-index"
+	unsupportedLogType = "splunk"
 )
 
 func newScheme() *runtime.Scheme {
@@ -28,7 +32,7 @@ func newBaseCapp() cappv1alpha1.Capp {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cappName,
 			Namespace: cappNamespace,
-			UID:       testCappUID,
+			UID:       types.UID("test-uid"),
 		},
 	}
 }
@@ -49,4 +53,23 @@ func newCappConfig() *cappv1alpha1.CappConfig {
 			},
 		},
 	}
+}
+
+func newSyslogNGScheme() *runtime.Scheme {
+	s := newScheme()
+	utilruntime.Must(loggingv1beta1.AddToScheme(s))
+	return s
+}
+
+func newLogSpec(logType cappv1alpha1.LogType) cappv1alpha1.LogSpec {
+	spec := cappv1alpha1.LogSpec{
+		Type:           logType,
+		Host:           elasticHost,
+		User:           "elastic-user",
+		PasswordSecret: "elastic-creds",
+	}
+	if logType == cappv1alpha1.LogTypeElastic {
+		spec.Index = elasticIndex
+	}
+	return spec
 }

--- a/internal/kinds/capp/resourcemanagers/syslogngflow_test.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngflow_test.go
@@ -1,0 +1,162 @@
+package resourcemanagers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
+	"github.com/go-logr/logr"
+	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/filter"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func newSyslogNGFlowManager(k8sClient client.Client) SyslogNGFlowManager {
+	return SyslogNGFlowManager{
+		ResourceManagerClient: rclient.ResourceManagerClient{K8sclient: k8sClient, Log: logr.Discard()},
+		EventRecorder:         events.NewFakeRecorder(10),
+	}
+}
+
+func newSyslogNGFlow(outputRefs ...string) *loggingv1beta1.SyslogNGFlow {
+	if len(outputRefs) == 0 {
+		outputRefs = []string{cappName}
+	}
+	return &loggingv1beta1.SyslogNGFlow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cappName,
+			Namespace: cappNamespace,
+			Labels:    utils.ManagedResourceLabels(cappName),
+		},
+		Spec: loggingv1beta1.SyslogNGFlowSpec{
+			Match: &loggingv1beta1.SyslogNGMatch{
+				Regexp: &filter.RegexpMatchExpr{
+					Pattern: cappName,
+					Type:    "string",
+					Value:   fmt.Sprintf("json#kubernetes#labels#%s", knativeConfiguration),
+				},
+			},
+			LocalOutputRefs: outputRefs,
+		},
+	}
+}
+
+func TestSyslogNGFlowCreateOrUpdate(t *testing.T) {
+	ctx := context.Background()
+	key := types.NamespacedName{Name: cappName, Namespace: cappNamespace}
+
+	t.Run("creates when not found", func(t *testing.T) {
+		fm := newSyslogNGFlowManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		capp := newBaseCapp()
+		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
+
+		require.NoError(t, fm.createOrUpdate(ctx, capp))
+
+		got := &loggingv1beta1.SyslogNGFlow{}
+		require.NoError(t, fm.K8sclient.Get(ctx, key, got))
+		require.Equal(t, cappName, got.Spec.Match.Regexp.Pattern)
+		require.Equal(t, []string{cappName}, got.Spec.LocalOutputRefs)
+		require.Equal(t, cappName, got.OwnerReferences[0].Name)
+	})
+
+	t.Run("updates when spec differs", func(t *testing.T) {
+		fm := newSyslogNGFlowManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		require.NoError(t, fm.K8sclient.Create(ctx, newSyslogNGFlow("stale-output")))
+
+		capp := newBaseCapp()
+		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
+		require.NoError(t, fm.createOrUpdate(ctx, capp))
+
+		got := &loggingv1beta1.SyslogNGFlow{}
+		require.NoError(t, fm.K8sclient.Get(ctx, key, got))
+		require.Equal(t, []string{cappName}, got.Spec.LocalOutputRefs)
+	})
+}
+
+func TestSyslogNGFlowManage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("reconciles when log is required", func(t *testing.T) {
+		fm := newSyslogNGFlowManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		capp := newBaseCapp()
+		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
+		require.NoError(t, fm.Manage(ctx, capp))
+	})
+
+	t.Run("cleans up when log is not required", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build()
+		require.NoError(t, fakeClient.Create(ctx, newSyslogNGFlow()))
+
+		fm := newSyslogNGFlowManager(fakeClient)
+		require.NoError(t, fm.Manage(ctx, newBaseCapp()))
+
+		got := &loggingv1beta1.SyslogNGFlow{}
+		getErr := fakeClient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got)
+		require.Error(t, getErr)
+		require.True(t, errors.IsNotFound(getErr))
+	})
+
+	t.Run("cleans up when log type is unsupported", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build()
+		require.NoError(t, fakeClient.Create(ctx, newSyslogNGFlow()))
+
+		fm := newSyslogNGFlowManager(fakeClient)
+		capp := newBaseCapp()
+		capp.Spec.LogSpec = cappv1alpha1.LogSpec{
+			Type: cappv1alpha1.LogType(unsupportedLogType),
+			Host: elasticHost,
+		}
+		require.NoError(t, fm.Manage(ctx, capp))
+
+		got := &loggingv1beta1.SyslogNGFlow{}
+		getErr := fakeClient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got)
+		require.Error(t, getErr)
+		require.True(t, errors.IsNotFound(getErr))
+	})
+}
+
+func TestSyslogNGFlowCleanUp(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("succeeds when SyslogNGFlow does not exist", func(t *testing.T) {
+		fm := newSyslogNGFlowManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		require.NoError(t, fm.CleanUp(ctx, newBaseCapp()))
+	})
+
+	t.Run("deletes SyslogNGFlow by capp name", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build()
+		require.NoError(t, fakeClient.Create(ctx, newSyslogNGFlow()))
+
+		require.NoError(t, newSyslogNGFlowManager(fakeClient).CleanUp(ctx, newBaseCapp()))
+
+		got := &loggingv1beta1.SyslogNGFlow{}
+		getErr := fakeClient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got)
+		require.Error(t, getErr)
+		require.True(t, errors.IsNotFound(getErr))
+	})
+
+	t.Run("skips delete when capp is deleting and flow has owner reference", func(t *testing.T) {
+		capp := newBaseCapp()
+		now := metav1.Now()
+		capp.DeletionTimestamp = &now
+
+		flow := newSyslogNGFlow()
+		require.NoError(t, controllerutil.SetOwnerReference(&capp, flow, newSyslogNGScheme()))
+
+		fm := newSyslogNGFlowManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).WithObjects(flow).Build())
+		require.NoError(t, fm.CleanUp(ctx, capp))
+
+		got := &loggingv1beta1.SyslogNGFlow{}
+		require.NoError(t, fm.K8sclient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got))
+	})
+}

--- a/internal/kinds/capp/resourcemanagers/syslogngoutput_test.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngoutput_test.go
@@ -11,55 +11,20 @@ import (
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/output"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	elasticHost           = "https://elastic.example:9200/_bulk"
-	elasticIndex          = "my-index"
-	elasticIndexUpdated   = "my-index-v2"
-	elasticUser           = "elastic-user"
-	elasticPasswordSecret = "elastic-creds"
-	unsupportedLogType    = "splunk"
-)
-
-func newSyslogNGOutputScheme() *runtime.Scheme {
-	s := newScheme()
-	utilruntime.Must(loggingv1beta1.AddToScheme(s))
-	return s
-}
-
 func newSyslogNGOutputManager(k8sClient client.Client) SyslogNGOutputManager {
 	return SyslogNGOutputManager{
 		ResourceManagerClient: rclient.ResourceManagerClient{K8sclient: k8sClient, Log: logr.Discard()},
 		EventRecorder:         events.NewFakeRecorder(10),
 	}
-}
-
-func newLogSpec(logType cappv1alpha1.LogType) cappv1alpha1.LogSpec {
-	spec := cappv1alpha1.LogSpec{
-		Type:           logType,
-		Host:           elasticHost,
-		User:           elasticUser,
-		PasswordSecret: elasticPasswordSecret,
-	}
-	if logType == cappv1alpha1.LogTypeElastic {
-		spec.Index = elasticIndex
-	}
-	return spec
-}
-
-func newSyslogNGOutputCapp(logSpec cappv1alpha1.LogSpec) cappv1alpha1.Capp {
-	capp := newBaseCapp()
-	capp.Spec.LogSpec = logSpec
-	return capp
 }
 
 func newSyslogNGOutput() *loggingv1beta1.SyslogNGOutput {
@@ -85,8 +50,9 @@ func TestSyslogNGOutputCreateOrUpdate(t *testing.T) {
 	key := types.NamespacedName{Name: cappName, Namespace: cappNamespace}
 
 	t.Run("creates when not found", func(t *testing.T) {
-		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build())
-		capp := newSyslogNGOutputCapp(newLogSpec(cappv1alpha1.LogTypeElastic))
+		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		capp := newBaseCapp()
+		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
 
 		require.NoError(t, om.createOrUpdate(ctx, capp))
 
@@ -98,21 +64,27 @@ func TestSyslogNGOutputCreateOrUpdate(t *testing.T) {
 	})
 
 	t.Run("updates when spec differs", func(t *testing.T) {
-		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build())
+		const updatedIndex = "my-index-v2"
+
+		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
 		require.NoError(t, om.K8sclient.Create(ctx, newSyslogNGOutput()))
 
 		spec := newLogSpec(cappv1alpha1.LogTypeElastic)
-		spec.Index = elasticIndexUpdated
-		require.NoError(t, om.createOrUpdate(ctx, newSyslogNGOutputCapp(spec)))
+		spec.Index = updatedIndex
+		capp := newBaseCapp()
+		capp.Spec.LogSpec = spec
+		require.NoError(t, om.createOrUpdate(ctx, capp))
 
 		got := &loggingv1beta1.SyslogNGOutput{}
 		require.NoError(t, om.K8sclient.Get(ctx, key, got))
-		require.Equal(t, elasticIndexUpdated, got.Spec.Elasticsearch.Index)
+		require.Equal(t, updatedIndex, got.Spec.Elasticsearch.Index)
 	})
 
 	t.Run("creates datastream output when log type is elastic-datastream", func(t *testing.T) {
-		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build())
-		require.NoError(t, om.createOrUpdate(ctx, newSyslogNGOutputCapp(newLogSpec(cappv1alpha1.LogTypeElasticDataStream))))
+		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		capp := newBaseCapp()
+		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElasticDataStream)
+		require.NoError(t, om.createOrUpdate(ctx, capp))
 
 		got := &loggingv1beta1.SyslogNGOutput{}
 		require.NoError(t, om.K8sclient.Get(ctx, key, got))
@@ -127,12 +99,14 @@ func TestSyslogNGOutputManage(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("reconciles when log is required", func(t *testing.T) {
-		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build())
-		require.NoError(t, om.Manage(ctx, newSyslogNGOutputCapp(newLogSpec(cappv1alpha1.LogTypeElastic))))
+		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		capp := newBaseCapp()
+		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
+		require.NoError(t, om.Manage(ctx, capp))
 	})
 
 	t.Run("cleans up when log is not required", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build()
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGOutput()))
 
 		om := newSyslogNGOutputManager(fakeClient)
@@ -140,41 +114,47 @@ func TestSyslogNGOutputManage(t *testing.T) {
 
 		got := &loggingv1beta1.SyslogNGOutput{}
 		getErr := fakeClient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got)
-		require.True(t, client.IgnoreNotFound(getErr) == nil && getErr != nil,
-			"expected %q to not exist", cappName)
+		require.Error(t, getErr)
+		require.True(t, errors.IsNotFound(getErr))
 	})
 
 	t.Run("cleans up when log type is unsupported", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build()
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGOutput()))
 
 		om := newSyslogNGOutputManager(fakeClient)
-		capp := newSyslogNGOutputCapp(cappv1alpha1.LogSpec{
+		capp := newBaseCapp()
+		capp.Spec.LogSpec = cappv1alpha1.LogSpec{
 			Type: cappv1alpha1.LogType(unsupportedLogType),
 			Host: elasticHost,
-		})
+		}
 		require.NoError(t, om.Manage(ctx, capp))
 
 		got := &loggingv1beta1.SyslogNGOutput{}
 		getErr := fakeClient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got)
-		require.True(t, client.IgnoreNotFound(getErr) == nil && getErr != nil,
-			"expected %q to not exist", cappName)
+		require.Error(t, getErr)
+		require.True(t, errors.IsNotFound(getErr))
 	})
 }
 
 func TestSyslogNGOutputCleanUp(t *testing.T) {
 	ctx := context.Background()
 
+	t.Run("succeeds when SyslogNGOutput does not exist", func(t *testing.T) {
+		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		require.NoError(t, om.CleanUp(ctx, newBaseCapp()))
+	})
+
 	t.Run("deletes SyslogNGOutput by capp name", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build()
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGOutput()))
 
 		require.NoError(t, newSyslogNGOutputManager(fakeClient).CleanUp(ctx, newBaseCapp()))
 
 		got := &loggingv1beta1.SyslogNGOutput{}
 		getErr := fakeClient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got)
-		require.True(t, client.IgnoreNotFound(getErr) == nil && getErr != nil,
-			"expected %q to not exist", cappName)
+		require.Error(t, getErr)
+		require.True(t, errors.IsNotFound(getErr))
 	})
 
 	t.Run("skips delete when capp is deleting and output has owner reference", func(t *testing.T) {
@@ -183,9 +163,9 @@ func TestSyslogNGOutputCleanUp(t *testing.T) {
 		capp.DeletionTimestamp = &now
 
 		syslogOutput := newSyslogNGOutput()
-		require.NoError(t, controllerutil.SetOwnerReference(&capp, syslogOutput, newSyslogNGOutputScheme()))
+		require.NoError(t, controllerutil.SetOwnerReference(&capp, syslogOutput, newSyslogNGScheme()))
 
-		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).WithObjects(syslogOutput).Build())
+		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).WithObjects(syslogOutput).Build())
 		require.NoError(t, om.CleanUp(ctx, capp))
 
 		got := &loggingv1beta1.SyslogNGOutput{}

--- a/internal/kinds/capp/resourcemanagers/syslogngoutput_test.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngoutput_test.go
@@ -1,0 +1,194 @@
+package resourcemanagers
+
+import (
+	"context"
+	"testing"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
+	"github.com/go-logr/logr"
+	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/output"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	elasticHost           = "https://elastic.example:9200/_bulk"
+	elasticIndex          = "my-index"
+	elasticIndexUpdated   = "my-index-v2"
+	elasticUser           = "elastic-user"
+	elasticPasswordSecret = "elastic-creds"
+	unsupportedLogType    = "splunk"
+)
+
+func newSyslogNGOutputScheme() *runtime.Scheme {
+	s := newScheme()
+	utilruntime.Must(loggingv1beta1.AddToScheme(s))
+	return s
+}
+
+func newSyslogNGOutputManager(k8sClient client.Client) SyslogNGOutputManager {
+	return SyslogNGOutputManager{
+		ResourceManagerClient: rclient.ResourceManagerClient{K8sclient: k8sClient, Log: logr.Discard()},
+		EventRecorder:         events.NewFakeRecorder(10),
+	}
+}
+
+func newLogSpec(logType cappv1alpha1.LogType) cappv1alpha1.LogSpec {
+	spec := cappv1alpha1.LogSpec{
+		Type:           logType,
+		Host:           elasticHost,
+		User:           elasticUser,
+		PasswordSecret: elasticPasswordSecret,
+	}
+	if logType == cappv1alpha1.LogTypeElastic {
+		spec.Index = elasticIndex
+	}
+	return spec
+}
+
+func newSyslogNGOutputCapp(logSpec cappv1alpha1.LogSpec) cappv1alpha1.Capp {
+	capp := newBaseCapp()
+	capp.Spec.LogSpec = logSpec
+	return capp
+}
+
+func newSyslogNGOutput() *loggingv1beta1.SyslogNGOutput {
+	return &loggingv1beta1.SyslogNGOutput{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cappName,
+			Namespace: cappNamespace,
+			Labels:    utils.ManagedResourceLabels(cappName),
+		},
+		Spec: loggingv1beta1.SyslogNGOutputSpec{
+			Elasticsearch: &output.ElasticsearchOutput{
+				Index: elasticIndex,
+				HTTPOutput: output.HTTPOutput{
+					URL: elasticHost,
+				},
+			},
+		},
+	}
+}
+
+func TestSyslogNGOutputCreateOrUpdate(t *testing.T) {
+	ctx := context.Background()
+	key := types.NamespacedName{Name: cappName, Namespace: cappNamespace}
+
+	t.Run("creates when not found", func(t *testing.T) {
+		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build())
+		capp := newSyslogNGOutputCapp(newLogSpec(cappv1alpha1.LogTypeElastic))
+
+		require.NoError(t, om.createOrUpdate(ctx, capp))
+
+		got := &loggingv1beta1.SyslogNGOutput{}
+		require.NoError(t, om.K8sclient.Get(ctx, key, got))
+		require.Equal(t, elasticIndex, got.Spec.Elasticsearch.Index)
+		require.Equal(t, elasticHost, got.Spec.Elasticsearch.URL)
+		require.Equal(t, cappName, got.OwnerReferences[0].Name)
+	})
+
+	t.Run("updates when spec differs", func(t *testing.T) {
+		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build())
+		require.NoError(t, om.K8sclient.Create(ctx, newSyslogNGOutput()))
+
+		spec := newLogSpec(cappv1alpha1.LogTypeElastic)
+		spec.Index = elasticIndexUpdated
+		require.NoError(t, om.createOrUpdate(ctx, newSyslogNGOutputCapp(spec)))
+
+		got := &loggingv1beta1.SyslogNGOutput{}
+		require.NoError(t, om.K8sclient.Get(ctx, key, got))
+		require.Equal(t, elasticIndexUpdated, got.Spec.Elasticsearch.Index)
+	})
+
+	t.Run("creates datastream output when log type is elastic-datastream", func(t *testing.T) {
+		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build())
+		require.NoError(t, om.createOrUpdate(ctx, newSyslogNGOutputCapp(newLogSpec(cappv1alpha1.LogTypeElasticDataStream))))
+
+		got := &loggingv1beta1.SyslogNGOutput{}
+		require.NoError(t, om.K8sclient.Get(ctx, key, got))
+		require.Nil(t, got.Spec.Elasticsearch)
+		require.NotNil(t, got.Spec.ElasticsearchDatastream)
+		require.Equal(t, elasticHost, got.Spec.ElasticsearchDatastream.URL)
+		require.Equal(t, cappName, got.OwnerReferences[0].Name)
+	})
+}
+
+func TestSyslogNGOutputManage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("reconciles when log is required", func(t *testing.T) {
+		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build())
+		require.NoError(t, om.Manage(ctx, newSyslogNGOutputCapp(newLogSpec(cappv1alpha1.LogTypeElastic))))
+	})
+
+	t.Run("cleans up when log is not required", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build()
+		require.NoError(t, fakeClient.Create(ctx, newSyslogNGOutput()))
+
+		om := newSyslogNGOutputManager(fakeClient)
+		require.NoError(t, om.Manage(ctx, newBaseCapp()))
+
+		got := &loggingv1beta1.SyslogNGOutput{}
+		getErr := fakeClient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got)
+		require.True(t, client.IgnoreNotFound(getErr) == nil && getErr != nil,
+			"expected %q to not exist", cappName)
+	})
+
+	t.Run("cleans up when log type is unsupported", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build()
+		require.NoError(t, fakeClient.Create(ctx, newSyslogNGOutput()))
+
+		om := newSyslogNGOutputManager(fakeClient)
+		capp := newSyslogNGOutputCapp(cappv1alpha1.LogSpec{
+			Type: cappv1alpha1.LogType(unsupportedLogType),
+			Host: elasticHost,
+		})
+		require.NoError(t, om.Manage(ctx, capp))
+
+		got := &loggingv1beta1.SyslogNGOutput{}
+		getErr := fakeClient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got)
+		require.True(t, client.IgnoreNotFound(getErr) == nil && getErr != nil,
+			"expected %q to not exist", cappName)
+	})
+}
+
+func TestSyslogNGOutputCleanUp(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("deletes SyslogNGOutput by capp name", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).Build()
+		require.NoError(t, fakeClient.Create(ctx, newSyslogNGOutput()))
+
+		require.NoError(t, newSyslogNGOutputManager(fakeClient).CleanUp(ctx, newBaseCapp()))
+
+		got := &loggingv1beta1.SyslogNGOutput{}
+		getErr := fakeClient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got)
+		require.True(t, client.IgnoreNotFound(getErr) == nil && getErr != nil,
+			"expected %q to not exist", cappName)
+	})
+
+	t.Run("skips delete when capp is deleting and output has owner reference", func(t *testing.T) {
+		capp := newBaseCapp()
+		now := metav1.Now()
+		capp.DeletionTimestamp = &now
+
+		syslogOutput := newSyslogNGOutput()
+		require.NoError(t, controllerutil.SetOwnerReference(&capp, syslogOutput, newSyslogNGOutputScheme()))
+
+		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGOutputScheme()).WithObjects(syslogOutput).Build())
+		require.NoError(t, om.CleanUp(ctx, capp))
+
+		got := &loggingv1beta1.SyslogNGOutput{}
+		require.NoError(t, om.K8sclient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: cappNamespace}, got))
+	})
+}


### PR DESCRIPTION
Extend logging operator test coverage with flow reconcile and cleanup
paths, and centralize shared syslog fixtures used by output and flow
tests.