### PR TITLE
test(e2e): remove redundant post-delete existence checks

### DIFF
--- a/test/e2e/capp_test.go
+++ b/test/e2e/capp_test.go
@@ -43,9 +43,6 @@ var _ = Describe("Validate capp creation", func() {
 
 		By("Checks if deleted successfully")
 		utils.DeleteCapp(Default, k8sClient, assertionCapp)
-		Eventually(func() (bool, error) {
-			return utils.ResourceExists(k8sClient, assertionCapp)
-		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 	})
 
 	It("Validate state functionality", func() {

--- a/test/e2e/dnsrecord_test.go
+++ b/test/e2e/dnsrecord_test.go
@@ -46,9 +46,6 @@ var _ = Describe("Validate DNSRecord functionality", func() {
 
 		By("Deleting the Capp instance")
 		utils.DeleteCapp(Default, k8sClient, createdCapp)
-		Eventually(func() (bool, error) {
-			return utils.ResourceExists(k8sClient, createdCapp)
-		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the DNSRecord was deleted successfully")
 		Eventually(func() (bool, error) {

--- a/test/e2e/domain_mapping_test.go
+++ b/test/e2e/domain_mapping_test.go
@@ -56,9 +56,6 @@ var _ = Describe("Validate DomainMapping functionality", func() {
 
 		By("Deleting the Capp instance")
 		utils.DeleteCapp(Default, k8sClient, createdCapp)
-		Eventually(func() (bool, error) {
-			return utils.ResourceExists(k8sClient, createdCapp)
-		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the domainMapping was deleted successfully")
 		Eventually(func() (bool, error) {

--- a/test/e2e/ksvc_test.go
+++ b/test/e2e/ksvc_test.go
@@ -68,9 +68,6 @@ var _ = Describe("Validate KSVC functionality", func() {
 
 		By("Deleting the capp instance")
 		utils.DeleteCapp(Default, k8sClient, assertionCapp)
-		Eventually(func() (bool, error) {
-			return utils.ResourceExists(k8sClient, assertionCapp)
-		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the ksvc exists")
 		Eventually(func() (bool, error) {

--- a/test/e2e/logger_test.go
+++ b/test/e2e/logger_test.go
@@ -110,9 +110,6 @@ func testCappWithLogger(logType cappv1alpha1.LogType) {
 
 		By("Deleting the Capp instance")
 		utils.DeleteCapp(Default, k8sClient, createdCapp)
-		Eventually(func() (bool, error) {
-			return utils.ResourceExists(k8sClient, createdCapp)
-		}, consts.Timeout, consts.Interval).ShouldNot(BeTrue(), "Should not find a resource.")
 
 		By("Checking if the SyslogNGOutput was deleted successfully")
 		Eventually(func() (bool, error) {


### PR DESCRIPTION
DeleteCapp already waits for removal; the extra Eventually polls added no new signal and slowed tests.