### PR TITLE
test(resourcemanagers): standardize manager test naming

### DIFF
--- a/internal/kinds/capp/resourcemanagers/certificate_test.go
+++ b/internal/kinds/capp/resourcemanagers/certificate_test.go
@@ -128,7 +128,7 @@ func TestCertificateManagerManage(t *testing.T) {
 		require.Equal(t, cappName, got.OwnerReferences[0].Name)
 	})
 
-	t.Run("skips update when spec and owner match", func(t *testing.T) {
+	t.Run("skips update when unchanged", func(t *testing.T) {
 		mgr := newCertificateManager(newCertificateClient())
 		capp := newCappWithTLS(hostnameBare, true)
 		require.NoError(t, mgr.Manage(ctx, capp))
@@ -174,7 +174,7 @@ func TestCertificateManagerManage(t *testing.T) {
 func TestCertificateManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("deletes all owned certificates", func(t *testing.T) {
+	t.Run("deletes all owned resources", func(t *testing.T) {
 		const otherCertName = "other.capp-zone.com"
 		fakeClient := newFakeClient(newCertificateScheme(),
 			newCertificate(hostnameFQDN, nil),
@@ -191,12 +191,12 @@ func TestCertificateManagerCleanUp(t *testing.T) {
 		}
 	})
 
-	t.Run("succeeds when no certificates exist", func(t *testing.T) {
+	t.Run("succeeds when none exist", func(t *testing.T) {
 		mgr := newCertificateManager(newFakeClient(newCertificateScheme()))
 		require.NoError(t, mgr.CleanUp(ctx, newBaseCapp()))
 	})
 
-	t.Run("skips delete when capp deleting and certificate has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now
@@ -211,7 +211,7 @@ func TestCertificateManagerCleanUp(t *testing.T) {
 		require.NoError(t, mgr.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
 	})
 
-	t.Run("deletes when capp is deleting and certificate lacks owner reference", func(t *testing.T) {
+	t.Run("deletes when deleting and lacks owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/dnsrecord_test.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord_test.go
@@ -68,7 +68,7 @@ func newCNAMERecord(resourceName string, mutate func(*dnsrecordv1alpha1.CNAMERec
 	return rec
 }
 
-func TestDNSRecordCreateOrUpdate(t *testing.T) {
+func TestDNSRecordManagerCreateOrUpdate(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates when not found", func(t *testing.T) {
@@ -139,7 +139,7 @@ func TestDNSRecordCreateOrUpdate(t *testing.T) {
 		require.Equal(t, cappName, got.OwnerReferences[0].Name)
 	})
 
-	t.Run("skips update when spec and owner match", func(t *testing.T) {
+	t.Run("skips update when unchanged", func(t *testing.T) {
 		dm := newDNSRecordManager(newDNSRecordClient())
 		capp := newCappWithHostname(hostnameBare)
 		require.NoError(t, dm.createOrUpdate(ctx, capp))
@@ -164,7 +164,7 @@ func TestDNSRecordCreateOrUpdate(t *testing.T) {
 	})
 }
 
-func TestDNSRecordManage(t *testing.T) {
+func TestDNSRecordManagerManage(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("reconciles when hostname is set", func(t *testing.T) {
@@ -187,10 +187,10 @@ func TestDNSRecordManage(t *testing.T) {
 	})
 }
 
-func TestDNSRecordCleanUp(t *testing.T) {
+func TestDNSRecordManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("deletes all owned DNS records", func(t *testing.T) {
+	t.Run("deletes all owned resources", func(t *testing.T) {
 		const otherRecordName = "other.capp-zone.com"
 		fakeClient := newFakeClient(newDNSRecordScheme(),
 			newCNAMERecord(hostnameFQDN, nil),
@@ -207,12 +207,12 @@ func TestDNSRecordCleanUp(t *testing.T) {
 		}
 	})
 
-	t.Run("succeeds when no records exist", func(t *testing.T) {
+	t.Run("succeeds when none exist", func(t *testing.T) {
 		dm := newDNSRecordManager(newFakeClient(newDNSRecordScheme()))
 		require.NoError(t, dm.CleanUp(ctx, newBaseCapp()))
 	})
 
-	t.Run("skips delete when capp deleting and record has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now
@@ -227,7 +227,7 @@ func TestDNSRecordCleanUp(t *testing.T) {
 		require.NoError(t, dm.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
 	})
 
-	t.Run("deletes when capp is deleting and record lacks owner reference", func(t *testing.T) {
+	t.Run("deletes when deleting and lacks owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/domainmapping_test.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping_test.go
@@ -148,7 +148,7 @@ func TestDomainMappingManagerCreateOrUpdate(t *testing.T) {
 		require.Equal(t, cappName, got.OwnerReferences[0].Name)
 	})
 
-	t.Run("skips update when spec and owner match", func(t *testing.T) {
+	t.Run("skips update when unchanged", func(t *testing.T) {
 		mgr := newDomainMappingManager(newDomainMappingClient())
 		capp := newCappWithHostname(hostnameBare)
 		require.NoError(t, mgr.createOrUpdate(ctx, capp))
@@ -199,7 +199,7 @@ func TestDomainMappingManagerManage(t *testing.T) {
 func TestDomainMappingManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("deletes all owned domain mappings", func(t *testing.T) {
+	t.Run("deletes all owned resources", func(t *testing.T) {
 		const otherMappingName = "other.capp-zone.com"
 		fakeClient := newFakeClient(newDomainMappingScheme(),
 			newDomainMapping(hostnameFQDN, nil),
@@ -230,12 +230,12 @@ func TestDomainMappingManagerCleanUp(t *testing.T) {
 		require.True(t, errors.IsNotFound(getErr))
 	})
 
-	t.Run("succeeds when no domain mappings exist", func(t *testing.T) {
+	t.Run("succeeds when none exist", func(t *testing.T) {
 		mgr := newDomainMappingManager(newFakeClient(newDomainMappingScheme()))
 		require.NoError(t, mgr.CleanUp(ctx, newBaseCapp()))
 	})
 
-	t.Run("skips delete when capp deleting and mapping has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now
@@ -250,7 +250,7 @@ func TestDomainMappingManagerCleanUp(t *testing.T) {
 		require.NoError(t, mgr.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
 	})
 
-	t.Run("deletes when capp is deleting and mapping lacks owner reference", func(t *testing.T) {
+	t.Run("deletes when deleting and lacks owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/kafkasource_test.go
+++ b/internal/kinds/capp/resourcemanagers/kafkasource_test.go
@@ -69,7 +69,7 @@ func newKafkaSource(source string) *kafkasourcev1.KafkaSource {
 	}
 }
 
-func TestKafkaSourceCreateOrUpdate(t *testing.T) {
+func TestKafkaSourceManagerCreateOrUpdate(t *testing.T) {
 	ctx := context.Background()
 	key := types.NamespacedName{Name: fmt.Sprintf("%s-%s", cappName, ordersSource), Namespace: cappNamespace}
 
@@ -136,7 +136,7 @@ func TestKafkaSourceCreateOrUpdate(t *testing.T) {
 	})
 }
 
-func TestKafkaSourceCleanUpOrphans(t *testing.T) {
+func TestKafkaSourceManagerCleanUpOrphans(t *testing.T) {
 	t.Run("deletes orphan not in spec", func(t *testing.T) {
 		ctx := context.Background()
 		fakeClient := newFakeClient(newKafkaSourceScheme())
@@ -163,18 +163,18 @@ func TestKafkaSourceCleanUpOrphans(t *testing.T) {
 	})
 }
 
-func TestKafkaSourceManage(t *testing.T) {
+func TestKafkaSourceManagerManage(t *testing.T) {
 	ctx := context.Background()
 	kafkaCfg := newKafkaSourceConfiguration()
 
-	t.Run("reconciles when kafka is required", func(t *testing.T) {
+	t.Run("reconciles when required", func(t *testing.T) {
 		km := newKafkaSourceManager(newFakeClient(newKafkaSourceScheme()))
 		capp := newBaseCapp()
 		capp.Spec.EventSourcesSpec.Sources = []cappv1alpha1.SourceConfiguration{newKafkaSourceEntry(ordersA, kafkaCfg)}
 		require.NoError(t, km.Manage(ctx, capp))
 	})
 
-	t.Run("cleans up when kafka is not required", func(t *testing.T) {
+	t.Run("cleans up when not required", func(t *testing.T) {
 		fakeClient := newFakeClient(newKafkaSourceScheme())
 		require.NoError(t, fakeClient.Create(ctx, newKafkaSource(ordersA)))
 
@@ -193,8 +193,8 @@ func TestKafkaSourceManage(t *testing.T) {
 	})
 }
 
-func TestKafkaSourceCleanUp(t *testing.T) {
-	t.Run("deletes all owned KafkaSources", func(t *testing.T) {
+func TestKafkaSourceManagerCleanUp(t *testing.T) {
+	t.Run("deletes all owned resources", func(t *testing.T) {
 		ctx := context.Background()
 		fakeClient := newFakeClient(newKafkaSourceScheme())
 		for _, source := range []string{ordersA, ordersB} {

--- a/internal/kinds/capp/resourcemanagers/ksvc_test.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc_test.go
@@ -57,7 +57,7 @@ func newKsvcCapp() cappv1alpha1.Capp {
 	return capp
 }
 
-func TestKnativeServicePrepareResource(t *testing.T) {
+func TestKnativeServiceManagerPrepareResource(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("filters internal annotations and propagates allowed metadata", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestKnativeServicePrepareResource(t *testing.T) {
 	})
 }
 
-func TestKnativeServiceManage(t *testing.T) {
+func TestKnativeServiceManagerManage(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates ksvc with owner reference when enabled", func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestKnativeServiceManage(t *testing.T) {
 		require.Equal(t, updatedContainerImage, got.Spec.Template.Spec.Containers[0].Image)
 	})
 
-	t.Run("skips update when spec is unchanged", func(t *testing.T) {
+	t.Run("skips update when unchanged", func(t *testing.T) {
 		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
 		capp := newKsvcCapp()
 		require.NoError(t, km.Manage(ctx, capp))
@@ -235,15 +235,15 @@ func TestKnativeServiceManage(t *testing.T) {
 	})
 }
 
-func TestKnativeServiceCleanUp(t *testing.T) {
+func TestKnativeServiceManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("succeeds when ksvc does not exist", func(t *testing.T) {
+	t.Run("succeeds when none exist", func(t *testing.T) {
 		km, _ := newKsvcManager(newFakeClient(newKsvcScheme()))
 		require.NoError(t, km.CleanUp(ctx, newKsvcCapp()))
 	})
 
-	t.Run("skips delete when capp is deleting and ksvc has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newKsvcCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/nfspvc_test.go
+++ b/internal/kinds/capp/resourcemanagers/nfspvc_test.go
@@ -75,7 +75,7 @@ func newNFSPVC(name string) *nfspvcv1alpha1.NfsPvc {
 	}
 }
 
-func TestNFSPVCCreateOrUpdate(t *testing.T) {
+func TestNFSPVCManagerCreateOrUpdate(t *testing.T) {
 	ctx := context.Background()
 	keyA := types.NamespacedName{Name: nfsVolA, Namespace: cappNamespace}
 
@@ -119,17 +119,17 @@ func TestNFSPVCCreateOrUpdate(t *testing.T) {
 	})
 }
 
-func TestNFSPVCManage(t *testing.T) {
+func TestNFSPVCManagerManage(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("reconciles when nfs is required", func(t *testing.T) {
+	t.Run("reconciles when required", func(t *testing.T) {
 		nm := newNFSPVCManager(newFakeClient(newNFSPVCScheme()))
 		capp := cappWithVolumes(newNFSVolume(nfsVolA, nfsPath))
 
 		require.NoError(t, nm.Manage(ctx, capp))
 	})
 
-	t.Run("cleans up when nfs is not required", func(t *testing.T) {
+	t.Run("cleans up when not required", func(t *testing.T) {
 		fakeClient := newFakeClient(newNFSPVCScheme())
 		require.NoError(t, fakeClient.Create(ctx, newNFSPVC(nfsVolA)))
 
@@ -143,10 +143,10 @@ func TestNFSPVCManage(t *testing.T) {
 	})
 }
 
-func TestNFSPVCCleanUp(t *testing.T) {
+func TestNFSPVCManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("deletes all owned NFSPVCs", func(t *testing.T) {
+	t.Run("deletes all owned resources", func(t *testing.T) {
 		fakeClient := newFakeClient(newNFSPVCScheme())
 		for _, vol := range []string{nfsVolA, nfsVolB} {
 			require.NoError(t, fakeClient.Create(ctx, newNFSPVC(vol)))
@@ -162,7 +162,7 @@ func TestNFSPVCCleanUp(t *testing.T) {
 		}
 	})
 
-	t.Run("skips delete when capp is deleting and NFSPVC has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/pingsource_test.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource_test.go
@@ -53,7 +53,7 @@ func newPingSource(source string) *sourcesv1.PingSource {
 	}
 }
 
-func TestPingSourceCleanUpOrphans(t *testing.T) {
+func TestPingSourceManagerCleanUpOrphans(t *testing.T) {
 	pingCfg := &cappv1alpha1.PingSourceConfiguration{Schedule: schedule}
 	tests := []struct {
 		name          string
@@ -109,7 +109,7 @@ func TestPingSourceCleanUpOrphans(t *testing.T) {
 	}
 }
 
-func TestPingSourceCreateOrUpdate(t *testing.T) {
+func TestPingSourceManagerCreateOrUpdate(t *testing.T) {
 	tests := []struct {
 		name         string
 		preCreate    bool
@@ -118,12 +118,12 @@ func TestPingSourceCreateOrUpdate(t *testing.T) {
 		expectedData string
 	}{
 		{
-			name:         "creates PingSource when not found",
+			name:         "creates when not found",
 			data:         "data",
 			expectedData: "data",
 		},
 		{
-			name:         "updates PingSource when spec differs",
+			name:         "updates when spec differs",
 			preCreate:    true,
 			preData:      "old-data",
 			data:         "new-data",
@@ -165,11 +165,11 @@ func TestPingSourceCreateOrUpdate(t *testing.T) {
 	}
 }
 
-func TestPingSourceManage(t *testing.T) {
+func TestPingSourceManagerManage(t *testing.T) {
 	ctx := context.Background()
 	pingCfg := &cappv1alpha1.PingSourceConfiguration{Schedule: schedule}
 
-	t.Run("reconciles when ping is required", func(t *testing.T) {
+	t.Run("reconciles when required", func(t *testing.T) {
 		pm := newPingSourceManager(newFakeClient(newPingSourceScheme()))
 		capp := newBaseCapp()
 		capp.Spec.EventSourcesSpec.Sources = []cappv1alpha1.SourceConfiguration{
@@ -178,7 +178,7 @@ func TestPingSourceManage(t *testing.T) {
 		require.NoError(t, pm.Manage(ctx, capp))
 	})
 
-	t.Run("cleans up when ping is not required", func(t *testing.T) {
+	t.Run("cleans up when not required", func(t *testing.T) {
 		fakeClient := newFakeClient(newPingSourceScheme())
 		require.NoError(t, fakeClient.Create(ctx, newPingSource(ordersA)))
 
@@ -197,8 +197,8 @@ func TestPingSourceManage(t *testing.T) {
 	})
 }
 
-func TestPingSourceCleanUp(t *testing.T) {
-	t.Run("deletes all owned PingSources", func(t *testing.T) {
+func TestPingSourceManagerCleanUp(t *testing.T) {
+	t.Run("deletes all owned resources", func(t *testing.T) {
 		ctx := context.Background()
 		fakeClient := newFakeClient(newPingSourceScheme())
 		for _, source := range []string{sourceA, sourceB} {

--- a/internal/kinds/capp/resourcemanagers/syslogngflow_test.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngflow_test.go
@@ -50,7 +50,7 @@ func newSyslogNGFlow(outputRefs ...string) *loggingv1beta1.SyslogNGFlow {
 	}
 }
 
-func TestSyslogNGFlowCreateOrUpdate(t *testing.T) {
+func TestSyslogNGFlowManagerCreateOrUpdate(t *testing.T) {
 	ctx := context.Background()
 	key := types.NamespacedName{Name: cappName, Namespace: cappNamespace}
 
@@ -82,17 +82,17 @@ func TestSyslogNGFlowCreateOrUpdate(t *testing.T) {
 	})
 }
 
-func TestSyslogNGFlowManage(t *testing.T) {
+func TestSyslogNGFlowManagerManage(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("reconciles when log is required", func(t *testing.T) {
+	t.Run("reconciles when required", func(t *testing.T) {
 		fm := newSyslogNGFlowManager(newFakeClient(newSyslogNGScheme()))
 		capp := newBaseCapp()
 		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
 		require.NoError(t, fm.Manage(ctx, capp))
 	})
 
-	t.Run("cleans up when log is not required", func(t *testing.T) {
+	t.Run("cleans up when not required", func(t *testing.T) {
 		fakeClient := newFakeClient(newSyslogNGScheme())
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGFlow()))
 
@@ -124,10 +124,10 @@ func TestSyslogNGFlowManage(t *testing.T) {
 	})
 }
 
-func TestSyslogNGFlowCleanUp(t *testing.T) {
+func TestSyslogNGFlowManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("succeeds when SyslogNGFlow does not exist", func(t *testing.T) {
+	t.Run("succeeds when none exist", func(t *testing.T) {
 		fm := newSyslogNGFlowManager(newFakeClient(newSyslogNGScheme()))
 		require.NoError(t, fm.CleanUp(ctx, newBaseCapp()))
 	})
@@ -144,7 +144,7 @@ func TestSyslogNGFlowCleanUp(t *testing.T) {
 		require.True(t, errors.IsNotFound(getErr))
 	})
 
-	t.Run("skips delete when capp is deleting and flow has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/syslogngoutput_test.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngoutput_test.go
@@ -44,7 +44,7 @@ func newSyslogNGOutput() *loggingv1beta1.SyslogNGOutput {
 	}
 }
 
-func TestSyslogNGOutputCreateOrUpdate(t *testing.T) {
+func TestSyslogNGOutputManagerCreateOrUpdate(t *testing.T) {
 	ctx := context.Background()
 	key := types.NamespacedName{Name: cappName, Namespace: cappNamespace}
 
@@ -94,17 +94,17 @@ func TestSyslogNGOutputCreateOrUpdate(t *testing.T) {
 	})
 }
 
-func TestSyslogNGOutputManage(t *testing.T) {
+func TestSyslogNGOutputManagerManage(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("reconciles when log is required", func(t *testing.T) {
+	t.Run("reconciles when required", func(t *testing.T) {
 		om := newSyslogNGOutputManager(newFakeClient(newSyslogNGScheme()))
 		capp := newBaseCapp()
 		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
 		require.NoError(t, om.Manage(ctx, capp))
 	})
 
-	t.Run("cleans up when log is not required", func(t *testing.T) {
+	t.Run("cleans up when not required", func(t *testing.T) {
 		fakeClient := newFakeClient(newSyslogNGScheme())
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGOutput()))
 
@@ -136,10 +136,10 @@ func TestSyslogNGOutputManage(t *testing.T) {
 	})
 }
 
-func TestSyslogNGOutputCleanUp(t *testing.T) {
+func TestSyslogNGOutputManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("succeeds when SyslogNGOutput does not exist", func(t *testing.T) {
+	t.Run("succeeds when none exist", func(t *testing.T) {
 		om := newSyslogNGOutputManager(newFakeClient(newSyslogNGScheme()))
 		require.NoError(t, om.CleanUp(ctx, newBaseCapp()))
 	})
@@ -156,7 +156,7 @@ func TestSyslogNGOutputCleanUp(t *testing.T) {
 		require.True(t, errors.IsNotFound(getErr))
 	})
 
-	t.Run("skips delete when capp is deleting and output has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now


### PR DESCRIPTION
Align outer test identifiers and shared sub-test phrases across
resourcemanagers suites so scenarios read consistently.