### PR TITLE
test(resourcemanagers): add DomainMapping manager unit tests

### DIFF
--- a/internal/kinds/capp/resourcemanagers/dnsrecord_test.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
-	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
@@ -22,16 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	dnsZone           = "capp-zone.com."
-	dnsCNAME          = "ingress.capp-zone.com."
-	dnsProvider       = "dns-default"
-	routeHostnameBare = "my-app"
-	routeHostnameFQDN = "my-app.capp-zone.com"
-)
-
-var dnsRecordKey = types.NamespacedName{Name: routeHostnameFQDN, Namespace: cappNamespace}
-
 func newDNSRecordScheme() *runtime.Scheme {
 	s := newScheme()
 	utilruntime.Must(dnsrecordv1alpha1.AddToScheme(s))
@@ -46,27 +35,15 @@ func newDNSRecordManager(k8sClient client.Client) DNSRecordManager {
 }
 
 func newDNSRecordClient(objects ...client.Object) client.Client {
-	cfg := newCappConfig()
-	cfg.Spec.DNSConfig = cappv1alpha1.DNSConfig{
-		Zone:     dnsZone,
-		CNAME:    dnsCNAME,
-		Provider: dnsProvider,
-	}
-	objs := append([]client.Object{cfg}, objects...)
+	objs := append([]client.Object{newCappConfigWithDNS()}, objects...)
 	return fake.NewClientBuilder().
 		WithScheme(newDNSRecordScheme()).
 		WithObjects(objs...).
 		Build()
 }
 
-func newCappWithRouteHostname(hostname string) cappv1alpha1.Capp {
-	capp := newBaseCapp()
-	capp.Spec.RouteSpec.Hostname = hostname
-	return capp
-}
-
-func newDNSCNAMERecord(resourceName string, mutate func(*dnsrecordv1alpha1.CNAMERecord)) *dnsrecordv1alpha1.CNAMERecord {
-	recordName := routeHostnameBare
+func newCNAMERecord(resourceName string, mutate func(*dnsrecordv1alpha1.CNAMERecord)) *dnsrecordv1alpha1.CNAMERecord {
+	recordName := hostnameBare
 	zone := dnsZone
 	cname := dnsCNAME
 	rec := &dnsrecordv1alpha1.CNAMERecord{
@@ -100,91 +77,91 @@ func TestDNSRecordCreateOrUpdate(t *testing.T) {
 
 	t.Run("creates when not found", func(t *testing.T) {
 		dm := newDNSRecordManager(newDNSRecordClient())
-		capp := newCappWithRouteHostname(routeHostnameBare)
+		capp := newCappWithHostname(hostnameBare)
 
 		require.NoError(t, dm.createOrUpdate(ctx, capp))
 
 		got := &dnsrecordv1alpha1.CNAMERecord{}
-		require.NoError(t, dm.K8sclient.Get(ctx, dnsRecordKey, got))
-		require.Equal(t, routeHostnameFQDN, got.Name)
+		require.NoError(t, dm.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
+		require.Equal(t, hostnameFQDN, got.Name)
 		require.Equal(t, dnsCNAME, *got.Spec.ForProvider.Cname)
 	})
 
 	t.Run("creates FQDN hostname", func(t *testing.T) {
 		dm := newDNSRecordManager(newDNSRecordClient())
-		capp := newCappWithRouteHostname(routeHostnameFQDN)
+		capp := newCappWithHostname(hostnameFQDN)
 
 		require.NoError(t, dm.createOrUpdate(ctx, capp))
 
 		got := &dnsrecordv1alpha1.CNAMERecord{}
-		require.NoError(t, dm.K8sclient.Get(ctx, dnsRecordKey, got))
-		require.Equal(t, routeHostnameBare, *got.Spec.ForProvider.Name)
+		require.NoError(t, dm.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
+		require.Equal(t, hostnameBare, *got.Spec.ForProvider.Name)
 	})
 
 	t.Run("updates when ForProvider differs", func(t *testing.T) {
 		staleCname := "stale.ingress.capp-zone.com."
-		existing := newDNSCNAMERecord(routeHostnameFQDN, func(rec *dnsrecordv1alpha1.CNAMERecord) {
+		existing := newCNAMERecord(hostnameFQDN, func(rec *dnsrecordv1alpha1.CNAMERecord) {
 			rec.Spec.ForProvider.Cname = &staleCname
 		})
 		dm := newDNSRecordManager(newDNSRecordClient(existing))
-		capp := newCappWithRouteHostname(routeHostnameBare)
+		capp := newCappWithHostname(hostnameBare)
 
 		require.NoError(t, dm.createOrUpdate(ctx, capp))
 
 		got := &dnsrecordv1alpha1.CNAMERecord{}
-		require.NoError(t, dm.K8sclient.Get(ctx, dnsRecordKey, got))
+		require.NoError(t, dm.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
 		require.Equal(t, dnsCNAME, *got.Spec.ForProvider.Cname)
 	})
 
 	t.Run("updates when ProviderConfigReference differs", func(t *testing.T) {
 		wrongProvider := "wrong-provider"
-		existing := newDNSCNAMERecord(routeHostnameFQDN, func(rec *dnsrecordv1alpha1.CNAMERecord) {
+		existing := newCNAMERecord(hostnameFQDN, func(rec *dnsrecordv1alpha1.CNAMERecord) {
 			rec.Spec.ProviderConfigReference = &xpv1.ProviderConfigReference{
 				Name: wrongProvider,
 				Kind: ClusterProviderConfigKind,
 			}
 		})
 		dm := newDNSRecordManager(newDNSRecordClient(existing))
-		capp := newCappWithRouteHostname(routeHostnameBare)
+		capp := newCappWithHostname(hostnameBare)
 
 		require.NoError(t, dm.createOrUpdate(ctx, capp))
 
 		got := &dnsrecordv1alpha1.CNAMERecord{}
-		require.NoError(t, dm.K8sclient.Get(ctx, dnsRecordKey, got))
+		require.NoError(t, dm.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
 		require.Equal(t, dnsProvider, got.Spec.ProviderConfigReference.Name)
 	})
 
 	t.Run("adds owner reference when missing", func(t *testing.T) {
-		existing := newDNSCNAMERecord(routeHostnameFQDN, nil)
+		existing := newCNAMERecord(hostnameFQDN, nil)
 		dm := newDNSRecordManager(newDNSRecordClient(existing))
-		capp := newCappWithRouteHostname(routeHostnameBare)
+		capp := newCappWithHostname(hostnameBare)
 
 		require.NoError(t, dm.createOrUpdate(ctx, capp))
 
 		got := &dnsrecordv1alpha1.CNAMERecord{}
-		require.NoError(t, dm.K8sclient.Get(ctx, dnsRecordKey, got))
+		require.NoError(t, dm.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
 		require.Equal(t, cappName, got.OwnerReferences[0].Name)
 	})
 
 	t.Run("skips update when spec and owner match", func(t *testing.T) {
 		dm := newDNSRecordManager(newDNSRecordClient())
-		capp := newCappWithRouteHostname(routeHostnameBare)
+		capp := newCappWithHostname(hostnameBare)
 		require.NoError(t, dm.createOrUpdate(ctx, capp))
 
 		before := &dnsrecordv1alpha1.CNAMERecord{}
-		require.NoError(t, dm.K8sclient.Get(ctx, dnsRecordKey, before))
+		require.NoError(t, dm.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, before))
 		beforeRV := before.ResourceVersion
 
 		require.NoError(t, dm.createOrUpdate(ctx, capp))
 
 		after := &dnsrecordv1alpha1.CNAMERecord{}
-		require.NoError(t, dm.K8sclient.Get(ctx, dnsRecordKey, after))
+		require.NoError(t, dm.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, after))
 		require.Equal(t, beforeRV, after.ResourceVersion)
 	})
 
 	t.Run("returns error when CappConfig missing", func(t *testing.T) {
 		dm := newDNSRecordManager(fake.NewClientBuilder().WithScheme(newDNSRecordScheme()).Build())
-		capp := newCappWithRouteHostname(routeHostnameBare)
+		capp := newCappWithHostname(hostnameBare)
 
 		err := dm.createOrUpdate(ctx, capp)
 		require.Error(t, err)
@@ -196,12 +173,12 @@ func TestDNSRecordManage(t *testing.T) {
 
 	t.Run("reconciles when hostname is set", func(t *testing.T) {
 		dm := newDNSRecordManager(newDNSRecordClient())
-		capp := newCappWithRouteHostname(routeHostnameBare)
+		capp := newCappWithHostname(hostnameBare)
 		require.NoError(t, dm.Manage(ctx, capp))
 	})
 
 	t.Run("cleans up when hostname is empty", func(t *testing.T) {
-		existing := newDNSCNAMERecord(routeHostnameFQDN, nil)
+		existing := newCNAMERecord(hostnameFQDN, nil)
 		fakeClient := newDNSRecordClient(existing)
 		dm := newDNSRecordManager(fakeClient)
 		capp := newBaseCapp()
@@ -209,7 +186,7 @@ func TestDNSRecordManage(t *testing.T) {
 		require.NoError(t, dm.Manage(ctx, capp))
 
 		got := &dnsrecordv1alpha1.CNAMERecord{}
-		getErr := fakeClient.Get(ctx, dnsRecordKey, got)
+		getErr := fakeClient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got)
 		require.True(t, errors.IsNotFound(getErr))
 	})
 }
@@ -222,15 +199,15 @@ func TestDNSRecordCleanUp(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(newDNSRecordScheme()).
 			WithObjects(
-				newDNSCNAMERecord(routeHostnameFQDN, nil),
-				newDNSCNAMERecord(otherRecordName, nil),
+				newCNAMERecord(hostnameFQDN, nil),
+				newCNAMERecord(otherRecordName, nil),
 			).
 			Build()
 		dm := newDNSRecordManager(fakeClient)
 
 		require.NoError(t, dm.CleanUp(ctx, newBaseCapp()))
 
-		for _, name := range []string{routeHostnameFQDN, otherRecordName} {
+		for _, name := range []string{hostnameFQDN, otherRecordName} {
 			got := &dnsrecordv1alpha1.CNAMERecord{}
 			getErr := fakeClient.Get(ctx, types.NamespacedName{Name: name, Namespace: cappNamespace}, got)
 			require.True(t, errors.IsNotFound(getErr))
@@ -247,14 +224,14 @@ func TestDNSRecordCleanUp(t *testing.T) {
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now
 
-		record := newDNSCNAMERecord(routeHostnameFQDN, nil)
+		record := newCNAMERecord(hostnameFQDN, nil)
 		require.NoError(t, controllerutil.SetOwnerReference(&capp, record, newDNSRecordScheme()))
 
 		dm := newDNSRecordManager(fake.NewClientBuilder().WithScheme(newDNSRecordScheme()).WithObjects(record).Build())
 		require.NoError(t, dm.CleanUp(ctx, capp))
 
 		got := &dnsrecordv1alpha1.CNAMERecord{}
-		require.NoError(t, dm.K8sclient.Get(ctx, dnsRecordKey, got))
+		require.NoError(t, dm.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
 	})
 
 	t.Run("deletes when capp is deleting and record lacks owner reference", func(t *testing.T) {
@@ -262,12 +239,12 @@ func TestDNSRecordCleanUp(t *testing.T) {
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now
 
-		record := newDNSCNAMERecord(routeHostnameFQDN, nil)
+		record := newCNAMERecord(hostnameFQDN, nil)
 		dm := newDNSRecordManager(fake.NewClientBuilder().WithScheme(newDNSRecordScheme()).WithObjects(record).Build())
 		require.NoError(t, dm.CleanUp(ctx, capp))
 
 		got := &dnsrecordv1alpha1.CNAMERecord{}
-		getErr := dm.K8sclient.Get(ctx, dnsRecordKey, got)
+		getErr := dm.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got)
 		require.True(t, errors.IsNotFound(getErr))
 	})
 }

--- a/internal/kinds/capp/resourcemanagers/domainmapping_test.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping_test.go
@@ -1,0 +1,276 @@
+package resourcemanagers
+
+import (
+	"context"
+	"testing"
+
+	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/events"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
+	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func newDomainMappingScheme() *runtime.Scheme {
+	s := newScheme()
+	utilruntime.Must(knativev1beta1.AddToScheme(s))
+	return s
+}
+
+func newDomainMappingManager(k8sClient client.Client) DomainMappingManager {
+	return DomainMappingManager{
+		ResourceManagerClient: rclient.ResourceManagerClient{K8sclient: k8sClient, Log: logr.Discard()},
+		EventRecorder:         events.NewFakeRecorder(10),
+	}
+}
+
+func newDomainMappingClient(objects ...client.Object) client.Client {
+	objs := append([]client.Object{newCappConfigWithDNS()}, objects...)
+	return fake.NewClientBuilder().
+		WithScheme(newDomainMappingScheme()).
+		WithObjects(objs...).
+		Build()
+}
+
+func newDomainMapping(name string, mutate func(*knativev1beta1.DomainMapping)) *knativev1beta1.DomainMapping {
+	dm := &knativev1beta1.DomainMapping{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cappNamespace,
+			Labels:    utils.ManagedResourceLabels(cappName),
+		},
+		Spec: knativev1beta1.DomainMappingSpec{
+			Ref: duckv1.KReference{
+				APIVersion: knativev1.SchemeGroupVersion.String(),
+				Name:       cappName,
+				Kind:       knativeServiceKind,
+			},
+		},
+	}
+	if mutate != nil {
+		mutate(dm)
+	}
+	return dm
+}
+
+func TestDomainMappingManagerPrepareResource(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("omits TLS when disabled", func(t *testing.T) {
+		mgr := newDomainMappingManager(newDomainMappingClient(newSecret(utils.GenerateSecretName(hostnameFQDN), nil)))
+		capp := newCappWithTLS(hostnameBare, false)
+
+		got, err := mgr.prepareResource(ctx, capp)
+		require.NoError(t, err)
+		require.Nil(t, got.Spec.TLS)
+	})
+
+	t.Run("sets TLS when enabled and secret exists", func(t *testing.T) {
+		mgr := newDomainMappingManager(newDomainMappingClient(newSecret(utils.GenerateSecretName(hostnameFQDN), nil)))
+		capp := newCappWithTLS(hostnameBare, true)
+
+		got, err := mgr.prepareResource(ctx, capp)
+		require.NoError(t, err)
+		require.NotNil(t, got.Spec.TLS)
+		require.Equal(t, utils.GenerateSecretName(hostnameFQDN), got.Spec.TLS.SecretName)
+	})
+
+	t.Run("omits TLS when enabled and secret is missing", func(t *testing.T) {
+		mgr := newDomainMappingManager(newDomainMappingClient())
+		capp := newCappWithTLS(hostnameBare, true)
+
+		got, err := mgr.prepareResource(ctx, capp)
+		require.NoError(t, err)
+		require.Nil(t, got.Spec.TLS)
+	})
+}
+
+func TestDomainMappingManagerCreateOrUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("creates when not found", func(t *testing.T) {
+		mgr := newDomainMappingManager(newDomainMappingClient())
+		capp := newCappWithHostname(hostnameBare)
+
+		require.NoError(t, mgr.createOrUpdate(ctx, capp))
+
+		got := &knativev1beta1.DomainMapping{}
+		require.NoError(t, mgr.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
+		require.Equal(t, hostnameFQDN, got.Name)
+		require.Equal(t, cappName, got.Spec.Ref.Name)
+		require.Equal(t, knativeServiceKind, got.Spec.Ref.Kind)
+		require.Equal(t, knativev1.SchemeGroupVersion.String(), got.Spec.Ref.APIVersion)
+		require.Equal(t, cappName, got.Labels[utils.CappResourceKey])
+	})
+
+	t.Run("creates FQDN hostname", func(t *testing.T) {
+		mgr := newDomainMappingManager(newDomainMappingClient())
+		capp := newCappWithHostname(hostnameFQDN)
+
+		require.NoError(t, mgr.createOrUpdate(ctx, capp))
+
+		got := &knativev1beta1.DomainMapping{}
+		require.NoError(t, mgr.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
+		require.Equal(t, hostnameFQDN, got.Name)
+	})
+
+	t.Run("updates when spec differs", func(t *testing.T) {
+		existing := newDomainMapping(hostnameFQDN, func(dm *knativev1beta1.DomainMapping) {
+			dm.Spec.Ref.Name = "wrong-ksvc"
+		})
+		mgr := newDomainMappingManager(newDomainMappingClient(existing))
+		capp := newCappWithHostname(hostnameBare)
+
+		require.NoError(t, mgr.createOrUpdate(ctx, capp))
+
+		got := &knativev1beta1.DomainMapping{}
+		require.NoError(t, mgr.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
+		require.Equal(t, cappName, got.Spec.Ref.Name)
+	})
+
+	t.Run("adds owner reference when missing", func(t *testing.T) {
+		existing := newDomainMapping(hostnameFQDN, nil)
+		mgr := newDomainMappingManager(newDomainMappingClient(existing))
+		capp := newCappWithHostname(hostnameBare)
+
+		require.NoError(t, mgr.createOrUpdate(ctx, capp))
+
+		got := &knativev1beta1.DomainMapping{}
+		require.NoError(t, mgr.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
+		require.Equal(t, cappName, got.OwnerReferences[0].Name)
+	})
+
+	t.Run("skips update when spec and owner match", func(t *testing.T) {
+		mgr := newDomainMappingManager(newDomainMappingClient())
+		capp := newCappWithHostname(hostnameBare)
+		require.NoError(t, mgr.createOrUpdate(ctx, capp))
+
+		before := &knativev1beta1.DomainMapping{}
+		require.NoError(t, mgr.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, before))
+		beforeRV := before.ResourceVersion
+
+		require.NoError(t, mgr.createOrUpdate(ctx, capp))
+
+		after := &knativev1beta1.DomainMapping{}
+		require.NoError(t, mgr.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, after))
+		require.Equal(t, beforeRV, after.ResourceVersion)
+	})
+
+	t.Run("returns error when CappConfig missing", func(t *testing.T) {
+		mgr := newDomainMappingManager(fake.NewClientBuilder().WithScheme(newDomainMappingScheme()).Build())
+		capp := newCappWithHostname(hostnameBare)
+
+		err := mgr.createOrUpdate(ctx, capp)
+		require.Error(t, err)
+	})
+}
+
+func TestDomainMappingManagerManage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("reconciles when hostname is set", func(t *testing.T) {
+		mgr := newDomainMappingManager(newDomainMappingClient())
+		capp := newCappWithHostname(hostnameBare)
+		require.NoError(t, mgr.Manage(ctx, capp))
+	})
+
+	t.Run("cleans up when hostname is empty", func(t *testing.T) {
+		existing := newDomainMapping(hostnameFQDN, nil)
+		fakeClient := newDomainMappingClient(existing)
+		mgr := newDomainMappingManager(fakeClient)
+		capp := newBaseCapp()
+
+		require.NoError(t, mgr.Manage(ctx, capp))
+
+		got := &knativev1beta1.DomainMapping{}
+		getErr := fakeClient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got)
+		require.True(t, errors.IsNotFound(getErr))
+	})
+}
+
+func TestDomainMappingManagerCleanUp(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("deletes all owned domain mappings", func(t *testing.T) {
+		const otherMappingName = "other.capp-zone.com"
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(newDomainMappingScheme()).
+			WithObjects(
+				newDomainMapping(hostnameFQDN, nil),
+				newDomainMapping(otherMappingName, nil),
+			).
+			Build()
+		mgr := newDomainMappingManager(fakeClient)
+
+		require.NoError(t, mgr.CleanUp(ctx, newBaseCapp()))
+
+		for _, name := range []string{hostnameFQDN, otherMappingName} {
+			got := &knativev1beta1.DomainMapping{}
+			getErr := fakeClient.Get(ctx, types.NamespacedName{Name: name, Namespace: cappNamespace}, got)
+			require.True(t, errors.IsNotFound(getErr))
+		}
+	})
+
+	t.Run("deletes associated TLS secret", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(newDomainMappingScheme()).
+			WithObjects(
+				newDomainMapping(hostnameFQDN, nil),
+				newSecret(utils.GenerateSecretName(hostnameFQDN), nil),
+			).
+			Build()
+		mgr := newDomainMappingManager(fakeClient)
+
+		require.NoError(t, mgr.CleanUp(ctx, newBaseCapp()))
+
+		got := &corev1.Secret{}
+		getErr := fakeClient.Get(ctx, types.NamespacedName{Name: utils.GenerateSecretName(hostnameFQDN), Namespace: cappNamespace}, got)
+		require.True(t, errors.IsNotFound(getErr))
+	})
+
+	t.Run("succeeds when no domain mappings exist", func(t *testing.T) {
+		mgr := newDomainMappingManager(fake.NewClientBuilder().WithScheme(newDomainMappingScheme()).Build())
+		require.NoError(t, mgr.CleanUp(ctx, newBaseCapp()))
+	})
+
+	t.Run("skips delete when capp deleting and mapping has owner reference", func(t *testing.T) {
+		capp := newBaseCapp()
+		now := metav1.Now()
+		capp.DeletionTimestamp = &now
+
+		mapping := newDomainMapping(hostnameFQDN, nil)
+		require.NoError(t, controllerutil.SetOwnerReference(&capp, mapping, newDomainMappingScheme()))
+
+		mgr := newDomainMappingManager(fake.NewClientBuilder().WithScheme(newDomainMappingScheme()).WithObjects(mapping).Build())
+		require.NoError(t, mgr.CleanUp(ctx, capp))
+
+		got := &knativev1beta1.DomainMapping{}
+		require.NoError(t, mgr.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
+	})
+
+	t.Run("deletes when capp is deleting and mapping lacks owner reference", func(t *testing.T) {
+		capp := newBaseCapp()
+		now := metav1.Now()
+		capp.DeletionTimestamp = &now
+
+		mapping := newDomainMapping(hostnameFQDN, nil)
+		mgr := newDomainMappingManager(fake.NewClientBuilder().WithScheme(newDomainMappingScheme()).WithObjects(mapping).Build())
+		require.NoError(t, mgr.CleanUp(ctx, capp))
+
+		got := &knativev1beta1.DomainMapping{}
+		getErr := mgr.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got)
+		require.True(t, errors.IsNotFound(getErr))
+	})
+}

--- a/internal/kinds/capp/resourcemanagers/fixtures_test.go
+++ b/internal/kinds/capp/resourcemanagers/fixtures_test.go
@@ -18,6 +18,15 @@ const (
 	elasticHost        = "https://elastic.example:9200/_bulk"
 	elasticIndex       = "my-index"
 	unsupportedLogType = "splunk"
+
+	dnsZone      = "capp-zone.com."
+	dnsCNAME     = "ingress.capp-zone.com."
+	dnsProvider  = "dns-default"
+	issuerName   = "letsencrypt-prod"
+	issuerKind   = "ClusterIssuer"
+	issuerGroup  = "cert-manager.io"
+	hostnameBare = "my-app"
+	hostnameFQDN = "my-app.capp-zone.com"
 )
 
 func newScheme() *runtime.Scheme {
@@ -72,4 +81,44 @@ func newLogSpec(logType cappv1alpha1.LogType) cappv1alpha1.LogSpec {
 		spec.Index = elasticIndex
 	}
 	return spec
+}
+
+func newCappConfigWithDNS() *cappv1alpha1.CappConfig {
+	cfg := newCappConfig()
+	cfg.Spec.DNSConfig = cappv1alpha1.DNSConfig{
+		Zone:     dnsZone,
+		CNAME:    dnsCNAME,
+		Provider: dnsProvider,
+		IssuerRef: cappv1alpha1.IssuerRef{
+			Name:  issuerName,
+			Kind:  issuerKind,
+			Group: issuerGroup,
+		},
+	}
+	return cfg
+}
+
+func newCappWithHostname(hostname string) cappv1alpha1.Capp {
+	capp := newBaseCapp()
+	capp.Spec.RouteSpec.Hostname = hostname
+	return capp
+}
+
+func newCappWithTLS(hostname string, tls bool) cappv1alpha1.Capp {
+	capp := newCappWithHostname(hostname)
+	capp.Spec.RouteSpec.TlsEnabled = tls
+	return capp
+}
+
+func newSecret(name string, mutate func(*corev1.Secret)) *corev1.Secret {
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cappNamespace,
+		},
+	}
+	if mutate != nil {
+		mutate(sec)
+	}
+	return sec
 }


### PR DESCRIPTION
Cover reconcile, TLS wiring, cleanup, and TLS secret removal.
Extract shared route and DNS fixtures for DNSRecord and
DomainMapping tests.