### PR TITLE
feat(webhook): reject autoscaling annotations in Capp templates

### DIFF
--- a/internal/webhook/rcs/v1alpha1/validator.go
+++ b/internal/webhook/rcs/v1alpha1/validator.go
@@ -19,6 +19,7 @@ import (
 	kafkasecurity "knative.dev/eventing-kafka-broker/control-plane/pkg/security"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	kautoscaling "knative.dev/serving/pkg/apis/autoscaling"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/go-logr/logr"
@@ -102,6 +103,10 @@ func (c *CappValidator) handle(ctx context.Context, operation admissionv1.Operat
 	}
 
 	if err := validateEventSources(ctx, c.Client, capp, config.Spec.MaxKafkaConsumers); err != nil {
+		return admission.Denied(err.Error())
+	}
+
+	if err := validateTemplateAnnotations(capp); err != nil {
 		return admission.Denied(err.Error())
 	}
 
@@ -206,6 +211,16 @@ func validateEventSources(ctx context.Context, r client.Reader, capp cappv1alpha
 			if err := common.ValidateURI(src.URI); err != nil {
 				return fmt.Errorf("%s[%d].uri: %w", eventSourcePath, i, err)
 			}
+		}
+	}
+	return nil
+}
+
+func validateTemplateAnnotations(capp cappv1alpha1.Capp) error {
+	prefix := kautoscaling.GroupName + "/"
+	for key := range capp.Spec.ConfigurationSpec.Template.Annotations {
+		if strings.HasPrefix(key, prefix) {
+			return fmt.Errorf("forbidden annotation %q in template annotations: autoscaling annotations are derived by the operator and cannot be set directly", key)
 		}
 	}
 	return nil

--- a/internal/webhook/rcs/v1alpha1/validator_test.go
+++ b/internal/webhook/rcs/v1alpha1/validator_test.go
@@ -519,6 +519,44 @@ func TestValidateKafkaSourceConsumers(t *testing.T) {
 	}
 }
 
+func TestValidateTemplateAnnotations(t *testing.T) {
+	forbiddenKey := knativeautoscaling.GroupName + "/minScale"
+
+	tests := []struct {
+		name            string
+		annotations     map[string]string
+		wantErrContains []string
+	}{
+		{
+			name:        "allows capp with non-autoscaling annotations",
+			annotations: map[string]string{"app.example.com/foo": "bar"},
+		},
+		{
+			name:            "rejects capp with autoscaling annotation",
+			annotations:     map[string]string{forbiddenKey: "3"},
+			wantErrContains: []string{"forbidden annotation", forbiddenKey},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			capp := cappv1alpha1.Capp{}
+			capp.Spec.ConfigurationSpec.Template.Annotations = tc.annotations
+
+			err := validateTemplateAnnotations(capp)
+			if len(tc.wantErrContains) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			for _, s := range tc.wantErrContains {
+				assert.Contains(t, err.Error(), s)
+			}
+		})
+	}
+}
+
 func TestValidateScaleSpec(t *testing.T) {
 	const maxReplicasErrMsg = "maxReplicas"
 

--- a/test/e2e/ksvc_test.go
+++ b/test/e2e/ksvc_test.go
@@ -140,23 +140,6 @@ var _ = Describe("Validate KSVC functionality", func() {
 		verifyLatestReadyRevision(createdCapp.Name, createdCapp.Namespace, latestReadyRevisionBeforeUpdate)
 	})
 
-	It("Should create capp with autoscale annotation. The default annotation in the ksvc should be overridden", func() {
-		By("Creating a capp instance")
-		testCapp := mocks.CreateBaseCapp()
-		annotations := map[string]string{
-			autoscaling.TargetAnnotationKey: "666",
-		}
-		testCapp.Spec.ConfigurationSpec.Template.Annotations = annotations
-		createdCapp := utils.CreateCapp(Default, k8sClient, testCapp)
-		assertionCapp := utils.GetCapp(k8sClient, createdCapp.Name, createdCapp.Namespace)
-
-		By("Checking if the ksvc's defaults annotations were overridden")
-		Eventually(func() string {
-			ksvc := utils.GetKSVC(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return ksvc.Spec.ConfigurationSpec.Template.Annotations[autoscaling.TargetAnnotationKey]
-		}, consts.Timeout, consts.Interval).Should(Equal("666"))
-	})
-
 	It("Should check the default ksvc annotation is equal to the cappConfig's concurrency value", func() {
 		By("Creating a capp instance")
 		testCapp := mocks.CreateBaseCapp()


### PR DESCRIPTION
Prevents users from bypassing operator-managed autoscaling by setting autoscaling.knative.dev/* annotations directly. The E2E test asserting override behavior is removed since that path is now rejected.