### PR TITLE
test: add route/state status coverage, dedupe state constants

### DIFF
--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -29,6 +29,9 @@ import (
 )
 
 const (
+	// CappStateEnabled is the enabled state value for a Capp.
+	CappStateEnabled = "enabled"
+
 	// CappStateDisabled is the disabled state value for a Capp.
 	CappStateDisabled = "disabled"
 

--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -24,8 +24,6 @@ import (
 )
 
 const (
-	cappDisabledState                     = "disabled"
-	cappEnabledState                      = "enabled"
 	KnativeService                        = "KnativeService"
 	eventCappKnativeServiceCreationFailed = "KnativeServiceCreationFailed"
 	eventCappKnativeServiceCreated        = "KnativeServiceCreated"
@@ -120,7 +118,7 @@ func (k KnativeServiceManager) CleanUp(ctx context.Context, capp cappv1alpha1.Ca
 
 // IsRequired determines if a Knative service (ksvc) is required based on the Capp's spec.
 func (k KnativeServiceManager) IsRequired(capp cappv1alpha1.Capp) bool {
-	return capp.Spec.State == cappEnabledState
+	return capp.Spec.State == cappv1alpha1.CappStateEnabled
 }
 
 // Manage creates or updates a KnativeService resource based on the provided Capp if it's required.
@@ -153,7 +151,7 @@ func (k KnativeServiceManager) createOrUpdate(ctx context.Context, capp cappv1al
 				return err
 			}
 
-			if capp.Status.StateStatus.State == cappDisabledState && k.IsRequired(capp) &&
+			if capp.Status.StateStatus.State == cappv1alpha1.CappStateDisabled && k.IsRequired(capp) &&
 				!capp.Status.StateStatus.LastChange.IsZero() {
 				k.Log.Info("Capp resumed to enabled state")
 				k.EventRecorder.Eventf(&capp, nil, corev1.EventTypeNormal, eventCappEnabled, eventCappEnabled, fmt.Sprintf("Capp %q state changed to enabled", capp.Name))

--- a/internal/kinds/capp/resourcemanagers/ksvc_test.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc_test.go
@@ -41,7 +41,7 @@ func newKsvcManager(k8sClient client.Client) (KnativeServiceManager, *events.Fak
 
 func newKsvcCapp() cappv1alpha1.Capp {
 	capp := newBaseCapp()
-	capp.Spec.State = cappEnabledState
+	capp.Spec.State = cappv1alpha1.CappStateEnabled
 	capp.Spec.ScaleSpec = cappv1alpha1.ScaleSpec{Metric: kautoscaling.CPU}
 	capp.Spec.ConfigurationSpec = knativev1.ConfigurationSpec{
 		Template: knativev1.RevisionTemplateSpec{
@@ -205,7 +205,7 @@ func TestKnativeServiceManagerManage(t *testing.T) {
 		require.NoError(t, km.Manage(ctx, capp))
 		require.Contains(t, <-recorder.Events, eventCappKnativeServiceCreated)
 
-		capp.Spec.State = cappDisabledState
+		capp.Spec.State = cappv1alpha1.CappStateDisabled
 		require.NoError(t, km.Manage(ctx, capp))
 
 		got := &knativev1.Service{}
@@ -220,7 +220,7 @@ func TestKnativeServiceManagerManage(t *testing.T) {
 		km, recorder := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
 		capp := newKsvcCapp()
 		capp.Status.StateStatus = cappv1alpha1.StateStatus{
-			State:      cappDisabledState,
+			State:      cappv1alpha1.CappStateDisabled,
 			LastChange: metav1.Now(),
 		}
 

--- a/internal/kinds/capp/status/capp_test.go
+++ b/internal/kinds/capp/status/capp_test.go
@@ -3,12 +3,15 @@ package status
 import (
 	"context"
 	"testing"
+	"time"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	rmanagers "github.com/dana-team/container-app-operator/internal/kinds/capp/resourcemanagers"
 	nfspvcv1alpha1 "github.com/dana-team/nfspvc-operator/api/v1alpha1"
+	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -400,4 +403,104 @@ func TestBuildCappConditionsPreservesExistingConditions(t *testing.T) {
 	}
 	require.NotNil(t, other)
 	assert.Equal(t, metav1.ConditionTrue, other.Status)
+}
+
+func TestCreateStateStatus(t *testing.T) {
+	t.Run("sets state and timestamp when state is empty", func(t *testing.T) {
+		status := &cappv1alpha1.StateStatus{}
+
+		CreateStateStatus(status, cappv1alpha1.CappStateEnabled)
+
+		assert.Equal(t, cappv1alpha1.CappStateEnabled, status.State)
+		assert.False(t, status.LastChange.IsZero())
+	})
+
+	t.Run("updates state and timestamp on state change", func(t *testing.T) {
+		original := metav1.Now()
+		status := &cappv1alpha1.StateStatus{
+			State:      cappv1alpha1.CappStateEnabled,
+			LastChange: original,
+		}
+
+		CreateStateStatus(status, cappv1alpha1.CappStateDisabled)
+
+		assert.Equal(t, cappv1alpha1.CappStateDisabled, status.State)
+		assert.False(t, status.LastChange.Before(&original))
+	})
+
+	t.Run("does not change timestamp when state is unchanged", func(t *testing.T) {
+		original := metav1.Now()
+		status := &cappv1alpha1.StateStatus{
+			State:      cappv1alpha1.CappStateEnabled,
+			LastChange: original,
+		}
+
+		CreateStateStatus(status, cappv1alpha1.CappStateEnabled)
+
+		assert.Equal(t, cappv1alpha1.CappStateEnabled, status.State)
+		assert.Equal(t, original, status.LastChange)
+	})
+}
+
+func TestStripVolatileStatusFields(t *testing.T) {
+	ts := metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	ptrTs := &ts
+
+	status := cappv1alpha1.CappStatus{
+		Conditions: []metav1.Condition{
+			{Type: cappv1alpha1.CappConditionReady, Status: metav1.ConditionTrue, LastTransitionTime: ts},
+		},
+		LoggingStatus: cappv1alpha1.LoggingStatus{
+			Conditions: []metav1.Condition{
+				{Type: loggingReady, Status: metav1.ConditionTrue, LastTransitionTime: ts},
+			},
+		},
+		RouteStatus: cappv1alpha1.RouteStatus{
+			CertificateObjectStatus: cmapi.CertificateStatus{
+				Conditions: []cmapi.CertificateCondition{
+					{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue, LastTransitionTime: ptrTs},
+				},
+			},
+			DNSRecordObjectStatus: cappv1alpha1.DNSRecordObjectStatus{
+				CNAMERecordObjectStatus: dnsrecordv1alpha1.CNAMERecordStatus{
+					ResourceStatus: xpv1.ResourceStatus{
+						ConditionedStatus: xpv1.ConditionedStatus{
+							Conditions: []xpv1.Condition{
+								{Type: xpv1.TypeReady, Status: corev1.ConditionTrue, LastTransitionTime: ts},
+							},
+						},
+					},
+				},
+			},
+		},
+		EventingStatus: cappv1alpha1.EventingStatus{
+			EventSources: []cappv1alpha1.EventSourceStatus{
+				{
+					Name: "src",
+					Condition: kapis.Condition{
+						Type:               kapis.ConditionReady,
+						Status:             corev1.ConditionTrue,
+						LastTransitionTime: kapis.VolatileTime{Inner: ts},
+					},
+				},
+			},
+		},
+	}
+
+	result := stripVolatileStatusFields(status)
+
+	require.Len(t, result.Conditions, 1)
+	assert.True(t, result.Conditions[0].LastTransitionTime.IsZero())
+
+	require.Len(t, result.LoggingStatus.Conditions, 1)
+	assert.True(t, result.LoggingStatus.Conditions[0].LastTransitionTime.IsZero())
+
+	require.Len(t, result.RouteStatus.CertificateObjectStatus.Conditions, 1)
+	assert.Nil(t, result.RouteStatus.CertificateObjectStatus.Conditions[0].LastTransitionTime)
+
+	require.Len(t, result.RouteStatus.DNSRecordObjectStatus.CNAMERecordObjectStatus.Conditions, 1)
+	assert.True(t, result.RouteStatus.DNSRecordObjectStatus.CNAMERecordObjectStatus.Conditions[0].LastTransitionTime.IsZero())
+
+	require.Len(t, result.EventingStatus.EventSources, 1)
+	assert.True(t, result.EventingStatus.EventSources[0].Condition.LastTransitionTime.Inner.IsZero())
 }

--- a/internal/kinds/capp/status/route_test.go
+++ b/internal/kinds/capp/status/route_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	rmanagers "github.com/dana-team/container-app-operator/internal/kinds/capp/resourcemanagers"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/utils"
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,6 +39,101 @@ func routeCapp() cappv1alpha1.Capp {
 	capp := newCapp()
 	capp.Spec.RouteSpec.Hostname = hostname
 	return capp
+}
+
+func newCappConfig() *cappv1alpha1.CappConfig {
+	return &cappv1alpha1.CappConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.CappConfigName,
+			Namespace: utils.CappNS,
+		},
+		Spec: cappv1alpha1.CappConfigSpec{
+			DNSConfig: cappv1alpha1.DNSConfig{
+				Zone: zone,
+			},
+		},
+	}
+}
+
+func TestBuildRouteStatus(t *testing.T) {
+	ctx := context.Background()
+	capp := routeCapp()
+
+	t.Run("returns error when capp config missing", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(newRouteScheme()).Build()
+		isRequired := map[string]bool{}
+
+		_, err := buildRouteStatus(ctx, fakeClient, capp, isRequired)
+		require.Error(t, err)
+	})
+
+	t.Run("returns empty statuses when no sub-resources required", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(newRouteScheme()).
+			WithObjects(newCappConfig()).Build()
+		isRequired := map[string]bool{
+			rmanagers.DomainMapping: false,
+			rmanagers.DNSRecord:     false,
+			rmanagers.Certificate:   false,
+		}
+
+		result, err := buildRouteStatus(ctx, fakeClient, capp, isRequired)
+		require.NoError(t, err)
+		assert.Empty(t, result.DomainMappingObjectStatus.Conditions)
+		assert.Empty(t, result.DNSRecordObjectStatus.CNAMERecordObjectStatus.Conditions)
+		assert.Empty(t, result.CertificateObjectStatus.Conditions)
+	})
+
+	t.Run("populates all sub-statuses when resources exist", func(t *testing.T) {
+		dm := &knativev1beta1.DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: cappNamespace,
+			},
+			Status: knativev1beta1.DomainMappingStatus{
+				URL: apis.HTTPS(resourceName),
+			},
+		}
+		cert := &cmapi.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: cappNamespace,
+			},
+			Status: cmapi.CertificateStatus{
+				Conditions: []cmapi.CertificateCondition{
+					{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue},
+				},
+			},
+		}
+		target := "target.example.com."
+		cname := &dnsrecordv1alpha1.CNAMERecord{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: cappNamespace,
+			},
+			Status: dnsrecordv1alpha1.CNAMERecordStatus{
+				AtProvider: dnsrecordv1alpha1.CNAMERecordObservation{
+					Cname: &target,
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().WithScheme(newRouteScheme()).
+			WithObjects(newCappConfig(), dm, cert, cname).Build()
+		isRequired := map[string]bool{
+			rmanagers.DomainMapping: true,
+			rmanagers.DNSRecord:     true,
+			rmanagers.Certificate:   true,
+		}
+
+		result, err := buildRouteStatus(ctx, fakeClient, capp, isRequired)
+		require.NoError(t, err)
+		require.NotNil(t, result.DomainMappingObjectStatus.URL)
+		assert.Equal(t, resourceName, result.DomainMappingObjectStatus.URL.Host)
+		require.Len(t, result.CertificateObjectStatus.Conditions, 1)
+		assert.Equal(t, cmapi.CertificateConditionReady, result.CertificateObjectStatus.Conditions[0].Type)
+		require.NotNil(t, result.DNSRecordObjectStatus.CNAMERecordObjectStatus.AtProvider.Cname)
+		assert.Equal(t, target, *result.DNSRecordObjectStatus.CNAMERecordObjectStatus.AtProvider.Cname)
+	})
 }
 
 func TestBuildDomainMappingStatus(t *testing.T) {
@@ -106,7 +204,7 @@ func TestBuildCertificateStatus(t *testing.T) {
 			},
 			Status: cmapi.CertificateStatus{
 				Conditions: []cmapi.CertificateCondition{
-					{Type: cmapi.CertificateConditionReady, Status: "True"},
+					{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue},
 				},
 			},
 		}


### PR DESCRIPTION
Covers buildRouteStatus orchestration, CreateStateStatus timestamp handling, and stripVolatileStatusFields across all condition sources (capp, logging, route, DNS record, eventing). Also introduces a shared CappStateEnabled constant so ksvc no longer duplicates local enabled/disabled state strings.