### PR TITLE
test(controllers): cover watch predicates and request mappers

### DIFF
--- a/internal/kinds/capp/controllers/controller_test.go
+++ b/internal/kinds/capp/controllers/controller_test.go
@@ -1,16 +1,25 @@
 package controllers
 
 import (
+	"context"
 	"testing"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
+	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	knativeapis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const conditionTypeReady = "Ready"
@@ -98,7 +107,7 @@ func TestCertificateConditions(t *testing.T) {
 	}, pairs)
 }
 
-func TestDomainMappingWatchPredicateIntegration(t *testing.T) {
+func TestDomainMappingWatchPredicate(t *testing.T) {
 	makeDM := func(condStatus corev1.ConditionStatus) *knativev1beta1.DomainMapping {
 		dm := &knativev1beta1.DomainMapping{}
 		if condStatus != "" {
@@ -165,7 +174,7 @@ func TestDomainMappingWatchPredicateIntegration(t *testing.T) {
 	}
 }
 
-func TestCertificateWatchPredicateIntegration(t *testing.T) {
+func TestCertificateWatchPredicate(t *testing.T) {
 	makeCert := func(condStatus cmmeta.ConditionStatus) *cmapi.Certificate {
 		cert := &cmapi.Certificate{}
 		if condStatus != "" {
@@ -228,6 +237,227 @@ func TestCertificateWatchPredicateIntegration(t *testing.T) {
 				string(cmapi.CertificateConditionReady),
 			)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCnameRecordConditionChanged(t *testing.T) {
+	makeCNAME := func(conds ...xpv1.Condition) *dnsrecordv1alpha1.CNAMERecord {
+		rec := &dnsrecordv1alpha1.CNAMERecord{}
+		rec.Status.SetConditions(conds...)
+		return rec
+	}
+
+	tests := []struct {
+		name          string
+		oldObj        *dnsrecordv1alpha1.CNAMERecord
+		newObj        *dnsrecordv1alpha1.CNAMERecord
+		conditionType xpv1.ConditionType
+		expected      bool
+	}{
+		{
+			name:          "stable when both Ready=True",
+			oldObj:        makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}),
+			newObj:        makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}),
+			conditionType: xpv1.TypeReady,
+			expected:      false,
+		},
+		{
+			name:          "detects Ready transition False to True",
+			oldObj:        makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionFalse}),
+			newObj:        makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}),
+			conditionType: xpv1.TypeReady,
+			expected:      true,
+		},
+		{
+			name:          "no change when neither has the condition",
+			oldObj:        makeCNAME(),
+			newObj:        makeCNAME(),
+			conditionType: xpv1.TypeReady,
+			expected:      false,
+		},
+		{
+			name:          "changed when condition appears",
+			oldObj:        makeCNAME(),
+			newObj:        makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}),
+			conditionType: xpv1.TypeReady,
+			expected:      true,
+		},
+		{
+			name:          "ignores other condition types",
+			oldObj:        makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}, xpv1.Condition{Type: xpv1.TypeSynced, Status: corev1.ConditionFalse}),
+			newObj:        makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}, xpv1.Condition{Type: xpv1.TypeSynced, Status: corev1.ConditionTrue}),
+			conditionType: xpv1.TypeReady,
+			expected:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, cnameRecordConditionChanged(tt.oldObj, tt.newObj, tt.conditionType))
+		})
+	}
+}
+
+func TestCnameRecordWatchPredicate(t *testing.T) {
+	pred := cnameRecordWatchPredicate()
+
+	makeCNAME := func(conds ...xpv1.Condition) *dnsrecordv1alpha1.CNAMERecord {
+		rec := &dnsrecordv1alpha1.CNAMERecord{}
+		rec.Status.SetConditions(conds...)
+		return rec
+	}
+
+	t.Run("delete always triggers", func(t *testing.T) {
+		e := event.DeleteEvent{Object: makeCNAME()}
+		assert.True(t, pred.Delete(e))
+	})
+
+	updateTests := []struct {
+		name     string
+		oldObj   client.Object
+		newObj   client.Object
+		expected bool
+	}{
+		{
+			name:     "stable when Ready and Synced unchanged",
+			oldObj:   makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}, xpv1.Condition{Type: xpv1.TypeSynced, Status: corev1.ConditionTrue}),
+			newObj:   makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}, xpv1.Condition{Type: xpv1.TypeSynced, Status: corev1.ConditionTrue}),
+			expected: false,
+		},
+		{
+			name:     "triggers when Ready changes",
+			oldObj:   makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionFalse}, xpv1.Condition{Type: xpv1.TypeSynced, Status: corev1.ConditionTrue}),
+			newObj:   makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}, xpv1.Condition{Type: xpv1.TypeSynced, Status: corev1.ConditionTrue}),
+			expected: true,
+		},
+		{
+			name:     "triggers when Synced changes",
+			oldObj:   makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}, xpv1.Condition{Type: xpv1.TypeSynced, Status: corev1.ConditionFalse}),
+			newObj:   makeCNAME(xpv1.Condition{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}, xpv1.Condition{Type: xpv1.TypeSynced, Status: corev1.ConditionTrue}),
+			expected: true,
+		},
+	}
+
+	for _, tt := range updateTests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := event.UpdateEvent{ObjectOld: tt.oldObj, ObjectNew: tt.newObj}
+			assert.Equal(t, tt.expected, pred.Update(e))
+		})
+	}
+}
+
+func TestKnativeServiceWatchPredicate(t *testing.T) {
+	pred := knativeServiceWatchPredicate()
+
+	makeSvc := func(latestReady, latestCreated string) *knativev1.Service {
+		svc := &knativev1.Service{}
+		svc.Generation = 1
+		svc.Status.LatestReadyRevisionName = latestReady
+		svc.Status.LatestCreatedRevisionName = latestCreated
+		return svc
+	}
+
+	tests := []struct {
+		name     string
+		oldObj   client.Object
+		newObj   client.Object
+		expected bool
+	}{
+		{
+			name:     "no change when revision names identical",
+			oldObj:   makeSvc("rev-1", "rev-2"),
+			newObj:   makeSvc("rev-1", "rev-2"),
+			expected: false,
+		},
+		{
+			name:     "triggers when LatestReadyRevisionName changes",
+			oldObj:   makeSvc("rev-1", "rev-2"),
+			newObj:   makeSvc("rev-3", "rev-2"),
+			expected: true,
+		},
+		{
+			name:     "triggers when LatestCreatedRevisionName changes",
+			oldObj:   makeSvc("rev-1", "rev-2"),
+			newObj:   makeSvc("rev-1", "rev-4"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := event.UpdateEvent{ObjectOld: tt.oldObj, ObjectNew: tt.newObj}
+			assert.Equal(t, tt.expected, pred.Update(e))
+		})
+	}
+}
+
+func TestFindCappFromEvent(t *testing.T) {
+	r := &CappReconciler{}
+	ctx := context.Background()
+
+	object := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cappName,
+			Namespace: nsName,
+		},
+	}
+
+	expected := []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Namespace: nsName, Name: cappName}},
+	}
+	assert.Equal(t, expected, r.findCappFromEvent(ctx, object))
+}
+
+func TestFindCappFromLabels(t *testing.T) {
+	r := &CappReconciler{}
+	ctx := context.Background()
+	resourceName := "owned-resource"
+
+	tests := []struct {
+		name     string
+		object   client.Object
+		expected []reconcile.Request
+	}{
+		{
+			name: "returns request when label present",
+			object: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: nsName,
+					Labels:    map[string]string{utils.CappResourceKey: cappName},
+				},
+			},
+			expected: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: nsName, Name: cappName}},
+			},
+		},
+		{
+			name: "returns nil when label missing",
+			object: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: nsName,
+					Labels:    map[string]string{},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "returns nil when labels are nil",
+			object: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: nsName,
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, r.findCappFromLabels(ctx, tt.object))
 		})
 	}
 }


### PR DESCRIPTION
Adds unit tests for CNAME record condition diffing, CNAME/knative service watch predicates, and label-based reconcile request mapping. Renames existing predicate tests to drop misleading "Integration" suffix.