### PR TITLE
fix(api): apply URI relative-path CEL validation in CRDs

### DIFF
--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -155,7 +155,7 @@ type SourceConfiguration struct {
 
 	// URI is a relative path appended to the resolved Capp Knative Service address (e.g. "/path").
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:xValidation:rule="self == null || self.startsWith('/')",message="uri must be a relative path"
+	// +kubebuilder:validation:XValidation:rule="self.startsWith('/')",message="uri must be a relative path"
 	URI *kapis.URL `json:"uri,omitempty"`
 
 	// Configuration for a PingSource.

--- a/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capprevisions.yaml
@@ -8886,6 +8886,9 @@ spec:
                                     the resolved Capp Knative Service address (e.g.
                                     "/path").
                                   type: string
+                                  x-kubernetes-validations:
+                                  - message: uri must be a relative path
+                                    rule: self.startsWith('/')
                               required:
                               - name
                               type: object

--- a/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
+++ b/charts/container-app-operator/crds/rcs.dana.io_capps.yaml
@@ -8697,6 +8697,9 @@ spec:
                           description: URI is a relative path appended to the resolved
                             Capp Knative Service address (e.g. "/path").
                           type: string
+                          x-kubernetes-validations:
+                          - message: uri must be a relative path
+                            rule: self.startsWith('/')
                       required:
                       - name
                       type: object

--- a/config/crd/bases/rcs.dana.io_capprevisions.yaml
+++ b/config/crd/bases/rcs.dana.io_capprevisions.yaml
@@ -8886,6 +8886,9 @@ spec:
                                     the resolved Capp Knative Service address (e.g.
                                     "/path").
                                   type: string
+                                  x-kubernetes-validations:
+                                  - message: uri must be a relative path
+                                    rule: self.startsWith('/')
                               required:
                               - name
                               type: object

--- a/config/crd/bases/rcs.dana.io_capps.yaml
+++ b/config/crd/bases/rcs.dana.io_capps.yaml
@@ -8697,6 +8697,9 @@ spec:
                           description: URI is a relative path appended to the resolved
                             Capp Knative Service address (e.g. "/path").
                           type: string
+                          x-kubernetes-validations:
+                          - message: uri must be a relative path
+                            rule: self.startsWith('/')
                       required:
                       - name
                       type: object


### PR DESCRIPTION
Wrong kubebuilder marker silently dropped the rule from generated CRDs.