### PR TITLE
test(resourcemanagers): centralize kafka and ping source fixtures

### DIFF
--- a/internal/kinds/capp/resourcemanagers/certificate_test.go
+++ b/internal/kinds/capp/resourcemanagers/certificate_test.go
@@ -128,7 +128,7 @@ func TestCertificateManagerManage(t *testing.T) {
 		require.Equal(t, cappName, got.OwnerReferences[0].Name)
 	})
 
-	t.Run("skips update when spec and owner match", func(t *testing.T) {
+	t.Run("skips update when unchanged", func(t *testing.T) {
 		mgr := newCertificateManager(newCertificateClient())
 		capp := newCappWithTLS(hostnameBare, true)
 		require.NoError(t, mgr.Manage(ctx, capp))
@@ -174,7 +174,7 @@ func TestCertificateManagerManage(t *testing.T) {
 func TestCertificateManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("deletes all owned certificates", func(t *testing.T) {
+	t.Run("deletes all owned resources", func(t *testing.T) {
 		const otherCertName = "other.capp-zone.com"
 		fakeClient := newFakeClient(newCertificateScheme(),
 			newCertificate(hostnameFQDN, nil),
@@ -191,12 +191,12 @@ func TestCertificateManagerCleanUp(t *testing.T) {
 		}
 	})
 
-	t.Run("succeeds when no certificates exist", func(t *testing.T) {
+	t.Run("succeeds when none exist", func(t *testing.T) {
 		mgr := newCertificateManager(newFakeClient(newCertificateScheme()))
 		require.NoError(t, mgr.CleanUp(ctx, newBaseCapp()))
 	})
 
-	t.Run("skips delete when capp deleting and certificate has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now
@@ -211,7 +211,7 @@ func TestCertificateManagerCleanUp(t *testing.T) {
 		require.NoError(t, mgr.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
 	})
 
-	t.Run("deletes when capp is deleting and certificate lacks owner reference", func(t *testing.T) {
+	t.Run("deletes when deleting and lacks owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/certificate_test.go
+++ b/internal/kinds/capp/resourcemanagers/certificate_test.go
@@ -17,7 +17,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -36,10 +35,7 @@ func newCertificateManager(k8sClient client.Client) CertificateManager {
 
 func newCertificateClient(objects ...client.Object) client.Client {
 	objs := append([]client.Object{newCappConfigWithDNS()}, objects...)
-	return fake.NewClientBuilder().
-		WithScheme(newCertificateScheme()).
-		WithObjects(objs...).
-		Build()
+	return newFakeClient(newCertificateScheme(), objs...)
 }
 
 func newCertificate(name string, mutate func(*cmapi.Certificate)) *cmapi.Certificate {
@@ -74,7 +70,7 @@ func TestCertificateManagerPrepareResource(t *testing.T) {
 	})
 
 	t.Run("returns error when CappConfig missing", func(t *testing.T) {
-		mgr := newCertificateManager(fake.NewClientBuilder().WithScheme(newCertificateScheme()).Build())
+		mgr := newCertificateManager(newFakeClient(newCertificateScheme()))
 		capp := newCappWithTLS(hostnameBare, true)
 
 		_, err := mgr.prepareResource(ctx, capp)
@@ -180,13 +176,10 @@ func TestCertificateManagerCleanUp(t *testing.T) {
 
 	t.Run("deletes all owned certificates", func(t *testing.T) {
 		const otherCertName = "other.capp-zone.com"
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(newCertificateScheme()).
-			WithObjects(
-				newCertificate(hostnameFQDN, nil),
-				newCertificate(otherCertName, nil),
-			).
-			Build()
+		fakeClient := newFakeClient(newCertificateScheme(),
+			newCertificate(hostnameFQDN, nil),
+			newCertificate(otherCertName, nil),
+		)
 		mgr := newCertificateManager(fakeClient)
 
 		require.NoError(t, mgr.CleanUp(ctx, newBaseCapp()))
@@ -199,7 +192,7 @@ func TestCertificateManagerCleanUp(t *testing.T) {
 	})
 
 	t.Run("succeeds when no certificates exist", func(t *testing.T) {
-		mgr := newCertificateManager(fake.NewClientBuilder().WithScheme(newCertificateScheme()).Build())
+		mgr := newCertificateManager(newFakeClient(newCertificateScheme()))
 		require.NoError(t, mgr.CleanUp(ctx, newBaseCapp()))
 	})
 
@@ -211,7 +204,7 @@ func TestCertificateManagerCleanUp(t *testing.T) {
 		cert := newCertificate(hostnameFQDN, nil)
 		require.NoError(t, controllerutil.SetOwnerReference(&capp, cert, newCertificateScheme()))
 
-		mgr := newCertificateManager(fake.NewClientBuilder().WithScheme(newCertificateScheme()).WithObjects(cert).Build())
+		mgr := newCertificateManager(newFakeClient(newCertificateScheme(), cert))
 		require.NoError(t, mgr.CleanUp(ctx, capp))
 
 		got := &cmapi.Certificate{}
@@ -224,7 +217,7 @@ func TestCertificateManagerCleanUp(t *testing.T) {
 		capp.DeletionTimestamp = &now
 
 		cert := newCertificate(hostnameFQDN, nil)
-		mgr := newCertificateManager(fake.NewClientBuilder().WithScheme(newCertificateScheme()).WithObjects(cert).Build())
+		mgr := newCertificateManager(newFakeClient(newCertificateScheme(), cert))
 		require.NoError(t, mgr.CleanUp(ctx, capp))
 
 		got := &cmapi.Certificate{}

--- a/internal/kinds/capp/resourcemanagers/dnsrecord_test.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord_test.go
@@ -68,7 +68,7 @@ func newCNAMERecord(resourceName string, mutate func(*dnsrecordv1alpha1.CNAMERec
 	return rec
 }
 
-func TestDNSRecordCreateOrUpdate(t *testing.T) {
+func TestDNSRecordManagerCreateOrUpdate(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates when not found", func(t *testing.T) {
@@ -139,7 +139,7 @@ func TestDNSRecordCreateOrUpdate(t *testing.T) {
 		require.Equal(t, cappName, got.OwnerReferences[0].Name)
 	})
 
-	t.Run("skips update when spec and owner match", func(t *testing.T) {
+	t.Run("skips update when unchanged", func(t *testing.T) {
 		dm := newDNSRecordManager(newDNSRecordClient())
 		capp := newCappWithHostname(hostnameBare)
 		require.NoError(t, dm.createOrUpdate(ctx, capp))
@@ -164,7 +164,7 @@ func TestDNSRecordCreateOrUpdate(t *testing.T) {
 	})
 }
 
-func TestDNSRecordManage(t *testing.T) {
+func TestDNSRecordManagerManage(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("reconciles when hostname is set", func(t *testing.T) {
@@ -187,10 +187,10 @@ func TestDNSRecordManage(t *testing.T) {
 	})
 }
 
-func TestDNSRecordCleanUp(t *testing.T) {
+func TestDNSRecordManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("deletes all owned DNS records", func(t *testing.T) {
+	t.Run("deletes all owned resources", func(t *testing.T) {
 		const otherRecordName = "other.capp-zone.com"
 		fakeClient := newFakeClient(newDNSRecordScheme(),
 			newCNAMERecord(hostnameFQDN, nil),
@@ -207,12 +207,12 @@ func TestDNSRecordCleanUp(t *testing.T) {
 		}
 	})
 
-	t.Run("succeeds when no records exist", func(t *testing.T) {
+	t.Run("succeeds when none exist", func(t *testing.T) {
 		dm := newDNSRecordManager(newFakeClient(newDNSRecordScheme()))
 		require.NoError(t, dm.CleanUp(ctx, newBaseCapp()))
 	})
 
-	t.Run("skips delete when capp deleting and record has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now
@@ -227,7 +227,7 @@ func TestDNSRecordCleanUp(t *testing.T) {
 		require.NoError(t, dm.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
 	})
 
-	t.Run("deletes when capp is deleting and record lacks owner reference", func(t *testing.T) {
+	t.Run("deletes when deleting and lacks owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/dnsrecord_test.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord_test.go
@@ -17,7 +17,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -36,10 +35,7 @@ func newDNSRecordManager(k8sClient client.Client) DNSRecordManager {
 
 func newDNSRecordClient(objects ...client.Object) client.Client {
 	objs := append([]client.Object{newCappConfigWithDNS()}, objects...)
-	return fake.NewClientBuilder().
-		WithScheme(newDNSRecordScheme()).
-		WithObjects(objs...).
-		Build()
+	return newFakeClient(newDNSRecordScheme(), objs...)
 }
 
 func newCNAMERecord(resourceName string, mutate func(*dnsrecordv1alpha1.CNAMERecord)) *dnsrecordv1alpha1.CNAMERecord {
@@ -160,7 +156,7 @@ func TestDNSRecordCreateOrUpdate(t *testing.T) {
 	})
 
 	t.Run("returns error when CappConfig missing", func(t *testing.T) {
-		dm := newDNSRecordManager(fake.NewClientBuilder().WithScheme(newDNSRecordScheme()).Build())
+		dm := newDNSRecordManager(newFakeClient(newDNSRecordScheme()))
 		capp := newCappWithHostname(hostnameBare)
 
 		err := dm.createOrUpdate(ctx, capp)
@@ -196,13 +192,10 @@ func TestDNSRecordCleanUp(t *testing.T) {
 
 	t.Run("deletes all owned DNS records", func(t *testing.T) {
 		const otherRecordName = "other.capp-zone.com"
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(newDNSRecordScheme()).
-			WithObjects(
-				newCNAMERecord(hostnameFQDN, nil),
-				newCNAMERecord(otherRecordName, nil),
-			).
-			Build()
+		fakeClient := newFakeClient(newDNSRecordScheme(),
+			newCNAMERecord(hostnameFQDN, nil),
+			newCNAMERecord(otherRecordName, nil),
+		)
 		dm := newDNSRecordManager(fakeClient)
 
 		require.NoError(t, dm.CleanUp(ctx, newBaseCapp()))
@@ -215,7 +208,7 @@ func TestDNSRecordCleanUp(t *testing.T) {
 	})
 
 	t.Run("succeeds when no records exist", func(t *testing.T) {
-		dm := newDNSRecordManager(fake.NewClientBuilder().WithScheme(newDNSRecordScheme()).Build())
+		dm := newDNSRecordManager(newFakeClient(newDNSRecordScheme()))
 		require.NoError(t, dm.CleanUp(ctx, newBaseCapp()))
 	})
 
@@ -227,7 +220,7 @@ func TestDNSRecordCleanUp(t *testing.T) {
 		record := newCNAMERecord(hostnameFQDN, nil)
 		require.NoError(t, controllerutil.SetOwnerReference(&capp, record, newDNSRecordScheme()))
 
-		dm := newDNSRecordManager(fake.NewClientBuilder().WithScheme(newDNSRecordScheme()).WithObjects(record).Build())
+		dm := newDNSRecordManager(newFakeClient(newDNSRecordScheme(), record))
 		require.NoError(t, dm.CleanUp(ctx, capp))
 
 		got := &dnsrecordv1alpha1.CNAMERecord{}
@@ -240,7 +233,7 @@ func TestDNSRecordCleanUp(t *testing.T) {
 		capp.DeletionTimestamp = &now
 
 		record := newCNAMERecord(hostnameFQDN, nil)
-		dm := newDNSRecordManager(fake.NewClientBuilder().WithScheme(newDNSRecordScheme()).WithObjects(record).Build())
+		dm := newDNSRecordManager(newFakeClient(newDNSRecordScheme(), record))
 		require.NoError(t, dm.CleanUp(ctx, capp))
 
 		got := &dnsrecordv1alpha1.CNAMERecord{}

--- a/internal/kinds/capp/resourcemanagers/domainmapping_test.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping_test.go
@@ -19,7 +19,6 @@ import (
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -38,10 +37,7 @@ func newDomainMappingManager(k8sClient client.Client) DomainMappingManager {
 
 func newDomainMappingClient(objects ...client.Object) client.Client {
 	objs := append([]client.Object{newCappConfigWithDNS()}, objects...)
-	return fake.NewClientBuilder().
-		WithScheme(newDomainMappingScheme()).
-		WithObjects(objs...).
-		Build()
+	return newFakeClient(newDomainMappingScheme(), objs...)
 }
 
 func newDomainMapping(name string, mutate func(*knativev1beta1.DomainMapping)) *knativev1beta1.DomainMapping {
@@ -169,7 +165,7 @@ func TestDomainMappingManagerCreateOrUpdate(t *testing.T) {
 	})
 
 	t.Run("returns error when CappConfig missing", func(t *testing.T) {
-		mgr := newDomainMappingManager(fake.NewClientBuilder().WithScheme(newDomainMappingScheme()).Build())
+		mgr := newDomainMappingManager(newFakeClient(newDomainMappingScheme()))
 		capp := newCappWithHostname(hostnameBare)
 
 		err := mgr.createOrUpdate(ctx, capp)
@@ -205,13 +201,10 @@ func TestDomainMappingManagerCleanUp(t *testing.T) {
 
 	t.Run("deletes all owned domain mappings", func(t *testing.T) {
 		const otherMappingName = "other.capp-zone.com"
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(newDomainMappingScheme()).
-			WithObjects(
-				newDomainMapping(hostnameFQDN, nil),
-				newDomainMapping(otherMappingName, nil),
-			).
-			Build()
+		fakeClient := newFakeClient(newDomainMappingScheme(),
+			newDomainMapping(hostnameFQDN, nil),
+			newDomainMapping(otherMappingName, nil),
+		)
 		mgr := newDomainMappingManager(fakeClient)
 
 		require.NoError(t, mgr.CleanUp(ctx, newBaseCapp()))
@@ -224,13 +217,10 @@ func TestDomainMappingManagerCleanUp(t *testing.T) {
 	})
 
 	t.Run("deletes associated TLS secret", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(newDomainMappingScheme()).
-			WithObjects(
-				newDomainMapping(hostnameFQDN, nil),
-				newSecret(utils.GenerateSecretName(hostnameFQDN), nil),
-			).
-			Build()
+		fakeClient := newFakeClient(newDomainMappingScheme(),
+			newDomainMapping(hostnameFQDN, nil),
+			newSecret(utils.GenerateSecretName(hostnameFQDN), nil),
+		)
 		mgr := newDomainMappingManager(fakeClient)
 
 		require.NoError(t, mgr.CleanUp(ctx, newBaseCapp()))
@@ -241,7 +231,7 @@ func TestDomainMappingManagerCleanUp(t *testing.T) {
 	})
 
 	t.Run("succeeds when no domain mappings exist", func(t *testing.T) {
-		mgr := newDomainMappingManager(fake.NewClientBuilder().WithScheme(newDomainMappingScheme()).Build())
+		mgr := newDomainMappingManager(newFakeClient(newDomainMappingScheme()))
 		require.NoError(t, mgr.CleanUp(ctx, newBaseCapp()))
 	})
 
@@ -253,7 +243,7 @@ func TestDomainMappingManagerCleanUp(t *testing.T) {
 		mapping := newDomainMapping(hostnameFQDN, nil)
 		require.NoError(t, controllerutil.SetOwnerReference(&capp, mapping, newDomainMappingScheme()))
 
-		mgr := newDomainMappingManager(fake.NewClientBuilder().WithScheme(newDomainMappingScheme()).WithObjects(mapping).Build())
+		mgr := newDomainMappingManager(newFakeClient(newDomainMappingScheme(), mapping))
 		require.NoError(t, mgr.CleanUp(ctx, capp))
 
 		got := &knativev1beta1.DomainMapping{}
@@ -266,7 +256,7 @@ func TestDomainMappingManagerCleanUp(t *testing.T) {
 		capp.DeletionTimestamp = &now
 
 		mapping := newDomainMapping(hostnameFQDN, nil)
-		mgr := newDomainMappingManager(fake.NewClientBuilder().WithScheme(newDomainMappingScheme()).WithObjects(mapping).Build())
+		mgr := newDomainMappingManager(newFakeClient(newDomainMappingScheme(), mapping))
 		require.NoError(t, mgr.CleanUp(ctx, capp))
 
 		got := &knativev1beta1.DomainMapping{}

--- a/internal/kinds/capp/resourcemanagers/domainmapping_test.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping_test.go
@@ -148,7 +148,7 @@ func TestDomainMappingManagerCreateOrUpdate(t *testing.T) {
 		require.Equal(t, cappName, got.OwnerReferences[0].Name)
 	})
 
-	t.Run("skips update when spec and owner match", func(t *testing.T) {
+	t.Run("skips update when unchanged", func(t *testing.T) {
 		mgr := newDomainMappingManager(newDomainMappingClient())
 		capp := newCappWithHostname(hostnameBare)
 		require.NoError(t, mgr.createOrUpdate(ctx, capp))
@@ -199,7 +199,7 @@ func TestDomainMappingManagerManage(t *testing.T) {
 func TestDomainMappingManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("deletes all owned domain mappings", func(t *testing.T) {
+	t.Run("deletes all owned resources", func(t *testing.T) {
 		const otherMappingName = "other.capp-zone.com"
 		fakeClient := newFakeClient(newDomainMappingScheme(),
 			newDomainMapping(hostnameFQDN, nil),
@@ -230,12 +230,12 @@ func TestDomainMappingManagerCleanUp(t *testing.T) {
 		require.True(t, errors.IsNotFound(getErr))
 	})
 
-	t.Run("succeeds when no domain mappings exist", func(t *testing.T) {
+	t.Run("succeeds when none exist", func(t *testing.T) {
 		mgr := newDomainMappingManager(newFakeClient(newDomainMappingScheme()))
 		require.NoError(t, mgr.CleanUp(ctx, newBaseCapp()))
 	})
 
-	t.Run("skips delete when capp deleting and mapping has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now
@@ -250,7 +250,7 @@ func TestDomainMappingManagerCleanUp(t *testing.T) {
 		require.NoError(t, mgr.K8sclient.Get(ctx, types.NamespacedName{Name: hostnameFQDN, Namespace: cappNamespace}, got))
 	})
 
-	t.Run("deletes when capp is deleting and mapping lacks owner reference", func(t *testing.T) {
+	t.Run("deletes when deleting and lacks owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/fixtures_test.go
+++ b/internal/kinds/capp/resourcemanagers/fixtures_test.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -121,4 +123,11 @@ func newSecret(name string, mutate func(*corev1.Secret)) *corev1.Secret {
 		mutate(sec)
 	}
 	return sec
+}
+
+func newFakeClient(scheme *runtime.Scheme, objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
 }

--- a/internal/kinds/capp/resourcemanagers/fixtures_test.go
+++ b/internal/kinds/capp/resourcemanagers/fixtures_test.go
@@ -29,6 +29,15 @@ const (
 	issuerGroup  = "cert-manager.io"
 	hostnameBare = "my-app"
 	hostnameFQDN = "my-app.capp-zone.com"
+
+	ordersSource    = "orders"
+	ordersA         = "orders-a"
+	ordersB         = "orders-b"
+	bootstrapServer = "kafka.example:9092"
+	topicOrders     = "orders"
+	topicPayments   = "payments"
+
+	schedule = "* * * * *"
 )
 
 func newScheme() *runtime.Scheme {
@@ -130,4 +139,26 @@ func newFakeClient(scheme *runtime.Scheme, objects ...client.Object) client.Clie
 		WithScheme(scheme).
 		WithObjects(objects...).
 		Build()
+}
+
+func newKafkaSourceConfiguration() cappv1alpha1.KafkaSourceConfiguration {
+	return cappv1alpha1.KafkaSourceConfiguration{
+		BootstrapServers: []string{bootstrapServer},
+		Topics:           []string{topicOrders, topicPayments},
+		SecretRef:        corev1.LocalObjectReference{Name: "kafka-creds"},
+	}
+}
+
+func newKafkaSourceEntry(name string, cfg cappv1alpha1.KafkaSourceConfiguration) cappv1alpha1.SourceConfiguration {
+	return cappv1alpha1.SourceConfiguration{
+		Name:                     name,
+		KafkaSourceConfiguration: &cfg,
+	}
+}
+
+func newPingSourceEntry(name string, cfg cappv1alpha1.PingSourceConfiguration) cappv1alpha1.SourceConfiguration {
+	return cappv1alpha1.SourceConfiguration{
+		Name:                    name,
+		PingSourceConfiguration: &cfg,
+	}
 }

--- a/internal/kinds/capp/resourcemanagers/kafkasource_test.go
+++ b/internal/kinds/capp/resourcemanagers/kafkasource_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -19,15 +18,6 @@ import (
 	kafkasourcev1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/sources/v1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	ordersSource    = "orders"
-	ordersA         = "orders-a"
-	ordersB         = "orders-b"
-	bootstrapServer = "kafka.example:9092"
-	topicOrders     = "orders"
-	topicPayments   = "payments"
 )
 
 func newKafkaSourceScheme() *runtime.Scheme {
@@ -41,21 +31,6 @@ func newKafkaSourceManager(k8sClient client.Client) KafkaSourceManager {
 	return KafkaSourceManager{
 		ResourceManagerClient: rclient.ResourceManagerClient{K8sclient: k8sClient, Log: logr.Discard()},
 		EventRecorder:         events.NewFakeRecorder(10),
-	}
-}
-
-func newKafkaSourceConfiguration() cappv1alpha1.KafkaSourceConfiguration {
-	return cappv1alpha1.KafkaSourceConfiguration{
-		BootstrapServers: []string{bootstrapServer},
-		Topics:           []string{topicOrders, topicPayments},
-		SecretRef:        corev1.LocalObjectReference{Name: "kafka-creds"},
-	}
-}
-
-func newKafkaSourceEntry(name string, cfg cappv1alpha1.KafkaSourceConfiguration) cappv1alpha1.SourceConfiguration {
-	return cappv1alpha1.SourceConfiguration{
-		Name:                     name,
-		KafkaSourceConfiguration: &cfg,
 	}
 }
 
@@ -181,7 +156,7 @@ func TestKafkaSourceManagerManage(t *testing.T) {
 		km := newKafkaSourceManager(fakeClient)
 		capp := newBaseCapp()
 		capp.Spec.EventSourcesSpec.Sources = []cappv1alpha1.SourceConfiguration{
-			{Name: ordersA, PingSourceConfiguration: &cappv1alpha1.PingSourceConfiguration{Schedule: "* * * * *"}},
+			newPingSourceEntry(ordersA, cappv1alpha1.PingSourceConfiguration{Schedule: schedule}),
 		}
 		require.NoError(t, km.Manage(ctx, capp))
 

--- a/internal/kinds/capp/resourcemanagers/kafkasource_test.go
+++ b/internal/kinds/capp/resourcemanagers/kafkasource_test.go
@@ -69,7 +69,7 @@ func newKafkaSource(source string) *kafkasourcev1.KafkaSource {
 	}
 }
 
-func TestKafkaSourceCreateOrUpdate(t *testing.T) {
+func TestKafkaSourceManagerCreateOrUpdate(t *testing.T) {
 	ctx := context.Background()
 	key := types.NamespacedName{Name: fmt.Sprintf("%s-%s", cappName, ordersSource), Namespace: cappNamespace}
 
@@ -136,7 +136,7 @@ func TestKafkaSourceCreateOrUpdate(t *testing.T) {
 	})
 }
 
-func TestKafkaSourceCleanUpOrphans(t *testing.T) {
+func TestKafkaSourceManagerCleanUpOrphans(t *testing.T) {
 	t.Run("deletes orphan not in spec", func(t *testing.T) {
 		ctx := context.Background()
 		fakeClient := newFakeClient(newKafkaSourceScheme())
@@ -163,18 +163,18 @@ func TestKafkaSourceCleanUpOrphans(t *testing.T) {
 	})
 }
 
-func TestKafkaSourceManage(t *testing.T) {
+func TestKafkaSourceManagerManage(t *testing.T) {
 	ctx := context.Background()
 	kafkaCfg := newKafkaSourceConfiguration()
 
-	t.Run("reconciles when kafka is required", func(t *testing.T) {
+	t.Run("reconciles when required", func(t *testing.T) {
 		km := newKafkaSourceManager(newFakeClient(newKafkaSourceScheme()))
 		capp := newBaseCapp()
 		capp.Spec.EventSourcesSpec.Sources = []cappv1alpha1.SourceConfiguration{newKafkaSourceEntry(ordersA, kafkaCfg)}
 		require.NoError(t, km.Manage(ctx, capp))
 	})
 
-	t.Run("cleans up when kafka is not required", func(t *testing.T) {
+	t.Run("cleans up when not required", func(t *testing.T) {
 		fakeClient := newFakeClient(newKafkaSourceScheme())
 		require.NoError(t, fakeClient.Create(ctx, newKafkaSource(ordersA)))
 
@@ -193,8 +193,8 @@ func TestKafkaSourceManage(t *testing.T) {
 	})
 }
 
-func TestKafkaSourceCleanUp(t *testing.T) {
-	t.Run("deletes all owned KafkaSources", func(t *testing.T) {
+func TestKafkaSourceManagerCleanUp(t *testing.T) {
+	t.Run("deletes all owned resources", func(t *testing.T) {
 		ctx := context.Background()
 		fakeClient := newFakeClient(newKafkaSourceScheme())
 		for _, source := range []string{ordersA, ordersB} {

--- a/internal/kinds/capp/resourcemanagers/kafkasource_test.go
+++ b/internal/kinds/capp/resourcemanagers/kafkasource_test.go
@@ -19,7 +19,6 @@ import (
 	kafkasourcev1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/sources/v1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -75,7 +74,7 @@ func TestKafkaSourceCreateOrUpdate(t *testing.T) {
 	key := types.NamespacedName{Name: fmt.Sprintf("%s-%s", cappName, ordersSource), Namespace: cappNamespace}
 
 	t.Run("creates when not found", func(t *testing.T) {
-		km := newKafkaSourceManager(fake.NewClientBuilder().WithScheme(newKafkaSourceScheme()).Build())
+		km := newKafkaSourceManager(newFakeClient(newKafkaSourceScheme()))
 		capp := newBaseCapp()
 		cfg := newKafkaSourceConfiguration()
 
@@ -89,7 +88,7 @@ func TestKafkaSourceCreateOrUpdate(t *testing.T) {
 	})
 
 	t.Run("updates when spec differs", func(t *testing.T) {
-		km := newKafkaSourceManager(fake.NewClientBuilder().WithScheme(newKafkaSourceScheme()).Build())
+		km := newKafkaSourceManager(newFakeClient(newKafkaSourceScheme()))
 		capp := newBaseCapp()
 		existing := newKafkaSource(ordersSource)
 		existing.Spec.Topics = []string{topicOrders}
@@ -104,7 +103,7 @@ func TestKafkaSourceCreateOrUpdate(t *testing.T) {
 	})
 
 	t.Run("pauses consumption when Capp is disabled", func(t *testing.T) {
-		km := newKafkaSourceManager(fake.NewClientBuilder().WithScheme(newKafkaSourceScheme()).Build())
+		km := newKafkaSourceManager(newFakeClient(newKafkaSourceScheme()))
 		capp := newBaseCapp()
 		capp.Spec.State = cappv1alpha1.CappStateDisabled
 		cfg := newKafkaSourceConfiguration()
@@ -119,7 +118,7 @@ func TestKafkaSourceCreateOrUpdate(t *testing.T) {
 	})
 
 	t.Run("preserves consumer group on update", func(t *testing.T) {
-		km := newKafkaSourceManager(fake.NewClientBuilder().WithScheme(newKafkaSourceScheme()).Build())
+		km := newKafkaSourceManager(newFakeClient(newKafkaSourceScheme()))
 		capp := newBaseCapp()
 		existing := newKafkaSource(ordersSource)
 		existing.Spec.ConsumerGroup = "immutable-group"
@@ -140,7 +139,7 @@ func TestKafkaSourceCreateOrUpdate(t *testing.T) {
 func TestKafkaSourceCleanUpOrphans(t *testing.T) {
 	t.Run("deletes orphan not in spec", func(t *testing.T) {
 		ctx := context.Background()
-		fakeClient := fake.NewClientBuilder().WithScheme(newKafkaSourceScheme()).Build()
+		fakeClient := newFakeClient(newKafkaSourceScheme())
 		for _, source := range []string{ordersA, ordersB} {
 			require.NoError(t, fakeClient.Create(ctx, newKafkaSource(source)))
 		}
@@ -169,14 +168,14 @@ func TestKafkaSourceManage(t *testing.T) {
 	kafkaCfg := newKafkaSourceConfiguration()
 
 	t.Run("reconciles when kafka is required", func(t *testing.T) {
-		km := newKafkaSourceManager(fake.NewClientBuilder().WithScheme(newKafkaSourceScheme()).Build())
+		km := newKafkaSourceManager(newFakeClient(newKafkaSourceScheme()))
 		capp := newBaseCapp()
 		capp.Spec.EventSourcesSpec.Sources = []cappv1alpha1.SourceConfiguration{newKafkaSourceEntry(ordersA, kafkaCfg)}
 		require.NoError(t, km.Manage(ctx, capp))
 	})
 
 	t.Run("cleans up when kafka is not required", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newKafkaSourceScheme()).Build()
+		fakeClient := newFakeClient(newKafkaSourceScheme())
 		require.NoError(t, fakeClient.Create(ctx, newKafkaSource(ordersA)))
 
 		km := newKafkaSourceManager(fakeClient)
@@ -197,7 +196,7 @@ func TestKafkaSourceManage(t *testing.T) {
 func TestKafkaSourceCleanUp(t *testing.T) {
 	t.Run("deletes all owned KafkaSources", func(t *testing.T) {
 		ctx := context.Background()
-		fakeClient := fake.NewClientBuilder().WithScheme(newKafkaSourceScheme()).Build()
+		fakeClient := newFakeClient(newKafkaSourceScheme())
 		for _, source := range []string{ordersA, ordersB} {
 			require.NoError(t, fakeClient.Create(ctx, newKafkaSource(source)))
 		}

--- a/internal/kinds/capp/resourcemanagers/ksvc_test.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc_test.go
@@ -57,7 +57,7 @@ func newKsvcCapp() cappv1alpha1.Capp {
 	return capp
 }
 
-func TestKnativeServicePrepareResource(t *testing.T) {
+func TestKnativeServiceManagerPrepareResource(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("filters internal annotations and propagates allowed metadata", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestKnativeServicePrepareResource(t *testing.T) {
 	})
 }
 
-func TestKnativeServiceManage(t *testing.T) {
+func TestKnativeServiceManagerManage(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates ksvc with owner reference when enabled", func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestKnativeServiceManage(t *testing.T) {
 		require.Equal(t, updatedContainerImage, got.Spec.Template.Spec.Containers[0].Image)
 	})
 
-	t.Run("skips update when spec is unchanged", func(t *testing.T) {
+	t.Run("skips update when unchanged", func(t *testing.T) {
 		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
 		capp := newKsvcCapp()
 		require.NoError(t, km.Manage(ctx, capp))
@@ -235,15 +235,15 @@ func TestKnativeServiceManage(t *testing.T) {
 	})
 }
 
-func TestKnativeServiceCleanUp(t *testing.T) {
+func TestKnativeServiceManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("succeeds when ksvc does not exist", func(t *testing.T) {
+	t.Run("succeeds when none exist", func(t *testing.T) {
 		km, _ := newKsvcManager(newFakeClient(newKsvcScheme()))
 		require.NoError(t, km.CleanUp(ctx, newKsvcCapp()))
 	})
 
-	t.Run("skips delete when capp is deleting and ksvc has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newKsvcCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/ksvc_test.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc_test.go
@@ -21,7 +21,6 @@ import (
 	kautoscaling "knative.dev/serving/pkg/apis/autoscaling"
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -58,13 +57,6 @@ func newKsvcCapp() cappv1alpha1.Capp {
 	return capp
 }
 
-func newKsvcClient(objects ...client.Object) client.Client {
-	return fake.NewClientBuilder().
-		WithScheme(newKsvcScheme()).
-		WithObjects(objects...).
-		Build()
-}
-
 func TestKnativeServicePrepareResource(t *testing.T) {
 	ctx := context.Background()
 
@@ -76,7 +68,7 @@ func TestKnativeServicePrepareResource(t *testing.T) {
 		)
 		internalAnnotationKey := utils.CappAPIGroup + "/internal"
 
-		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
 		capp := newKsvcCapp()
 		capp.Annotations = map[string]string{
 			allowedAnnotationKey:  allowedAnnotationValue,
@@ -98,7 +90,7 @@ func TestKnativeServicePrepareResource(t *testing.T) {
 			userLabelValue = "platform"
 		)
 
-		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
 		capp := newKsvcCapp()
 		capp.Labels = map[string]string{
 			userLabelKey:          userLabelValue,
@@ -114,7 +106,7 @@ func TestKnativeServicePrepareResource(t *testing.T) {
 	})
 
 	t.Run("sets route timeout on template", func(t *testing.T) {
-		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
 		capp := newKsvcCapp()
 		routeTimeout := int64(30)
 		capp.Spec.RouteSpec.RouteTimeoutSeconds = &routeTimeout
@@ -128,7 +120,7 @@ func TestKnativeServicePrepareResource(t *testing.T) {
 	t.Run("appends nfs volumes as pvc volume sources", func(t *testing.T) {
 		const nfsVolumeName = "data-vol"
 
-		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
 		capp := newKsvcCapp()
 		capp.Spec.VolumesSpec.NFSVolumes = []cappv1alpha1.NFSVolume{{
 			Name:     nfsVolumeName,
@@ -147,7 +139,7 @@ func TestKnativeServicePrepareResource(t *testing.T) {
 	t.Run("merges autoscale annotations from capp and cappConfig", func(t *testing.T) {
 		cappConfig := newCappConfig()
 
-		km, _ := newKsvcManager(newKsvcClient(cappConfig))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), cappConfig))
 		capp := newKsvcCapp()
 
 		got := km.prepareResource(capp, ctx)
@@ -163,7 +155,7 @@ func TestKnativeServiceManage(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates ksvc with owner reference when enabled", func(t *testing.T) {
-		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
 		capp := newKsvcCapp()
 
 		require.NoError(t, km.Manage(ctx, capp))
@@ -178,7 +170,7 @@ func TestKnativeServiceManage(t *testing.T) {
 	t.Run("updates ksvc when spec changes", func(t *testing.T) {
 		const updatedContainerImage = "example.com/app:v2"
 
-		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
 		capp := newKsvcCapp()
 		require.NoError(t, km.Manage(ctx, capp))
 
@@ -191,7 +183,7 @@ func TestKnativeServiceManage(t *testing.T) {
 	})
 
 	t.Run("skips update when spec is unchanged", func(t *testing.T) {
-		km, _ := newKsvcManager(newKsvcClient(newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
 		capp := newKsvcCapp()
 		require.NoError(t, km.Manage(ctx, capp))
 
@@ -207,7 +199,7 @@ func TestKnativeServiceManage(t *testing.T) {
 	})
 
 	t.Run("deletes ksvc and emits disabled event when state is disabled", func(t *testing.T) {
-		km, recorder := newKsvcManager(newKsvcClient(newCappConfig()))
+		km, recorder := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
 		capp := newKsvcCapp()
 		require.NoError(t, km.Manage(ctx, capp))
 		require.Contains(t, <-recorder.Events, eventCappKnativeServiceCreated)
@@ -224,7 +216,7 @@ func TestKnativeServiceManage(t *testing.T) {
 	})
 
 	t.Run("recreates ksvc and emits enabled event when resuming from disabled", func(t *testing.T) {
-		km, recorder := newKsvcManager(newKsvcClient(newCappConfig()))
+		km, recorder := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
 		capp := newKsvcCapp()
 		capp.Status.StateStatus = cappv1alpha1.StateStatus{
 			State:      cappDisabledState,
@@ -247,7 +239,7 @@ func TestKnativeServiceCleanUp(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("succeeds when ksvc does not exist", func(t *testing.T) {
-		km, _ := newKsvcManager(newKsvcClient())
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme()))
 		require.NoError(t, km.CleanUp(ctx, newKsvcCapp()))
 	})
 
@@ -264,7 +256,7 @@ func TestKnativeServiceCleanUp(t *testing.T) {
 		}
 		require.NoError(t, controllerutil.SetOwnerReference(&capp, ksvc, newKsvcScheme()))
 
-		km, _ := newKsvcManager(newKsvcClient(ksvc))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), ksvc))
 		require.NoError(t, km.CleanUp(ctx, capp))
 
 		got := &knativev1.Service{}

--- a/internal/kinds/capp/resourcemanagers/nfspvc_test.go
+++ b/internal/kinds/capp/resourcemanagers/nfspvc_test.go
@@ -18,7 +18,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -81,7 +80,7 @@ func TestNFSPVCCreateOrUpdate(t *testing.T) {
 	keyA := types.NamespacedName{Name: nfsVolA, Namespace: cappNamespace}
 
 	t.Run("creates when not found", func(t *testing.T) {
-		nm := newNFSPVCManager(fake.NewClientBuilder().WithScheme(newNFSPVCScheme()).Build())
+		nm := newNFSPVCManager(newFakeClient(newNFSPVCScheme()))
 		capp := cappWithVolumes(newNFSVolume(nfsVolA, nfsPath))
 
 		require.NoError(t, nm.createOrUpdate(ctx, capp))
@@ -94,7 +93,7 @@ func TestNFSPVCCreateOrUpdate(t *testing.T) {
 	})
 
 	t.Run("updates when spec differs", func(t *testing.T) {
-		nm := newNFSPVCManager(fake.NewClientBuilder().WithScheme(newNFSPVCScheme()).Build())
+		nm := newNFSPVCManager(newFakeClient(newNFSPVCScheme()))
 		existing := newNFSPVC(nfsVolA)
 		require.NoError(t, nm.K8sclient.Create(ctx, existing))
 
@@ -107,7 +106,7 @@ func TestNFSPVCCreateOrUpdate(t *testing.T) {
 	})
 
 	t.Run("creates multiple NFSPVCs from spec", func(t *testing.T) {
-		nm := newNFSPVCManager(fake.NewClientBuilder().WithScheme(newNFSPVCScheme()).Build())
+		nm := newNFSPVCManager(newFakeClient(newNFSPVCScheme()))
 		capp := cappWithVolumes(newNFSVolume(nfsVolA, nfsPath), newNFSVolume(nfsVolB, nfsPath))
 
 		require.NoError(t, nm.createOrUpdate(ctx, capp))
@@ -124,14 +123,14 @@ func TestNFSPVCManage(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("reconciles when nfs is required", func(t *testing.T) {
-		nm := newNFSPVCManager(fake.NewClientBuilder().WithScheme(newNFSPVCScheme()).Build())
+		nm := newNFSPVCManager(newFakeClient(newNFSPVCScheme()))
 		capp := cappWithVolumes(newNFSVolume(nfsVolA, nfsPath))
 
 		require.NoError(t, nm.Manage(ctx, capp))
 	})
 
 	t.Run("cleans up when nfs is not required", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newNFSPVCScheme()).Build()
+		fakeClient := newFakeClient(newNFSPVCScheme())
 		require.NoError(t, fakeClient.Create(ctx, newNFSPVC(nfsVolA)))
 
 		nm := newNFSPVCManager(fakeClient)
@@ -148,7 +147,7 @@ func TestNFSPVCCleanUp(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("deletes all owned NFSPVCs", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newNFSPVCScheme()).Build()
+		fakeClient := newFakeClient(newNFSPVCScheme())
 		for _, vol := range []string{nfsVolA, nfsVolB} {
 			require.NoError(t, fakeClient.Create(ctx, newNFSPVC(vol)))
 		}
@@ -171,7 +170,7 @@ func TestNFSPVCCleanUp(t *testing.T) {
 		nfspvc := newNFSPVC(nfsVolA)
 		require.NoError(t, controllerutil.SetOwnerReference(&capp, nfspvc, newNFSPVCScheme()))
 
-		nm := newNFSPVCManager(fake.NewClientBuilder().WithScheme(newNFSPVCScheme()).WithObjects(nfspvc).Build())
+		nm := newNFSPVCManager(newFakeClient(newNFSPVCScheme(), nfspvc))
 		require.NoError(t, nm.CleanUp(ctx, capp))
 
 		got := &nfspvcv1alpha1.NfsPvc{}

--- a/internal/kinds/capp/resourcemanagers/nfspvc_test.go
+++ b/internal/kinds/capp/resourcemanagers/nfspvc_test.go
@@ -75,7 +75,7 @@ func newNFSPVC(name string) *nfspvcv1alpha1.NfsPvc {
 	}
 }
 
-func TestNFSPVCCreateOrUpdate(t *testing.T) {
+func TestNFSPVCManagerCreateOrUpdate(t *testing.T) {
 	ctx := context.Background()
 	keyA := types.NamespacedName{Name: nfsVolA, Namespace: cappNamespace}
 
@@ -119,17 +119,17 @@ func TestNFSPVCCreateOrUpdate(t *testing.T) {
 	})
 }
 
-func TestNFSPVCManage(t *testing.T) {
+func TestNFSPVCManagerManage(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("reconciles when nfs is required", func(t *testing.T) {
+	t.Run("reconciles when required", func(t *testing.T) {
 		nm := newNFSPVCManager(newFakeClient(newNFSPVCScheme()))
 		capp := cappWithVolumes(newNFSVolume(nfsVolA, nfsPath))
 
 		require.NoError(t, nm.Manage(ctx, capp))
 	})
 
-	t.Run("cleans up when nfs is not required", func(t *testing.T) {
+	t.Run("cleans up when not required", func(t *testing.T) {
 		fakeClient := newFakeClient(newNFSPVCScheme())
 		require.NoError(t, fakeClient.Create(ctx, newNFSPVC(nfsVolA)))
 
@@ -143,10 +143,10 @@ func TestNFSPVCManage(t *testing.T) {
 	})
 }
 
-func TestNFSPVCCleanUp(t *testing.T) {
+func TestNFSPVCManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("deletes all owned NFSPVCs", func(t *testing.T) {
+	t.Run("deletes all owned resources", func(t *testing.T) {
 		fakeClient := newFakeClient(newNFSPVCScheme())
 		for _, vol := range []string{nfsVolA, nfsVolB} {
 			require.NoError(t, fakeClient.Create(ctx, newNFSPVC(vol)))
@@ -162,7 +162,7 @@ func TestNFSPVCCleanUp(t *testing.T) {
 		}
 	})
 
-	t.Run("skips delete when capp is deleting and NFSPVC has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/pingsource_test.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource_test.go
@@ -19,7 +19,6 @@ import (
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -89,7 +88,7 @@ func TestPingSourceCleanUpOrphans(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			fakeClient := fake.NewClientBuilder().WithScheme(newPingSourceScheme()).Build()
+			fakeClient := newFakeClient(newPingSourceScheme())
 			for _, ps := range tt.preCreate {
 				assert.NoError(t, fakeClient.Create(ctx, ps))
 			}
@@ -134,7 +133,7 @@ func TestPingSourceCreateOrUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			fakeClient := fake.NewClientBuilder().WithScheme(newPingSourceScheme()).Build()
+			fakeClient := newFakeClient(newPingSourceScheme())
 			pm := newPingSourceManager(fakeClient)
 			capp := newBaseCapp()
 
@@ -171,7 +170,7 @@ func TestPingSourceManage(t *testing.T) {
 	pingCfg := &cappv1alpha1.PingSourceConfiguration{Schedule: schedule}
 
 	t.Run("reconciles when ping is required", func(t *testing.T) {
-		pm := newPingSourceManager(fake.NewClientBuilder().WithScheme(newPingSourceScheme()).Build())
+		pm := newPingSourceManager(newFakeClient(newPingSourceScheme()))
 		capp := newBaseCapp()
 		capp.Spec.EventSourcesSpec.Sources = []cappv1alpha1.SourceConfiguration{
 			{Name: sourceA, PingSourceConfiguration: pingCfg},
@@ -180,7 +179,7 @@ func TestPingSourceManage(t *testing.T) {
 	})
 
 	t.Run("cleans up when ping is not required", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newPingSourceScheme()).Build()
+		fakeClient := newFakeClient(newPingSourceScheme())
 		require.NoError(t, fakeClient.Create(ctx, newPingSource(ordersA)))
 
 		pm := newPingSourceManager(fakeClient)
@@ -201,7 +200,7 @@ func TestPingSourceManage(t *testing.T) {
 func TestPingSourceCleanUp(t *testing.T) {
 	t.Run("deletes all owned PingSources", func(t *testing.T) {
 		ctx := context.Background()
-		fakeClient := fake.NewClientBuilder().WithScheme(newPingSourceScheme()).Build()
+		fakeClient := newFakeClient(newPingSourceScheme())
 		for _, source := range []string{sourceA, sourceB} {
 			require.NoError(t, fakeClient.Create(ctx, newPingSource(source)))
 		}

--- a/internal/kinds/capp/resourcemanagers/pingsource_test.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource_test.go
@@ -53,7 +53,7 @@ func newPingSource(source string) *sourcesv1.PingSource {
 	}
 }
 
-func TestPingSourceCleanUpOrphans(t *testing.T) {
+func TestPingSourceManagerCleanUpOrphans(t *testing.T) {
 	pingCfg := &cappv1alpha1.PingSourceConfiguration{Schedule: schedule}
 	tests := []struct {
 		name          string
@@ -109,7 +109,7 @@ func TestPingSourceCleanUpOrphans(t *testing.T) {
 	}
 }
 
-func TestPingSourceCreateOrUpdate(t *testing.T) {
+func TestPingSourceManagerCreateOrUpdate(t *testing.T) {
 	tests := []struct {
 		name         string
 		preCreate    bool
@@ -118,12 +118,12 @@ func TestPingSourceCreateOrUpdate(t *testing.T) {
 		expectedData string
 	}{
 		{
-			name:         "creates PingSource when not found",
+			name:         "creates when not found",
 			data:         "data",
 			expectedData: "data",
 		},
 		{
-			name:         "updates PingSource when spec differs",
+			name:         "updates when spec differs",
 			preCreate:    true,
 			preData:      "old-data",
 			data:         "new-data",
@@ -165,11 +165,11 @@ func TestPingSourceCreateOrUpdate(t *testing.T) {
 	}
 }
 
-func TestPingSourceManage(t *testing.T) {
+func TestPingSourceManagerManage(t *testing.T) {
 	ctx := context.Background()
 	pingCfg := &cappv1alpha1.PingSourceConfiguration{Schedule: schedule}
 
-	t.Run("reconciles when ping is required", func(t *testing.T) {
+	t.Run("reconciles when required", func(t *testing.T) {
 		pm := newPingSourceManager(newFakeClient(newPingSourceScheme()))
 		capp := newBaseCapp()
 		capp.Spec.EventSourcesSpec.Sources = []cappv1alpha1.SourceConfiguration{
@@ -178,7 +178,7 @@ func TestPingSourceManage(t *testing.T) {
 		require.NoError(t, pm.Manage(ctx, capp))
 	})
 
-	t.Run("cleans up when ping is not required", func(t *testing.T) {
+	t.Run("cleans up when not required", func(t *testing.T) {
 		fakeClient := newFakeClient(newPingSourceScheme())
 		require.NoError(t, fakeClient.Create(ctx, newPingSource(ordersA)))
 
@@ -197,8 +197,8 @@ func TestPingSourceManage(t *testing.T) {
 	})
 }
 
-func TestPingSourceCleanUp(t *testing.T) {
-	t.Run("deletes all owned PingSources", func(t *testing.T) {
+func TestPingSourceManagerCleanUp(t *testing.T) {
+	t.Run("deletes all owned resources", func(t *testing.T) {
 		ctx := context.Background()
 		fakeClient := newFakeClient(newPingSourceScheme())
 		for _, source := range []string{sourceA, sourceB} {

--- a/internal/kinds/capp/resourcemanagers/pingsource_test.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource_test.go
@@ -23,7 +23,6 @@ import (
 
 const (
 	sourceName = "ping"
-	schedule   = "* * * * *"
 	sourceA    = "ping-a"
 	sourceB    = "ping-b"
 	sourceC    = "ping-c"
@@ -54,7 +53,7 @@ func newPingSource(source string) *sourcesv1.PingSource {
 }
 
 func TestPingSourceManagerCleanUpOrphans(t *testing.T) {
-	pingCfg := &cappv1alpha1.PingSourceConfiguration{Schedule: schedule}
+	pingCfg := cappv1alpha1.PingSourceConfiguration{Schedule: schedule}
 	tests := []struct {
 		name          string
 		sources       []cappv1alpha1.SourceConfiguration
@@ -64,7 +63,7 @@ func TestPingSourceManagerCleanUpOrphans(t *testing.T) {
 	}{
 		{
 			name:          "deletes orphaned PingSource not in spec",
-			sources:       []cappv1alpha1.SourceConfiguration{{Name: sourceA, PingSourceConfiguration: pingCfg}},
+			sources:       []cappv1alpha1.SourceConfiguration{newPingSourceEntry(sourceA, pingCfg)},
 			preCreate:     []*sourcesv1.PingSource{newPingSource(sourceA), newPingSource(sourceB)},
 			expectKept:    []string{fmt.Sprintf("%s-%s", cappName, sourceA)},
 			expectDeleted: []string{fmt.Sprintf("%s-%s", cappName, sourceB)},
@@ -72,15 +71,15 @@ func TestPingSourceManagerCleanUpOrphans(t *testing.T) {
 		{
 			name: "keeps all owned when all are in spec",
 			sources: []cappv1alpha1.SourceConfiguration{
-				{Name: sourceA, PingSourceConfiguration: pingCfg},
-				{Name: sourceB, PingSourceConfiguration: pingCfg},
+				newPingSourceEntry(sourceA, pingCfg),
+				newPingSourceEntry(sourceB, pingCfg),
 			},
 			preCreate:  []*sourcesv1.PingSource{newPingSource(sourceA), newPingSource(sourceB)},
 			expectKept: []string{fmt.Sprintf("%s-%s", cappName, sourceA), fmt.Sprintf("%s-%s", cappName, sourceB)},
 		},
 		{
 			name:          "deletes all owned when none match spec",
-			sources:       []cappv1alpha1.SourceConfiguration{{Name: sourceA, PingSourceConfiguration: pingCfg}},
+			sources:       []cappv1alpha1.SourceConfiguration{newPingSourceEntry(sourceA, pingCfg)},
 			preCreate:     []*sourcesv1.PingSource{newPingSource(sourceB), newPingSource(sourceC)},
 			expectDeleted: []string{fmt.Sprintf("%s-%s", cappName, sourceB), fmt.Sprintf("%s-%s", cappName, sourceC)},
 		},
@@ -138,23 +137,14 @@ func TestPingSourceManagerCreateOrUpdate(t *testing.T) {
 			capp := newBaseCapp()
 
 			if tt.preCreate {
-				src := cappv1alpha1.SourceConfiguration{
-					Name: sourceName,
-					PingSourceConfiguration: &cappv1alpha1.PingSourceConfiguration{
-						Schedule: schedule,
-						Data:     tt.preData,
-					},
-				}
-				assert.NoError(t, pm.createOrUpdate(ctx, capp, src))
+				cfg := cappv1alpha1.PingSourceConfiguration{Schedule: schedule}
+				cfg.Data = tt.preData
+				assert.NoError(t, pm.createOrUpdate(ctx, capp, newPingSourceEntry(sourceName, cfg)))
 			}
 
-			src := cappv1alpha1.SourceConfiguration{
-				Name: sourceName,
-				PingSourceConfiguration: &cappv1alpha1.PingSourceConfiguration{
-					Schedule: schedule,
-					Data:     tt.data,
-				},
-			}
+			cfg := cappv1alpha1.PingSourceConfiguration{Schedule: schedule}
+			cfg.Data = tt.data
+			src := newPingSourceEntry(sourceName, cfg)
 			assert.NoError(t, pm.createOrUpdate(ctx, capp, src))
 			got := &sourcesv1.PingSource{}
 			assert.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s", cappName, sourceName), Namespace: cappNamespace}, got))
@@ -167,13 +157,12 @@ func TestPingSourceManagerCreateOrUpdate(t *testing.T) {
 
 func TestPingSourceManagerManage(t *testing.T) {
 	ctx := context.Background()
-	pingCfg := &cappv1alpha1.PingSourceConfiguration{Schedule: schedule}
 
 	t.Run("reconciles when required", func(t *testing.T) {
 		pm := newPingSourceManager(newFakeClient(newPingSourceScheme()))
 		capp := newBaseCapp()
 		capp.Spec.EventSourcesSpec.Sources = []cappv1alpha1.SourceConfiguration{
-			{Name: sourceA, PingSourceConfiguration: pingCfg},
+			newPingSourceEntry(sourceA, cappv1alpha1.PingSourceConfiguration{Schedule: schedule}),
 		}
 		require.NoError(t, pm.Manage(ctx, capp))
 	})

--- a/internal/kinds/capp/resourcemanagers/syslogngflow_test.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngflow_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -56,7 +55,7 @@ func TestSyslogNGFlowCreateOrUpdate(t *testing.T) {
 	key := types.NamespacedName{Name: cappName, Namespace: cappNamespace}
 
 	t.Run("creates when not found", func(t *testing.T) {
-		fm := newSyslogNGFlowManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		fm := newSyslogNGFlowManager(newFakeClient(newSyslogNGScheme()))
 		capp := newBaseCapp()
 		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
 
@@ -70,7 +69,7 @@ func TestSyslogNGFlowCreateOrUpdate(t *testing.T) {
 	})
 
 	t.Run("updates when spec differs", func(t *testing.T) {
-		fm := newSyslogNGFlowManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		fm := newSyslogNGFlowManager(newFakeClient(newSyslogNGScheme()))
 		require.NoError(t, fm.K8sclient.Create(ctx, newSyslogNGFlow("stale-output")))
 
 		capp := newBaseCapp()
@@ -87,14 +86,14 @@ func TestSyslogNGFlowManage(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("reconciles when log is required", func(t *testing.T) {
-		fm := newSyslogNGFlowManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		fm := newSyslogNGFlowManager(newFakeClient(newSyslogNGScheme()))
 		capp := newBaseCapp()
 		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
 		require.NoError(t, fm.Manage(ctx, capp))
 	})
 
 	t.Run("cleans up when log is not required", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build()
+		fakeClient := newFakeClient(newSyslogNGScheme())
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGFlow()))
 
 		fm := newSyslogNGFlowManager(fakeClient)
@@ -107,7 +106,7 @@ func TestSyslogNGFlowManage(t *testing.T) {
 	})
 
 	t.Run("cleans up when log type is unsupported", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build()
+		fakeClient := newFakeClient(newSyslogNGScheme())
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGFlow()))
 
 		fm := newSyslogNGFlowManager(fakeClient)
@@ -129,12 +128,12 @@ func TestSyslogNGFlowCleanUp(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("succeeds when SyslogNGFlow does not exist", func(t *testing.T) {
-		fm := newSyslogNGFlowManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		fm := newSyslogNGFlowManager(newFakeClient(newSyslogNGScheme()))
 		require.NoError(t, fm.CleanUp(ctx, newBaseCapp()))
 	})
 
 	t.Run("deletes SyslogNGFlow by capp name", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build()
+		fakeClient := newFakeClient(newSyslogNGScheme())
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGFlow()))
 
 		require.NoError(t, newSyslogNGFlowManager(fakeClient).CleanUp(ctx, newBaseCapp()))
@@ -153,7 +152,7 @@ func TestSyslogNGFlowCleanUp(t *testing.T) {
 		flow := newSyslogNGFlow()
 		require.NoError(t, controllerutil.SetOwnerReference(&capp, flow, newSyslogNGScheme()))
 
-		fm := newSyslogNGFlowManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).WithObjects(flow).Build())
+		fm := newSyslogNGFlowManager(newFakeClient(newSyslogNGScheme(), flow))
 		require.NoError(t, fm.CleanUp(ctx, capp))
 
 		got := &loggingv1beta1.SyslogNGFlow{}

--- a/internal/kinds/capp/resourcemanagers/syslogngflow_test.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngflow_test.go
@@ -50,7 +50,7 @@ func newSyslogNGFlow(outputRefs ...string) *loggingv1beta1.SyslogNGFlow {
 	}
 }
 
-func TestSyslogNGFlowCreateOrUpdate(t *testing.T) {
+func TestSyslogNGFlowManagerCreateOrUpdate(t *testing.T) {
 	ctx := context.Background()
 	key := types.NamespacedName{Name: cappName, Namespace: cappNamespace}
 
@@ -82,17 +82,17 @@ func TestSyslogNGFlowCreateOrUpdate(t *testing.T) {
 	})
 }
 
-func TestSyslogNGFlowManage(t *testing.T) {
+func TestSyslogNGFlowManagerManage(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("reconciles when log is required", func(t *testing.T) {
+	t.Run("reconciles when required", func(t *testing.T) {
 		fm := newSyslogNGFlowManager(newFakeClient(newSyslogNGScheme()))
 		capp := newBaseCapp()
 		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
 		require.NoError(t, fm.Manage(ctx, capp))
 	})
 
-	t.Run("cleans up when log is not required", func(t *testing.T) {
+	t.Run("cleans up when not required", func(t *testing.T) {
 		fakeClient := newFakeClient(newSyslogNGScheme())
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGFlow()))
 
@@ -124,10 +124,10 @@ func TestSyslogNGFlowManage(t *testing.T) {
 	})
 }
 
-func TestSyslogNGFlowCleanUp(t *testing.T) {
+func TestSyslogNGFlowManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("succeeds when SyslogNGFlow does not exist", func(t *testing.T) {
+	t.Run("succeeds when none exist", func(t *testing.T) {
 		fm := newSyslogNGFlowManager(newFakeClient(newSyslogNGScheme()))
 		require.NoError(t, fm.CleanUp(ctx, newBaseCapp()))
 	})
@@ -144,7 +144,7 @@ func TestSyslogNGFlowCleanUp(t *testing.T) {
 		require.True(t, errors.IsNotFound(getErr))
 	})
 
-	t.Run("skips delete when capp is deleting and flow has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/syslogngoutput_test.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngoutput_test.go
@@ -44,7 +44,7 @@ func newSyslogNGOutput() *loggingv1beta1.SyslogNGOutput {
 	}
 }
 
-func TestSyslogNGOutputCreateOrUpdate(t *testing.T) {
+func TestSyslogNGOutputManagerCreateOrUpdate(t *testing.T) {
 	ctx := context.Background()
 	key := types.NamespacedName{Name: cappName, Namespace: cappNamespace}
 
@@ -94,17 +94,17 @@ func TestSyslogNGOutputCreateOrUpdate(t *testing.T) {
 	})
 }
 
-func TestSyslogNGOutputManage(t *testing.T) {
+func TestSyslogNGOutputManagerManage(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("reconciles when log is required", func(t *testing.T) {
+	t.Run("reconciles when required", func(t *testing.T) {
 		om := newSyslogNGOutputManager(newFakeClient(newSyslogNGScheme()))
 		capp := newBaseCapp()
 		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
 		require.NoError(t, om.Manage(ctx, capp))
 	})
 
-	t.Run("cleans up when log is not required", func(t *testing.T) {
+	t.Run("cleans up when not required", func(t *testing.T) {
 		fakeClient := newFakeClient(newSyslogNGScheme())
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGOutput()))
 
@@ -136,10 +136,10 @@ func TestSyslogNGOutputManage(t *testing.T) {
 	})
 }
 
-func TestSyslogNGOutputCleanUp(t *testing.T) {
+func TestSyslogNGOutputManagerCleanUp(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("succeeds when SyslogNGOutput does not exist", func(t *testing.T) {
+	t.Run("succeeds when none exist", func(t *testing.T) {
 		om := newSyslogNGOutputManager(newFakeClient(newSyslogNGScheme()))
 		require.NoError(t, om.CleanUp(ctx, newBaseCapp()))
 	})
@@ -156,7 +156,7 @@ func TestSyslogNGOutputCleanUp(t *testing.T) {
 		require.True(t, errors.IsNotFound(getErr))
 	})
 
-	t.Run("skips delete when capp is deleting and output has owner reference", func(t *testing.T) {
+	t.Run("skips delete when deleting and has owner reference", func(t *testing.T) {
 		capp := newBaseCapp()
 		now := metav1.Now()
 		capp.DeletionTimestamp = &now

--- a/internal/kinds/capp/resourcemanagers/syslogngoutput_test.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngoutput_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -50,7 +49,7 @@ func TestSyslogNGOutputCreateOrUpdate(t *testing.T) {
 	key := types.NamespacedName{Name: cappName, Namespace: cappNamespace}
 
 	t.Run("creates when not found", func(t *testing.T) {
-		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		om := newSyslogNGOutputManager(newFakeClient(newSyslogNGScheme()))
 		capp := newBaseCapp()
 		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
 
@@ -66,7 +65,7 @@ func TestSyslogNGOutputCreateOrUpdate(t *testing.T) {
 	t.Run("updates when spec differs", func(t *testing.T) {
 		const updatedIndex = "my-index-v2"
 
-		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		om := newSyslogNGOutputManager(newFakeClient(newSyslogNGScheme()))
 		require.NoError(t, om.K8sclient.Create(ctx, newSyslogNGOutput()))
 
 		spec := newLogSpec(cappv1alpha1.LogTypeElastic)
@@ -81,7 +80,7 @@ func TestSyslogNGOutputCreateOrUpdate(t *testing.T) {
 	})
 
 	t.Run("creates datastream output when log type is elastic-datastream", func(t *testing.T) {
-		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		om := newSyslogNGOutputManager(newFakeClient(newSyslogNGScheme()))
 		capp := newBaseCapp()
 		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElasticDataStream)
 		require.NoError(t, om.createOrUpdate(ctx, capp))
@@ -99,14 +98,14 @@ func TestSyslogNGOutputManage(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("reconciles when log is required", func(t *testing.T) {
-		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		om := newSyslogNGOutputManager(newFakeClient(newSyslogNGScheme()))
 		capp := newBaseCapp()
 		capp.Spec.LogSpec = newLogSpec(cappv1alpha1.LogTypeElastic)
 		require.NoError(t, om.Manage(ctx, capp))
 	})
 
 	t.Run("cleans up when log is not required", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build()
+		fakeClient := newFakeClient(newSyslogNGScheme())
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGOutput()))
 
 		om := newSyslogNGOutputManager(fakeClient)
@@ -119,7 +118,7 @@ func TestSyslogNGOutputManage(t *testing.T) {
 	})
 
 	t.Run("cleans up when log type is unsupported", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build()
+		fakeClient := newFakeClient(newSyslogNGScheme())
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGOutput()))
 
 		om := newSyslogNGOutputManager(fakeClient)
@@ -141,12 +140,12 @@ func TestSyslogNGOutputCleanUp(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("succeeds when SyslogNGOutput does not exist", func(t *testing.T) {
-		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build())
+		om := newSyslogNGOutputManager(newFakeClient(newSyslogNGScheme()))
 		require.NoError(t, om.CleanUp(ctx, newBaseCapp()))
 	})
 
 	t.Run("deletes SyslogNGOutput by capp name", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).Build()
+		fakeClient := newFakeClient(newSyslogNGScheme())
 		require.NoError(t, fakeClient.Create(ctx, newSyslogNGOutput()))
 
 		require.NoError(t, newSyslogNGOutputManager(fakeClient).CleanUp(ctx, newBaseCapp()))
@@ -165,7 +164,7 @@ func TestSyslogNGOutputCleanUp(t *testing.T) {
 		syslogOutput := newSyslogNGOutput()
 		require.NoError(t, controllerutil.SetOwnerReference(&capp, syslogOutput, newSyslogNGScheme()))
 
-		om := newSyslogNGOutputManager(fake.NewClientBuilder().WithScheme(newSyslogNGScheme()).WithObjects(syslogOutput).Build())
+		om := newSyslogNGOutputManager(newFakeClient(newSyslogNGScheme(), syslogOutput))
 		require.NoError(t, om.CleanUp(ctx, capp))
 
 		got := &loggingv1beta1.SyslogNGOutput{}


### PR DESCRIPTION
Shared event-source constants and entry builders live in fixtures
so ping tests no longer depend on kafka-only definitions. Ping
setup reuses the shared entry pattern instead of repeated inline
config structs.