### PR TITLE
refactor(autoscale): remove dead annotation-merge path

### DIFF
--- a/internal/kinds/capp/autoscale/autoscale.go
+++ b/internal/kinds/capp/autoscale/autoscale.go
@@ -6,12 +6,10 @@ import (
 	"time"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
-	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	kautoscaling "knative.dev/serving/pkg/apis/autoscaling"
 )
 
 const (
-	AutoScalerSubString = "autoscaling"
 	rpsScaleKey         = "rps"
 	cpuScaleKey         = "cpu"
 	memoryScaleKey      = "memory"
@@ -29,7 +27,6 @@ func SetAutoScaler(capp cappv1alpha1.Capp, defaults cappv1alpha1.AutoscaleConfig
 		return autoScaleAnnotations
 	}
 
-	givenAutoScaleAnnotation := utils.FilterMap(capp.Spec.ConfigurationSpec.Template.Annotations, AutoScalerSubString)
 	autoScaleAnnotations[kautoscaling.ClassAnnotationKey] = getAutoScaleClassByMetric(scaleMetric)
 	autoScaleAnnotations[kautoscaling.MetricAnnotationKey] = scaleMetric
 	autoScaleAnnotations[kautoscaling.TargetAnnotationKey] = getTargetValue(scaleMetric, defaults)
@@ -38,12 +35,9 @@ func SetAutoScaler(capp cappv1alpha1.Capp, defaults cappv1alpha1.AutoscaleConfig
 		autoScaleAnnotations[kautoscaling.ScaleDownDelayAnnotationKey] = (time.Duration(capp.Spec.ScaleSpec.ScaleDelaySeconds) * time.Second).String()
 	}
 
-	autoScaleAnnotations = utils.MergeMaps(autoScaleAnnotations, givenAutoScaleAnnotation)
 	if capp.Spec.ScaleSpec.MinReplicas != 0 {
-		delete(autoScaleAnnotations, kautoscaling.ActivationScaleKey)
 		autoScaleAnnotations[kautoscaling.MinScaleAnnotationKey] = fmt.Sprintf("%d", capp.Spec.ScaleSpec.MinReplicas)
 	} else {
-		delete(autoScaleAnnotations, kautoscaling.MinScaleAnnotationKey)
 		autoScaleAnnotations[kautoscaling.ActivationScaleKey] = fmt.Sprintf("%d", defaults.ActivationScale)
 	}
 

--- a/internal/kinds/capp/utils/utils.go
+++ b/internal/kinds/capp/utils/utils.go
@@ -57,18 +57,6 @@ func MergeMaps(m1 map[string]string, m2 map[string]string) map[string]string {
 	return merged
 }
 
-// FilterMap returns a new map containing only the key-value pairs
-// where the key contains the specified substring.
-func FilterMap(originalMap map[string]string, substring string) map[string]string {
-	filteredMap := make(map[string]string)
-	for key, value := range originalMap {
-		if strings.Contains(key, substring) {
-			filteredMap[key] = value
-		}
-	}
-	return filteredMap
-}
-
 // GenerateSecretName generates TLS secret name for certificate and domain mapping.
 func GenerateSecretName(resourceName string) string {
 	return fmt.Sprintf("%s-tls", resourceName)


### PR DESCRIPTION
The validating webhook rejects any user-supplied autoscaling annotations at admission, so the FilterMap/MergeMaps path in SetAutoScaler was unreachable. Remove it along with the now-unnecessary delete() guards and the orphaned FilterMap utility.