### PR TITLE
chore(lint): add deadcode checks in CI and locally

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -49,3 +49,6 @@ jobs:
         with:
           version: v2.12.2
           args: --timeout=2m
+
+      - name: Run deadcode
+        run: make deadcode

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,14 @@ lint: golangci-lint ## Run golangci-lint linter
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix
 
+.PHONY: deadcode
+deadcode: deadcode-tool ## Run deadcode analysis (fails on unreachable code)
+	@output=$$($(DEADCODE) -test ./... 2>&1); \
+	if [ -n "$$output" ]; then \
+		echo "$$output"; \
+		exit 1; \
+	fi
+
 ##@ Build
 
 .PHONY: build
@@ -259,6 +267,7 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
 ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+DEADCODE ?= $(LOCALBIN)/deadcode-$(DEADCODE_VERSION)
 HELMFILE ?= $(LOCALBIN)/helmfile-$(HELMFILE_VERSION)
 HELM_DOCS ?= $(LOCALBIN)/helm-docs-$(HELM_DOCS_VERSION)
 
@@ -270,6 +279,7 @@ KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v2.12.2
+DEADCODE_VERSION ?= v0.44.0
 HELMFILE_VERSION ?= 1.4.3
 HELM_DOCS_VERSION ?= v1.14.2
 
@@ -292,6 +302,11 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+
+.PHONY: deadcode-tool
+deadcode-tool: $(DEADCODE) ## Download deadcode locally if necessary.
+$(DEADCODE): $(LOCALBIN)
+	$(call go-install-tool,$(DEADCODE),golang.org/x/tools/cmd/deadcode,$(DEADCODE_VERSION))
 
 .PHONY: helm
 helm: ## Install helm on the local machine

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -18,7 +18,6 @@ import (
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -84,15 +83,8 @@ func (k DomainMappingManager) CleanUp(ctx context.Context, capp cappv1alpha1.Cap
 	}
 
 	for _, item := range domainMappings.Items {
-		var dm knativev1beta1.DomainMapping
-		if err := k.K8sclient.Get(ctx, client.ObjectKeyFromObject(&item), &dm); err != nil {
-			if err := client.IgnoreNotFound(err); err != nil {
-				return err
-			}
-			continue
-		}
 		if capp.DeletionTimestamp != nil {
-			ok, err := controllerutil.HasOwnerReference(dm.OwnerReferences, &capp, k.K8sclient.Scheme())
+			ok, err := controllerutil.HasOwnerReference(item.OwnerReferences, &capp, k.K8sclient.Scheme())
 			if err != nil {
 				return err
 			}
@@ -100,13 +92,14 @@ func (k DomainMappingManager) CleanUp(ctx context.Context, capp cappv1alpha1.Cap
 				continue
 			}
 		}
+		dm := rclient.GetBareDomainMapping(item.Name, item.Namespace)
 		if err := k.DeleteResource(ctx, &dm); err != nil {
 			if errors.IsNotFound(err) {
 				continue
 			}
 			return err
 		}
-		secretName := utils.GenerateSecretName(dm.Name)
+		secretName := utils.GenerateSecretName(item.Name)
 		secret := corev1.Secret{}
 		if err := k.K8sclient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: dm.Namespace}, &secret); err != nil {
 			if !errors.IsNotFound(err) {


### PR DESCRIPTION
Add make deadcode and a CI step after golangci-lint. No golangci config changes. Wire domain mapping cleanup so deadcode passes.