### PR TITLE
test(e2e): propagate API errors from resource existence checks

### DIFF
--- a/test/e2e/capp_revision_test.go
+++ b/test/e2e/capp_revision_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Validate CappRevision creation", func() {
 	It("Should validate CappRevison lifecycle based on Capp lifecycle", func() {
 		baseCapp := mocks.CreateBaseCapp()
 		By("Creating regular Capp")
-		desiredCapp := utils.CreateCapp(k8sClient, baseCapp)
+		desiredCapp := utils.CreateCapp(Default, k8sClient, baseCapp)
 
 		Eventually(func(g Gomega) {
 			cappRevisions, err := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
@@ -55,7 +55,7 @@ var _ = Describe("Validate CappRevision creation", func() {
 		utils.GetCappRevision(k8sClient, cappRevisionName, desiredCapp.Namespace)
 
 		By("Deleting Capp")
-		utils.DeleteCapp(k8sClient, desiredCapp)
+		utils.DeleteCapp(Default, k8sClient, desiredCapp)
 		Eventually(func(g Gomega) {
 			cappRevisions, err := utils.GetCappRevisions(context.Background(), k8sClient, *desiredCapp)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -68,7 +68,7 @@ var _ = Describe("Validate CappRevision creation", func() {
 		baseCapp := mocks.CreateBaseCapp()
 
 		By("Creating Capp")
-		desiredCapp := utils.CreateCapp(k8sClient, baseCapp)
+		desiredCapp := utils.CreateCapp(Default, k8sClient, baseCapp)
 		desiredCapp = utils.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 		desiredCapp.Annotations = make(map[string]string)
 

--- a/test/e2e/capp_test.go
+++ b/test/e2e/capp_test.go
@@ -15,13 +15,13 @@ var _ = Describe("Validate capp creation", func() {
 	It("Should default scale metric when unset", func() {
 		baseCapp := mocks.CreateBaseCapp()
 		By("Creating Capp with no scale metric")
-		desiredCapp := utils.CreateCapp(k8sClient, baseCapp)
+		desiredCapp := utils.CreateCapp(Default, k8sClient, baseCapp)
 		Expect(desiredCapp.Spec.ScaleSpec.Metric).ShouldNot(BeNil())
 	})
 
 	It("Should succeed all adapter functions", func() {
 		baseCapp := mocks.CreateBaseCapp()
-		desiredCapp := utils.CreateCapp(k8sClient, baseCapp)
+		desiredCapp := utils.CreateCapp(Default, k8sClient, baseCapp)
 
 		By("Checks unique creation of Capp")
 		assertionCapp := utils.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
@@ -42,16 +42,16 @@ var _ = Describe("Validate capp creation", func() {
 		}, consts.Timeout, consts.Interval).Should(Equal(consts.RPSScaleMetric), "Should fetch capp.")
 
 		By("Checks if deleted successfully")
-		utils.DeleteCapp(k8sClient, assertionCapp)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, assertionCapp)
+		utils.DeleteCapp(Default, k8sClient, assertionCapp)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, assertionCapp)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
 	It("Validate state functionality", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(Default, k8sClient, testCapp)
 
 		By("Checking if the capp state is enabled")
 		Eventually(func() string {
@@ -61,8 +61,8 @@ var _ = Describe("Validate capp creation", func() {
 
 		By("Checking if the ksvc was created successfully")
 		ksvcObject := mocks.CreateKnativeServiceObject(createdCapp.Name)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, ksvcObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, ksvcObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking if the revision is ready")
@@ -85,12 +85,12 @@ var _ = Describe("Validate capp creation", func() {
 		}, consts.Timeout, consts.Interval).Should(Equal(consts.DisabledState))
 
 		By("Checking if the ksvc and the revision were deleted successfully")
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, ksvcObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, ksvcObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
-		Eventually(func() bool {
+		Eventually(func() (bool, error) {
 			revision := mocks.CreateRevisionObject(revisionName)
-			return utils.DoesResourceExist(k8sClient, revision)
+			return utils.ResourceExists(k8sClient, revision)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Updating the capp status to be enabled")
@@ -103,8 +103,8 @@ var _ = Describe("Validate capp creation", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Checking if the ksvc was recreated successfully")
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, ksvcObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, ksvcObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking if the revision is ready")
@@ -115,7 +115,7 @@ var _ = Describe("Validate capp creation", func() {
 		baseCapp.Name = utils.GenerateCappName()
 
 		By("Creating Capp with no minReplicas (should default to 0)")
-		createdCapp := utils.CreateCapp(k8sClient, baseCapp)
+		createdCapp := utils.CreateCapp(Default, k8sClient, baseCapp)
 		Eventually(func() int {
 			capp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 			return capp.Spec.ScaleSpec.MinReplicas
@@ -164,6 +164,6 @@ var _ = Describe("Validate capp creation", func() {
 		Expect(err.Error()).To(ContainSubstring("must be less than or equal to global min scale"))
 
 		By("Cleaning up")
-		utils.DeleteCapp(k8sClient, createdCapp)
+		utils.DeleteCapp(Default, k8sClient, createdCapp)
 	})
 })

--- a/test/e2e/certificate_test.go
+++ b/test/e2e/certificate_test.go
@@ -16,13 +16,13 @@ import (
 var _ = Describe("Validate Certificate functionality", func() {
 	It("Should create, update and delete Certificate when creating, updating and deleting a Capp instance", func() {
 		By("Creating an HTTPS Capp")
-		createdCapp, routeHostname := utils.CreateHTTPSCapp(k8sClient)
+		createdCapp, routeHostname := utils.CreateHTTPSCapp(Default, k8sClient)
 
 		By("Checking if the Certificate was created successfully")
 		certificateName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		certificateObject := mocks.CreateCertificateObject(certificateName)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, certificateObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, certificateObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking the Certificate has the needed labels")
@@ -54,8 +54,8 @@ var _ = Describe("Validate Certificate functionality", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, certificateObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, certificateObject)
 		}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should not find a resource.")
 
 		err = retry.RetryOnConflict(utils.NewRetryOnConflictBackoff(), func() error {
@@ -66,38 +66,38 @@ var _ = Describe("Validate Certificate functionality", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, certificateObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, certificateObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Deleting the Capp instance and checking if the Certificate was deleted successfully")
-		utils.DeleteCapp(k8sClient, createdCapp)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, certificateObject)
+		utils.DeleteCapp(Default, k8sClient, createdCapp)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, certificateObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
 	It("Should not create Certificate when creating a non-HTTPS Capp instance", func() {
 		By("Creating a Capp with a route")
-		_, routeHostname := utils.CreateCappWithHTTPHostname(k8sClient)
+		_, routeHostname := utils.CreateCappWithHTTPHostname(Default, k8sClient)
 
 		By("Checking if the Certificate was not created")
 		certificateName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		certificateObject := mocks.CreateCertificateObject(certificateName)
-		Consistently(func() bool {
-			return utils.DoesResourceExist(k8sClient, certificateObject)
+		Consistently(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, certificateObject)
 		}, consts.DefaultConsistently, consts.Interval).Should(BeFalse(), "Should not find a resource.")
 	})
 
 	It("Should cleanup Certificate when no longer required (tls)", func() {
 		By("Creating an HTTPS Capp")
-		createdCapp, routeHostname := utils.CreateHTTPSCapp(k8sClient)
+		createdCapp, routeHostname := utils.CreateHTTPSCapp(Default, k8sClient)
 
 		By("Checking if the Certificate was created successfully")
 		certificateName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		certificateObject := mocks.CreateCertificateObject(certificateName)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, certificateObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, certificateObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Removing the Certificate requirement from Capp Spec and checking cleanup", func() {
@@ -109,8 +109,8 @@ var _ = Describe("Validate Certificate functionality", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(func() bool {
-				return utils.DoesResourceExist(k8sClient, certificateObject)
+			Eventually(func() (bool, error) {
+				return utils.ResourceExists(k8sClient, certificateObject)
 			}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should not find a resource.")
 		})
 	})

--- a/test/e2e/dnsrecord_test.go
+++ b/test/e2e/dnsrecord_test.go
@@ -14,13 +14,13 @@ import (
 var _ = Describe("Validate DNSRecord functionality", func() {
 	It("Should create, update and delete DNSRecord when creating, updating and deleting a Capp instance", func() {
 		By("Creating a capp with a route")
-		createdCapp, _ := utils.CreateCappWithHTTPHostname(k8sClient)
+		createdCapp, _ := utils.CreateCappWithHTTPHostname(Default, k8sClient)
 
 		By("Checking if the DNSRecord was created successfully")
 		dnsRecordName := utils.GenerateResourceName(createdCapp.Spec.RouteSpec.Hostname, consts.ZoneValue)
 		dnsRecordObject := mocks.CreateDNSRecordObject(dnsRecordName)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, dnsRecordObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, dnsRecordObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking the DNSRecord has the needed labels")
@@ -45,26 +45,26 @@ var _ = Describe("Validate DNSRecord functionality", func() {
 		}, consts.Timeout, consts.Interval).Should(Equal(&createdCapp.Spec.RouteSpec.Hostname))
 
 		By("Deleting the Capp instance")
-		utils.DeleteCapp(k8sClient, createdCapp)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, createdCapp)
+		utils.DeleteCapp(Default, k8sClient, createdCapp)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, createdCapp)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the DNSRecord was deleted successfully")
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, dnsRecordObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, dnsRecordObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
 	It("Should not update DNSRecord when only Capp metadata changes", func() {
 		By("Creating a capp with a route")
-		createdCapp, _ := utils.CreateCappWithHTTPHostname(k8sClient)
+		createdCapp, _ := utils.CreateCappWithHTTPHostname(Default, k8sClient)
 
 		By("Checking if the DNSRecord was created successfully")
 		dnsRecordName := utils.GenerateResourceName(createdCapp.Spec.RouteSpec.Hostname, consts.ZoneValue)
 		dnsRecordObject := mocks.CreateDNSRecordObject(dnsRecordName)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, dnsRecordObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, dnsRecordObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Simulating external mutation of DNSRecord spec")

--- a/test/e2e/domain_mapping_test.go
+++ b/test/e2e/domain_mapping_test.go
@@ -13,13 +13,13 @@ import (
 var _ = Describe("Validate DomainMapping functionality", func() {
 	It("Should create, update and delete DomainMapping when creating, updating and deleting a Capp instance", func() {
 		By("Creating a capp with a route")
-		createdCapp, routeHostname := utils.CreateCappWithHTTPHostname(k8sClient)
+		createdCapp, routeHostname := utils.CreateCappWithHTTPHostname(Default, k8sClient)
 
 		By("Checking if the domainMapping was created successfully")
 		domainMappingName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		domainMappingObject := mocks.CreateDomainMappingObject(domainMappingName)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, domainMappingObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, domainMappingObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking the domainMapping has the needed labels")
@@ -55,28 +55,28 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 		}, consts.Timeout, consts.Interval).Should(Equal(createdCapp.Name), "Should keep DomainMapping after route timeout update")
 
 		By("Deleting the Capp instance")
-		utils.DeleteCapp(k8sClient, createdCapp)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, createdCapp)
+		utils.DeleteCapp(Default, k8sClient, createdCapp)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, createdCapp)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the domainMapping was deleted successfully")
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, domainMappingObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, domainMappingObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
 	It("Should create DomainMapping with secret when Creating an HTTPS Capp instance", func() {
 		By("Creating an HTTP Capp")
-		createdCapp, routeHostname := utils.CreateCappWithHTTPHostname(k8sClient)
+		createdCapp, routeHostname := utils.CreateCappWithHTTPHostname(Default, k8sClient)
 
 		By("Making sure the tls secret exists in advance")
 		resourceName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		secretName := utils.GenerateCertSecretName(resourceName)
 		secretObject := mocks.CreateSecretObject(secretName)
 		utils.CreateSecret(k8sClient, secretObject)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, secretObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, secretObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Changing Capp to be HTTPS")
@@ -101,7 +101,7 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 
 	It("Should update the RouteStatus of the Capp accordingly", func() {
 		By("Creating a capp with a route")
-		createdCapp, routeHostname := utils.CreateCappWithHTTPHostname(k8sClient)
+		createdCapp, routeHostname := utils.CreateCappWithHTTPHostname(Default, k8sClient)
 
 		domainMappingName := utils.GenerateResourceName(routeHostname, consts.ZoneValue)
 		By("Checking if the RouteStatus of the Capp was updated successfully")

--- a/test/e2e/kafkasource_test.go
+++ b/test/e2e/kafkasource_test.go
@@ -19,18 +19,18 @@ const (
 	kafkaUpdatedTopic    = "payments"
 )
 
-func createCappAndWaitForKafkaSource(spec cappv1alpha1.EventSourcesSpec) (*cappv1alpha1.Capp, string) {
+func createCappAndWaitForKafkaSource(g Gomega, spec cappv1alpha1.EventSourcesSpec) (*cappv1alpha1.Capp, string) {
 	utilst.CreateSecret(k8sClient, mocks.CreateKafkaCredentialsSecret())
 	testCapp := mocks.CreateBaseCapp()
 	testCapp.Spec.EventSourcesSpec = spec
-	createdCapp := utilst.CreateCapp(k8sClient, testCapp)
+	createdCapp := utilst.CreateCapp(g, k8sClient, testCapp)
 	ksName := createdCapp.Name + "-" + spec.Sources[0].Name
 
 	ksObj := &kafkasourcev1.KafkaSource{}
 	ksObj.Name = ksName
 	ksObj.Namespace = consts.NSName
-	Eventually(func() bool {
-		return utilst.DoesResourceExist(k8sClient, ksObj)
+	Eventually(func() (bool, error) {
+		return utilst.ResourceExists(k8sClient, ksObj)
 	}, consts.Timeout, consts.Interval).Should(BeTrue())
 
 	return createdCapp, ksName
@@ -53,7 +53,7 @@ func newEventSourceSpec() cappv1alpha1.EventSourcesSpec {
 
 var _ = Describe("Validate KafkaSource functionality", func() {
 	It("Should create a KafkaSource when adding a Kafka event source to a Capp", func() {
-		createdCapp, ksName := createCappAndWaitForKafkaSource(newEventSourceSpec())
+		createdCapp, ksName := createCappAndWaitForKafkaSource(Default, newEventSourceSpec())
 
 		By("Verifying EventingStatus is populated with the source")
 		Eventually(func(g Gomega) {
@@ -64,7 +64,7 @@ var _ = Describe("Validate KafkaSource functionality", func() {
 	})
 
 	It("Should update the KafkaSource when the Capp event source spec changes", func() {
-		createdCapp, ksName := createCappAndWaitForKafkaSource(newEventSourceSpec())
+		createdCapp, ksName := createCappAndWaitForKafkaSource(Default, newEventSourceSpec())
 
 		By("Updating the Capp KafkaSource topics")
 		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
@@ -83,7 +83,7 @@ var _ = Describe("Validate KafkaSource functionality", func() {
 	})
 
 	It("Should delete the KafkaSource when the event source is removed from the Capp spec", func() {
-		createdCapp, ksName := createCappAndWaitForKafkaSource(newEventSourceSpec())
+		createdCapp, ksName := createCappAndWaitForKafkaSource(Default, newEventSourceSpec())
 
 		By("Removing all event sources from Capp spec")
 		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
@@ -97,8 +97,8 @@ var _ = Describe("Validate KafkaSource functionality", func() {
 		ksObj := &kafkasourcev1.KafkaSource{}
 		ksObj.Name = ksName
 		ksObj.Namespace = consts.NSName
-		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, ksObj)
+		Eventually(func() (bool, error) {
+			return utilst.ResourceExists(k8sClient, ksObj)
 		}, consts.Timeout, consts.Interval).Should(BeFalse())
 
 		By("Verifying EventingStatus is cleared")

--- a/test/e2e/ksvc_test.go
+++ b/test/e2e/ksvc_test.go
@@ -29,8 +29,8 @@ func verifyLatestReadyRevision(name, namespace, latestReadyRevisionBeforeUpdate 
 func checkRevisionReadiness(revisionName string) {
 	By("Checking if the revision was created successfully")
 	revisionObject := mocks.CreateRevisionObject(revisionName)
-	Eventually(func() bool {
-		return utils.DoesResourceExist(k8sClient, revisionObject)
+	Eventually(func() (bool, error) {
+		return utils.ResourceExists(k8sClient, revisionObject)
 	}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 	By("Ensuring that the new revision is ready")
 	Eventually(func() bool {
@@ -43,7 +43,7 @@ var _ = Describe("Validate KSVC functionality", func() {
 		By("Creating a capp instance with memory scale metric")
 		testCapp := mocks.CreateBaseCapp()
 		testCapp.Spec.ScaleSpec.Metric = consts.MemoryScaleMetric
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(Default, k8sClient, testCapp)
 
 		By("Checking if the ksvc was created with memory metric annotation successfully")
 		Eventually(func() string {
@@ -56,38 +56,38 @@ var _ = Describe("Validate KSVC functionality", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
 		testCapp.Spec.ScaleSpec.Metric = consts.CPUScaleMetric
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(Default, k8sClient, testCapp)
 		assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 
 		By("Checking if the ksvc was created successfully")
 		ksvcObject := mocks.CreateKnativeServiceObject(assertionCapp.Name)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, ksvcObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, ksvcObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 		checkRevisionReadiness(assertionCapp.Name + consts.FirstRevisionSuffix)
 
 		By("Deleting the capp instance")
-		utils.DeleteCapp(k8sClient, assertionCapp)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, assertionCapp)
+		utils.DeleteCapp(Default, k8sClient, assertionCapp)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, assertionCapp)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the ksvc exists")
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, ksvcObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, ksvcObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the revision exists")
 		revisionObject := mocks.CreateRevisionObject(assertionCapp.Name + consts.FirstRevisionSuffix)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, revisionObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, revisionObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
 	It("Should create a new ready revision when updating capp spec", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(Default, k8sClient, testCapp)
 
 		By("Updating capp container image")
 		var latestReadyRevisionBeforeUpdate string
@@ -112,7 +112,7 @@ var _ = Describe("Validate KSVC functionality", func() {
 		By("Creating a capp instance with a secret environment variable")
 		testCapp := mocks.CreateBaseCapp()
 		testCapp.Spec.ConfigurationSpec.Template.Spec.PodSpec.Containers[0].Env = *mocks.CreateEnvVarObject(secretName)
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(Default, k8sClient, testCapp)
 		assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 
 		checkRevisionReadiness(assertionCapp.Name + consts.FirstRevisionSuffix)
@@ -147,7 +147,7 @@ var _ = Describe("Validate KSVC functionality", func() {
 			autoscaling.TargetAnnotationKey: "666",
 		}
 		testCapp.Spec.ConfigurationSpec.Template.Annotations = annotations
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(Default, k8sClient, testCapp)
 		assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 
 		By("Checking if the ksvc's defaults annotations were overridden")
@@ -160,7 +160,7 @@ var _ = Describe("Validate KSVC functionality", func() {
 	It("Should check the default ksvc annotation is equal to the cappConfig's concurrency value", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()
-		createdCapp := utils.CreateCapp(k8sClient, testCapp)
+		createdCapp := utils.CreateCapp(Default, k8sClient, testCapp)
 		assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
 
 		cappConfig := utils.GetCappConfig(k8sClient, consts.CappConfigName, consts.ControllerNS)

--- a/test/e2e/logger_test.go
+++ b/test/e2e/logger_test.go
@@ -51,7 +51,7 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 		utils.CreateCredentialsSecret(logType, k8sClient)
 
 		By(fmt.Sprintf("Creating a Capp with %s logger", logType))
-		createdCapp := utils.CreateCappWithLogger(logType, k8sClient)
+		createdCapp := utils.CreateCappWithLogger(Default, logType, k8sClient)
 
 		syslogNGOutputName := createdCapp.Name
 		syslogNGOutputObject := mocks.CreateSyslogNGOutputObject(syslogNGOutputName)
@@ -79,8 +79,8 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 		syslogNGFlowName := createdCapp.Name
 		syslogNGFlowObject := mocks.CreateSyslogNGFlowObject(syslogNGFlowName)
 
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, syslogNGFlowObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, syslogNGFlowObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking the SyslogNGFlow has the needed labels")
@@ -109,19 +109,19 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 		checkOutputParameters(logType, syslogNGOutputName, createdCapp.Namespace, consts.TestIndex, consts.ElasticDataStreamURL)
 
 		By("Deleting the Capp instance")
-		utils.DeleteCapp(k8sClient, createdCapp)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, createdCapp)
+		utils.DeleteCapp(Default, k8sClient, createdCapp)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, createdCapp)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the SyslogNGOutput was deleted successfully")
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, syslogNGOutputObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, syslogNGOutputObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the SyslogNGFlow was deleted successfully")
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, syslogNGFlowObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, syslogNGFlowObject)
 		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
@@ -130,7 +130,7 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 		utils.CreateCredentialsSecret(logType, k8sClient)
 
 		By(fmt.Sprintf("Creating a Capp with %s logger", logType))
-		createdCapp := utils.CreateCappWithLogger(logType, k8sClient)
+		createdCapp := utils.CreateCappWithLogger(Default, logType, k8sClient)
 
 		By("Checking if the SyslogNGFlow and SyslogNGOutput were created successfully")
 		syslogNGFlowName := createdCapp.Name
@@ -139,12 +139,12 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 		syslogNGOutputName := createdCapp.Name
 		syslogNGOutputObject := mocks.CreateSyslogNGOutputObject(syslogNGOutputName)
 
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, syslogNGFlowObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, syslogNGFlowObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, syslogNGOutputObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, syslogNGOutputObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Removing the logging requirement from Capp Spec and checking cleanup")
@@ -156,12 +156,12 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, syslogNGFlowObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, syslogNGFlowObject)
 		}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should not find a resource.")
 
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, syslogNGOutputObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, syslogNGOutputObject)
 		}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should not find a resource.")
 	})
 }

--- a/test/e2e/mutating_test.go
+++ b/test/e2e/mutating_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Validate the mutating webhook", func() {
 
 	It("Should add annotation on create", func() {
 		baseCapp := mock.CreateBaseCapp()
-		capp := utils.CreateCapp(k8sClient, baseCapp)
+		capp := utils.CreateCapp(Default, k8sClient, baseCapp)
 
 		annotation := capp.ObjectMeta.Annotations[consts.LastUpdatedByAnnotationKey]
 		Expect(annotation).To(Equal(adminAnnotationValue))
@@ -33,7 +33,7 @@ var _ = Describe("Validate the mutating webhook", func() {
 
 	It("Should add annotation on update", func() {
 		baseCapp := mock.CreateBaseCapp()
-		capp := utils.CreateCapp(k8sClient, baseCapp)
+		capp := utils.CreateCapp(Default, k8sClient, baseCapp)
 
 		annotation := capp.ObjectMeta.Annotations[consts.LastUpdatedByAnnotationKey]
 		Expect(annotation).To(Equal(adminAnnotationValue))
@@ -59,7 +59,7 @@ var _ = Describe("Validate the mutating webhook", func() {
 
 	It("Should add default resources to Capp", func() {
 		baseCapp := mock.CreateBaseCapp()
-		capp := utils.CreateCapp(k8sClient, baseCapp)
+		capp := utils.CreateCapp(Default, k8sClient, baseCapp)
 
 		cpuRequest := capp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Resources.Requests.Cpu()
 		Expect(cpuRequest.String()).ToNot(Equal(""))
@@ -80,7 +80,7 @@ var _ = Describe("Validate the mutating webhook", func() {
 				corev1.ResourceMemory: resource.MustParse("23Mi"),
 			},
 		}
-		capp := utils.CreateCapp(k8sClient, baseCapp)
+		capp := utils.CreateCapp(Default, k8sClient, baseCapp)
 
 		cpuRequest := capp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Resources.Requests.Cpu()
 		Expect(cpuRequest.String()).To(Equal("23m"))

--- a/test/e2e/pingsource_test.go
+++ b/test/e2e/pingsource_test.go
@@ -27,24 +27,24 @@ func pingSourceObjectName(cappName, srcName string) string {
 	return fmt.Sprintf("%s-%s", cappName, srcName)
 }
 
-func createCappWithPingSource(eventSourceSpec cappv1alpha1.EventSourcesSpec) *cappv1alpha1.Capp {
+func createCappWithPingSource(g Gomega, eventSourceSpec cappv1alpha1.EventSourcesSpec) *cappv1alpha1.Capp {
 	testCapp := mocks.CreateBaseCapp()
 	testCapp.Spec.EventSourcesSpec = eventSourceSpec
 
-	return utilst.CreateCapp(k8sClient, testCapp)
+	return utilst.CreateCapp(g, k8sClient, testCapp)
 }
 
 // createCappAndWaitForPingSource creates a Capp with the given EventSourcesSpec and waits
 // until the first PingSource is created, returning the Capp and the PingSource object name.
-func createCappAndWaitForPingSource(spec cappv1alpha1.EventSourcesSpec) (*cappv1alpha1.Capp, string) {
-	createdCapp := createCappWithPingSource(spec)
+func createCappAndWaitForPingSource(g Gomega, spec cappv1alpha1.EventSourcesSpec) (*cappv1alpha1.Capp, string) {
+	createdCapp := createCappWithPingSource(g, spec)
 	psName := pingSourceObjectName(createdCapp.Name, spec.Sources[0].Name)
 
 	psObj := &sourcesv1.PingSource{}
 	psObj.Name = psName
 	psObj.Namespace = consts.NSName
-	Eventually(func() bool {
-		return utilst.DoesResourceExist(k8sClient, psObj)
+	Eventually(func() (bool, error) {
+		return utilst.ResourceExists(k8sClient, psObj)
 	}, consts.Timeout, consts.Interval).Should(BeTrue())
 
 	return createdCapp, psName
@@ -66,7 +66,7 @@ func newEventSourceSpecWithPingSource() cappv1alpha1.EventSourcesSpec {
 
 var _ = Describe("Validate PingSource functionality", func() {
 	It("Should create a PingSource when adding a PingSource event source to a Capp", func() {
-		createdCapp, psName := createCappAndWaitForPingSource(newEventSourceSpecWithPingSource())
+		createdCapp, psName := createCappAndWaitForPingSource(Default, newEventSourceSpecWithPingSource())
 
 		By("Verifying EventingStatus is populated with the source")
 		Eventually(func() int {
@@ -78,7 +78,7 @@ var _ = Describe("Validate PingSource functionality", func() {
 	})
 
 	It("Should update the PingSource when the Capp event source spec changes", func() {
-		createdCapp, psName := createCappAndWaitForPingSource(newEventSourceSpecWithPingSource())
+		createdCapp, psName := createCappAndWaitForPingSource(Default, newEventSourceSpecWithPingSource())
 
 		By("Updating the Capp PingSource schedule and data")
 		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
@@ -100,7 +100,7 @@ var _ = Describe("Validate PingSource functionality", func() {
 	})
 
 	It("Should delete the PingSource when the event source is removed from the Capp spec", func() {
-		createdCapp, psName := createCappAndWaitForPingSource(newEventSourceSpecWithPingSource())
+		createdCapp, psName := createCappAndWaitForPingSource(Default, newEventSourceSpecWithPingSource())
 
 		By("Removing all event sources from Capp spec")
 		err := retry.RetryOnConflict(utilst.NewRetryOnConflictBackoff(), func() error {
@@ -114,8 +114,8 @@ var _ = Describe("Validate PingSource functionality", func() {
 		psObj := &sourcesv1.PingSource{}
 		psObj.Name = psName
 		psObj.Namespace = consts.NSName
-		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, psObj)
+		Eventually(func() (bool, error) {
+			return utilst.ResourceExists(k8sClient, psObj)
 		}, consts.Timeout, consts.Interval).Should(BeFalse())
 
 		By("Verifying EventingStatus is cleared")
@@ -125,17 +125,17 @@ var _ = Describe("Validate PingSource functionality", func() {
 	})
 
 	It("Should delete owned PingSources when the Capp is deleted", func() {
-		createdCapp, psName := createCappAndWaitForPingSource(newEventSourceSpecWithPingSource())
+		createdCapp, psName := createCappAndWaitForPingSource(Default, newEventSourceSpecWithPingSource())
 
 		By("Deleting the Capp")
-		utilst.DeleteCapp(k8sClient, createdCapp)
+		utilst.DeleteCapp(Default, k8sClient, createdCapp)
 
 		By("Verifying PingSource is deleted")
 		psObj := &sourcesv1.PingSource{}
 		psObj.Name = psName
 		psObj.Namespace = consts.NSName
-		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, psObj)
+		Eventually(func() (bool, error) {
+			return utilst.ResourceExists(k8sClient, psObj)
 		}, consts.Timeout, consts.Interval).Should(BeFalse())
 	})
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -69,8 +69,8 @@ func createE2ETestNamespace() {
 	}
 
 	Expect(k8sClient.Create(context.Background(), namespace)).To(SatisfyAny(BeNil(), WithTransform(errors.IsAlreadyExists, BeTrue())))
-	Eventually(func() bool {
-		return utils.DoesResourceExist(k8sClient, namespace)
+	Eventually(func() (bool, error) {
+		return utils.ResourceExists(k8sClient, namespace)
 	}, consts.Timeout, consts.Interval).Should(BeTrue(), "The namespace should be created")
 }
 
@@ -82,7 +82,7 @@ func cleanUp() {
 		},
 	}
 
-	if utils.DoesResourceExist(k8sClient, namespace) {
+	if exists, err := utils.ResourceExists(k8sClient, namespace); err == nil && exists {
 		Expect(k8sClient.Delete(context.Background(), namespace)).To(Succeed())
 		Eventually(func() error {
 			return k8sClient.Get(context.Background(), client.ObjectKey{Name: consts.NSName}, namespace)

--- a/test/e2e/utils/capp_adapter.go
+++ b/test/e2e/utils/capp_adapter.go
@@ -6,29 +6,32 @@ import (
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CreateCapp creates a new Capp instance with a unique name and returns it.
-func CreateCapp(k8sClient client.Client, capp *cappv1alpha1.Capp) *cappv1alpha1.Capp {
+func CreateCapp(g Gomega, k8sClient client.Client, capp *cappv1alpha1.Capp) *cappv1alpha1.Capp {
+	GinkgoHelper()
 	cappName := GenerateCappName()
 	newCapp := capp.DeepCopy()
 	newCapp.Name = cappName
 	Expect(k8sClient.Create(context.Background(), newCapp)).To(Succeed())
 
-	Eventually(func() bool {
-		return DoesResourceExist(k8sClient, newCapp)
+	g.Eventually(func() (bool, error) {
+		return ResourceExists(k8sClient, newCapp)
 	}, consts.Timeout, consts.Interval).Should(BeTrue(), "Capp should exist")
 
 	return newCapp
 }
 
 // DeleteCapp deletes an existing Capp instance.
-func DeleteCapp(k8sClient client.Client, capp *cappv1alpha1.Capp) {
+func DeleteCapp(g Gomega, k8sClient client.Client, capp *cappv1alpha1.Capp) {
+	GinkgoHelper()
 	Expect(k8sClient.Delete(context.Background(), capp)).To(Succeed())
-	Eventually(func() bool {
-		return DoesResourceExist(k8sClient, capp)
+	g.Eventually(func() (bool, error) {
+		return ResourceExists(k8sClient, capp)
 	}, consts.TimeoutCapp, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 }
 
@@ -39,6 +42,7 @@ func GenerateCappName() string {
 
 // GetCapp fetches and returns an existing instance of a Capp.
 func GetCapp(k8sClient client.Client, name string, namespace string) *cappv1alpha1.Capp {
+	GinkgoHelper()
 	capp := &cappv1alpha1.Capp{}
 	GetResource(k8sClient, capp, name, namespace)
 	return capp

--- a/test/e2e/utils/logger_adapter.go
+++ b/test/e2e/utils/logger_adapter.go
@@ -4,11 +4,12 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	mock "github.com/dana-team/container-app-operator/test/e2e/mocks"
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CreateCappWithLogger creates a Capp instance with the specified logger type and returns the created Capp object.
-func CreateCappWithLogger(logType cappv1alpha1.LogType, k8sClient client.Client) *cappv1alpha1.Capp {
+func CreateCappWithLogger(g Gomega, logType cappv1alpha1.LogType, k8sClient client.Client) *cappv1alpha1.Capp {
 	capp := mock.CreateBaseCapp()
 	switch logType {
 	case cappv1alpha1.LogTypeElastic:
@@ -16,7 +17,7 @@ func CreateCappWithLogger(logType cappv1alpha1.LogType, k8sClient client.Client)
 	case cappv1alpha1.LogTypeElasticDataStream:
 		capp.Spec.LogSpec = mock.CreateElasticDataStreamLogSpec()
 	}
-	return CreateCapp(k8sClient, capp)
+	return CreateCapp(g, k8sClient, capp)
 }
 
 // CreateCredentialsSecret creates a Kubernetes secret containing credentials for the specified logger type.

--- a/test/e2e/utils/resources_adapter.go
+++ b/test/e2e/utils/resources_adapter.go
@@ -30,22 +30,28 @@ func generateRandomString(length int) string {
 	return string(b)
 }
 
-// DoesResourceExist checks if a given Kubernetes object exists in the cluster.
-func DoesResourceExist(k8sClient client.Client, obj client.Object) bool {
+// ResourceExists checks if a given Kubernetes object exists in the cluster.
+// Returns (false, nil) when the object is not found, and (false, err) on any other API error.
+func ResourceExists(k8sClient client.Client, obj client.Object) (bool, error) {
 	copyObject := obj.DeepCopyObject().(client.Object)
 	key := client.ObjectKeyFromObject(copyObject)
 	err := k8sClient.Get(context.Background(), key, copyObject)
 	if errors.IsNotFound(err) {
-		return false
+		return false, nil
 	} else if err != nil {
-		Fail(fmt.Sprintf("The function failed with error: \n %s", err.Error()))
+		return false, err
 	}
-	return true
+	return true, nil
 }
 
-// GetResource fetches an existing resource and returns an instance of it.
+// GetResource fetches a resource into obj. NotFound is silently ignored so the
+// caller receives a zero-value obj; any other API error fails the test.
 func GetResource(k8sClient client.Client, obj client.Object, name, namespace string) {
-	Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, obj))
+	GinkgoHelper()
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, obj)
+	if !errors.IsNotFound(err) {
+		Expect(err).ToNot(HaveOccurred())
+	}
 }
 
 // generateName generates a new name by combining the given baseName
@@ -57,6 +63,7 @@ func generateName(baseName string) string {
 
 // GetSecret fetches and returns an existing instance of a Secret.
 func GetSecret(k8sClient client.Client, name string, namespace string) *corev1.Secret {
+	GinkgoHelper()
 	secret := &corev1.Secret{}
 	GetResource(k8sClient, secret, name, namespace)
 	return secret
@@ -64,6 +71,7 @@ func GetSecret(k8sClient client.Client, name string, namespace string) *corev1.S
 
 // GetCappConfig fetches and returns an existing instance of an existing cappConfig
 func GetCappConfig(k8sClient client.Client, name string, namespace string) *cappv1alpha1.CappConfig {
+	GinkgoHelper()
 	cappConfig := &cappv1alpha1.CappConfig{}
 	GetResource(k8sClient, cappConfig, name, namespace)
 	return cappConfig
@@ -93,6 +101,7 @@ func UpdateResource(k8sClient client.Client, object client.Object) error {
 
 // CreateSecret creates a new secret, ignoring AlreadyExists errors.
 func CreateSecret(k8sClient client.Client, secret *corev1.Secret) {
+	GinkgoHelper()
 	err := k8sClient.Create(context.Background(), secret)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/utils/route_adapter.go
+++ b/test/e2e/utils/route_adapter.go
@@ -9,29 +9,30 @@ import (
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	mock "github.com/dana-team/container-app-operator/test/e2e/mocks"
+	. "github.com/onsi/gomega"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CreateCappWithHTTPHostname creates a Capp with a Hostname.
-func CreateCappWithHTTPHostname(k8sClient client.Client) (*cappv1alpha1.Capp, string) {
+func CreateCappWithHTTPHostname(g Gomega, k8sClient client.Client) (*cappv1alpha1.Capp, string) {
 	httpsCapp := mock.CreateBaseCapp()
 	hostname := GenerateRouteHostname()
 
 	httpsCapp.Spec.RouteSpec.Hostname = hostname
 
-	return CreateCapp(k8sClient, httpsCapp), hostname
+	return CreateCapp(g, k8sClient, httpsCapp), hostname
 }
 
 // CreateHTTPSCapp creates a Capp with a Hostname, TLS Enabled and TLSSecret.
-func CreateHTTPSCapp(k8sClient client.Client) (*cappv1alpha1.Capp, string) {
+func CreateHTTPSCapp(g Gomega, k8sClient client.Client) (*cappv1alpha1.Capp, string) {
 	httpsCapp := mock.CreateBaseCapp()
 	hostname := GenerateRouteHostname()
 
 	httpsCapp.Spec.RouteSpec.Hostname = hostname
 	httpsCapp.Spec.RouteSpec.TlsEnabled = true
 
-	return CreateCapp(k8sClient, httpsCapp), hostname
+	return CreateCapp(g, k8sClient, httpsCapp), hostname
 }
 
 // GetDomainMapping fetches and returns an existing instance of a DomainMapping.

--- a/test/e2e/utils/testuser_adapter.go
+++ b/test/e2e/utils/testuser_adapter.go
@@ -7,6 +7,7 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/test/e2e/consts"
 	mock "github.com/dana-team/container-app-operator/test/e2e/mocks"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -19,12 +20,14 @@ import (
 
 // CreateTestUser creates a test user with the specified Kubernetes client and namespace.
 func CreateTestUser(k8sClient client.Client, namespace string) {
+	GinkgoHelper()
 	createTestUserServiceAccount(k8sClient)
 	createTestUserRoleAndRoleBinding(k8sClient, namespace)
 }
 
 // CreateExcludedServiceAccount configures a service account that should be excluded from the mutating webhook.
 func CreateExcludedServiceAccount(k8sClient client.Client) {
+	GinkgoHelper()
 	createUserServiceAccount(k8sClient, consts.ExcludedServiceAccountName, consts.ExcludedServiceAccountNamespace)
 	createUserRoleAndRoleBinding(k8sClient, consts.ExcludedServiceAccountName, consts.ExcludedServiceAccountNamespace)
 }
@@ -32,6 +35,7 @@ func CreateExcludedServiceAccount(k8sClient client.Client) {
 // SwitchUser switches the Kubernetes client's user context to the given serviceAccountName if it's not empty.
 // If serviceAccountName is empty, it reverts to the original context.
 func SwitchUser(k8sClient *client.Client, cfg *rest.Config, namespace string, scheme *runtime.Scheme, serviceAccountName string) {
+	GinkgoHelper()
 	cfg.Impersonate = rest.ImpersonationConfig{}
 	if serviceAccountName != "" {
 		cfg.Impersonate = rest.ImpersonationConfig{
@@ -48,23 +52,27 @@ func SwitchUser(k8sClient *client.Client, cfg *rest.Config, namespace string, sc
 
 // DeleteTestUser deletes the test user created in the specified namespace.
 func DeleteTestUser(k8sClient client.Client, namespace string) {
+	GinkgoHelper()
 	deleteUserRoleAndRoleBinding(k8sClient, consts.ServiceAccountName, namespace)
 	deleteTestUserServiceAccount(k8sClient, namespace)
 }
 
 // DeleteExcludedServiceAccount deletes the excluded user created in the specified namespace.
 func DeleteExcludedServiceAccount(k8sClient client.Client) {
+	GinkgoHelper()
 	deleteUserRoleAndRoleBinding(k8sClient, consts.ExcludedServiceAccountName, consts.ExcludedServiceAccountNamespace)
 	deleteUserServiceAccount(k8sClient, consts.ExcludedServiceAccountName, consts.ExcludedServiceAccountNamespace)
 }
 
 // createTestUserServiceAccount creates a service account for the test user in the specified namespace.
 func createTestUserServiceAccount(k8sClient client.Client) {
+	GinkgoHelper()
 	createUserServiceAccount(k8sClient, consts.ServiceAccountName, "")
 }
 
 // createUserServiceAccount creates a service account for the test user in the specified namespace.
 func createUserServiceAccount(k8sClient client.Client, serviceAccountName, namespace string) {
+	GinkgoHelper()
 	serviceAccount := mock.CreateServiceAccount(serviceAccountName, namespace)
 
 	err := k8sClient.Create(context.Background(), serviceAccount)
@@ -73,11 +81,13 @@ func createUserServiceAccount(k8sClient client.Client, serviceAccountName, names
 
 // createTestUserRoleAndRoleBinding creates a role and role binding for the test user in the specified namespace.
 func createTestUserRoleAndRoleBinding(k8sClient client.Client, namespace string) {
+	GinkgoHelper()
 	createUserRoleAndRoleBinding(k8sClient, consts.ServiceAccountName, namespace)
 }
 
 // createUserRoleAndRoleBinding creates a role and role binding for a user in the specified namespace.
 func createUserRoleAndRoleBinding(k8sClient client.Client, serviceAccountName, namespace string) {
+	GinkgoHelper()
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{cappv1alpha1.GroupVersion.Group},
@@ -113,11 +123,13 @@ func createUserRoleAndRoleBinding(k8sClient client.Client, serviceAccountName, n
 
 // deleteTestUserServiceAccount deletes the service account of the test user in the specified namespace.
 func deleteTestUserServiceAccount(k8sClient client.Client, namespace string) {
+	GinkgoHelper()
 	deleteUserServiceAccount(k8sClient, consts.ServiceAccountName, namespace)
 }
 
 // deleteUserServiceAccount deletes the service account of a user in the specified namespace.
 func deleteUserServiceAccount(k8sClient client.Client, serviceAccountName, namespace string) {
+	GinkgoHelper()
 	serviceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceAccountName,
@@ -130,6 +142,7 @@ func deleteUserServiceAccount(k8sClient client.Client, serviceAccountName, names
 
 // deleteUserRoleAndRoleBinding deletes the role and role binding of a user in the specified namespace.
 func deleteUserRoleAndRoleBinding(k8sClient client.Client, serviceAccountName, namespace string) {
+	GinkgoHelper()
 	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceAccountName,

--- a/test/e2e/volumes_test.go
+++ b/test/e2e/volumes_test.go
@@ -51,8 +51,8 @@ var _ = Describe("Validate NFSPVC functionality", func() {
 
 		By("Checking if the NFSPVC was created successfully")
 		nfspvcObject := mocks.CreateNFSPVCObject(nfspvcName)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, nfspvcObject)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, nfspvcObject)
 		}, consts.Timeout, consts.Interval).Should(BeTrue(), "Should find a resource.")
 
 		By("Checking the NFSPVC has the needed labels")
@@ -61,9 +61,9 @@ var _ = Describe("Validate NFSPVC functionality", func() {
 		Expect(nfspvcObject.Labels[consts.ManagedByLabelKey]).Should(Equal(consts.CappKey))
 
 		By("Deleting the Capp instance")
-		utils.DeleteCapp(k8sClient, testCapp)
-		Eventually(func() bool {
-			return utils.DoesResourceExist(k8sClient, nfspvcObject)
+		utils.DeleteCapp(Default, k8sClient, testCapp)
+		Eventually(func() (bool, error) {
+			return utils.ResourceExists(k8sClient, nfspvcObject)
 		}, consts.Timeout, consts.Interval).Should(BeFalse(), "Should find a resource.")
 	})
 })


### PR DESCRIPTION
DoesResourceExist called Fail directly on non-NotFound errors, which breaks async Gomega assertions that need to retry on transient failures. Replace it with ResourceExists returning (bool, error) so Eventually and Consistently can surface and retry errors correctly.

Pass Gomega through helpers so scoped assertions work inside Eventually blocks, and add GinkgoHelper() throughout so failure traces point to the call site in the test.