### PR TITLE
refactor(capp): cache CappConfig per reconcile loop

### DIFF
--- a/internal/kinds/capp/controllers/controller.go
+++ b/internal/kinds/capp/controllers/controller.go
@@ -357,11 +357,17 @@ func (r *CappReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	rmClient := rclient.ResourceManagerClient{K8sClient: r.Client, Log: logger}
+
+	cappConfig, err := rmanagers.GetCappConfig(ctx, r.Client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get CappConfig: %w", err)
+	}
+
 	resourceManagers := map[string]rmanagers.ResourceManager{
-		rmanagers.KnativeService: rmanagers.KnativeServiceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
-		rmanagers.DNSRecord:      rmanagers.DNSRecordManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
-		rmanagers.Certificate:    rmanagers.CertificateManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
-		rmanagers.DomainMapping:  rmanagers.DomainMappingManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+		rmanagers.KnativeService: rmanagers.KnativeServiceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder, CappConfig: cappConfig},
+		rmanagers.DNSRecord:      rmanagers.DNSRecordManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder, CappConfig: cappConfig},
+		rmanagers.Certificate:    rmanagers.CertificateManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder, CappConfig: cappConfig},
+		rmanagers.DomainMapping:  rmanagers.DomainMappingManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder, CappConfig: cappConfig},
 		rmanagers.SyslogNGFlow:   rmanagers.SyslogNGFlowManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
 		rmanagers.SyslogNGOutput: rmanagers.SyslogNGOutputManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
 		rmanagers.NfsPvc:         rmanagers.NFSPVCManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
@@ -382,7 +388,7 @@ func (r *CappReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, fmt.Errorf("failed to ensure finalizer in Capp: %w", err)
 	}
 
-	if err := r.SyncApplication(ctx, capp, resourceManagers, logger); err != nil {
+	if err := r.SyncApplication(ctx, capp, resourceManagers, cappConfig, logger); err != nil {
 		if errors.IsConflict(err) {
 			logger.Info(fmt.Sprintf("Conflict detected, requeuing: %s", err.Error()))
 			return ctrl.Result{RequeueAfter: RequeueTime}, nil
@@ -394,12 +400,12 @@ func (r *CappReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 // SyncApplication manages the lifecycle of Capp.
 // It ensures all manifests are applied according to the specification and synchronizes the status accordingly.
-func (r *CappReconciler) SyncApplication(ctx context.Context, capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.ResourceManager, logger logr.Logger) error {
+func (r *CappReconciler) SyncApplication(ctx context.Context, capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.ResourceManager, cappConfig *cappv1alpha1.CappConfig, logger logr.Logger) error {
 	for _, manager := range resourceManagers {
 		if err := manager.Manage(ctx, capp); err != nil {
 			return err
 		}
 	}
 
-	return status.SyncStatus(ctx, capp, logger, r.Client, resourceManagers)
+	return status.SyncStatus(ctx, capp, logger, r.Client, resourceManagers, cappConfig)
 }

--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -28,20 +28,17 @@ const (
 type CertificateManager struct {
 	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
+	CappConfig    *cappv1alpha1.CappConfig
 }
 
 // prepareResource prepares a Certificate resource based on the provided Capp.
-func (c CertificateManager) prepareResource(ctx context.Context, capp cappv1alpha1.Capp) (cmapi.Certificate, error) {
-	cappConfig, err := GetCappConfig(ctx, c.K8sClient)
-	if err != nil {
-		return cmapi.Certificate{}, err
-	}
-	dnsConfig := cappConfig.Spec.DNSConfig
+func (c CertificateManager) prepareResource(capp cappv1alpha1.Capp) cmapi.Certificate {
+	dnsConfig := c.CappConfig.Spec.DNSConfig
 
 	resourceName := GenerateResourceName(capp.Spec.RouteSpec.Hostname, dnsConfig.Zone)
 	secretName := generateTLSSecretName(resourceName)
 
-	certificate := cmapi.Certificate{
+	return cmapi.Certificate{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resourceName,
@@ -72,8 +69,6 @@ func (c CertificateManager) prepareResource(ctx context.Context, capp cappv1alph
 			},
 		},
 	}
-
-	return certificate, nil
 }
 
 // CleanUp attempts to delete all Certificates associated with a given Capp resource.
@@ -106,11 +101,7 @@ func (c CertificateManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) 
 
 // createOrUpdate creates or updates a Certificate resource.
 func (c CertificateManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.Capp) error {
-	certificateFromCapp, err := c.prepareResource(ctx, capp)
-	if err != nil {
-		return fmt.Errorf("failed to prepare Certificate: %w", err)
-	}
-
+	certificateFromCapp := c.prepareResource(capp)
 	certificate := cmapi.Certificate{}
 
 	if err := c.K8sClient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: certificateFromCapp.Name}, &certificate); err != nil {

--- a/internal/kinds/capp/resourcemanagers/certificate_test.go
+++ b/internal/kinds/capp/resourcemanagers/certificate_test.go
@@ -30,12 +30,12 @@ func newCertificateManager(k8sClient client.Client) CertificateManager {
 	return CertificateManager{
 		ResourceManagerClient: rclient.ResourceManagerClient{K8sClient: k8sClient, Log: logr.Discard()},
 		EventRecorder:         events.NewFakeRecorder(10),
+		CappConfig:            newCappConfigWithDNS(),
 	}
 }
 
 func newCertificateClient(objects ...client.Object) client.Client {
-	objs := append([]client.Object{newCappConfigWithDNS()}, objects...)
-	return newFakeClient(newCertificateScheme(), objs...)
+	return newFakeClient(newCertificateScheme(), objects...)
 }
 
 func newCertificate(mutate func(*cmapi.Certificate)) *cmapi.Certificate {
@@ -53,14 +53,11 @@ func newCertificate(mutate func(*cmapi.Certificate)) *cmapi.Certificate {
 }
 
 func TestCertificateManagerPrepareResource(t *testing.T) {
-	ctx := context.Background()
-
 	t.Run("prepares certificate spec from capp and DNS config", func(t *testing.T) {
 		mgr := newCertificateManager(newCertificateClient())
 		capp := newCappWithTLS(hostnameBare, true)
 
-		got, err := mgr.prepareResource(ctx, capp)
-		require.NoError(t, err)
+		got := mgr.prepareResource(capp)
 		require.Equal(t, hostnameFQDN, got.Name)
 		require.Equal(t, cmmeta.IssuerReference{Name: issuerName, Kind: issuerKind, Group: issuerGroup}, got.Spec.IssuerRef)
 		require.Equal(t, generateTLSSecretName(hostnameFQDN), got.Spec.SecretName)
@@ -69,13 +66,6 @@ func TestCertificateManagerPrepareResource(t *testing.T) {
 		require.Equal(t, []string{hostnameFQDN}, got.Spec.DNSNames)
 	})
 
-	t.Run("returns error when CappConfig missing", func(t *testing.T) {
-		mgr := newCertificateManager(newFakeClient(newCertificateScheme()))
-		capp := newCappWithTLS(hostnameBare, true)
-
-		_, err := mgr.prepareResource(ctx, capp)
-		require.Error(t, err)
-	})
 }
 
 func TestCertificateManagerManage(t *testing.T) {

--- a/internal/kinds/capp/resourcemanagers/dnsrecord.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord.go
@@ -30,15 +30,12 @@ const (
 type DNSRecordManager struct {
 	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
+	CappConfig    *cappv1alpha1.CappConfig
 }
 
 // prepareResource prepares a DNSRecord resource based on the provided Capp.
-func (r DNSRecordManager) prepareResource(ctx context.Context, capp cappv1alpha1.Capp) (dnsrecordv1alpha1.CNAMERecord, error) {
-	cappConfig, err := GetCappConfig(ctx, r.K8sClient)
-	if err != nil {
-		return dnsrecordv1alpha1.CNAMERecord{}, err
-	}
-	dnsConfig := cappConfig.Spec.DNSConfig
+func (r DNSRecordManager) prepareResource(capp cappv1alpha1.Capp) dnsrecordv1alpha1.CNAMERecord {
+	dnsConfig := r.CappConfig.Spec.DNSConfig
 
 	resourceName := GenerateResourceName(capp.Spec.RouteSpec.Hostname, dnsConfig.Zone)
 	recordName := GenerateRecordName(capp.Spec.RouteSpec.Hostname, dnsConfig.Zone)
@@ -65,7 +62,7 @@ func (r DNSRecordManager) prepareResource(ctx context.Context, capp cappv1alpha1
 		Kind: ClusterProviderConfigKind,
 	}
 
-	return dnsRecord, nil
+	return dnsRecord
 }
 
 // CleanUp attempts to delete all DNSRecords associated with a given Capp resource.
@@ -98,11 +95,7 @@ func (r DNSRecordManager) Manage(ctx context.Context, capp cappv1alpha1.Capp) er
 
 // createOrUpdate creates or updates a DNSRecord resource.
 func (r DNSRecordManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.Capp) error {
-	dnsRecordFromCapp, err := r.prepareResource(ctx, capp)
-	if err != nil {
-		return fmt.Errorf("failed to prepare DNSRecord: %w", err)
-	}
-
+	dnsRecordFromCapp := r.prepareResource(capp)
 	dnsRecord := dnsrecordv1alpha1.CNAMERecord{}
 
 	if err := r.K8sClient.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: dnsRecordFromCapp.Name}, &dnsRecord); err != nil {

--- a/internal/kinds/capp/resourcemanagers/dnsrecord_test.go
+++ b/internal/kinds/capp/resourcemanagers/dnsrecord_test.go
@@ -30,12 +30,12 @@ func newDNSRecordManager(k8sClient client.Client) DNSRecordManager {
 	return DNSRecordManager{
 		ResourceManagerClient: rclient.ResourceManagerClient{K8sClient: k8sClient, Log: logr.Discard()},
 		EventRecorder:         events.NewFakeRecorder(10),
+		CappConfig:            newCappConfigWithDNS(),
 	}
 }
 
 func newDNSRecordClient(objects ...client.Object) client.Client {
-	objs := append([]client.Object{newCappConfigWithDNS()}, objects...)
-	return newFakeClient(newDNSRecordScheme(), objs...)
+	return newFakeClient(newDNSRecordScheme(), objects...)
 }
 
 func newCNAMERecord(mutate func(*dnsrecordv1alpha1.CNAMERecord)) *dnsrecordv1alpha1.CNAMERecord {
@@ -155,13 +155,6 @@ func TestDNSRecordManagerCreateOrUpdate(t *testing.T) {
 		require.Equal(t, beforeRV, after.ResourceVersion)
 	})
 
-	t.Run("returns error when CappConfig missing", func(t *testing.T) {
-		dm := newDNSRecordManager(newFakeClient(newDNSRecordScheme()))
-		capp := newCappWithHostname(hostnameBare)
-
-		err := dm.createOrUpdate(ctx, capp)
-		require.Error(t, err)
-	})
 }
 
 func TestDNSRecordManagerManage(t *testing.T) {

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -30,15 +30,12 @@ const (
 type DomainMappingManager struct {
 	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
+	CappConfig    *cappv1alpha1.CappConfig
 }
 
 // prepareResource creates a new DomainMapping for a Knative service.
 func (k DomainMappingManager) prepareResource(ctx context.Context, capp cappv1alpha1.Capp) (knativev1beta1.DomainMapping, error) {
-	cappConfig, err := GetCappConfig(ctx, k.K8sClient)
-	if err != nil {
-		return knativev1beta1.DomainMapping{}, err
-	}
-	dnsConfig := cappConfig.Spec.DNSConfig
+	dnsConfig := k.CappConfig.Spec.DNSConfig
 
 	resourceName := GenerateResourceName(capp.Spec.RouteSpec.Hostname, dnsConfig.Zone)
 	secretName := generateTLSSecretName(resourceName)

--- a/internal/kinds/capp/resourcemanagers/domainmapping_test.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping_test.go
@@ -32,12 +32,12 @@ func newDomainMappingManager(k8sClient client.Client) DomainMappingManager {
 	return DomainMappingManager{
 		ResourceManagerClient: rclient.ResourceManagerClient{K8sClient: k8sClient, Log: logr.Discard()},
 		EventRecorder:         events.NewFakeRecorder(10),
+		CappConfig:            newCappConfigWithDNS(),
 	}
 }
 
 func newDomainMappingClient(objects ...client.Object) client.Client {
-	objs := append([]client.Object{newCappConfigWithDNS()}, objects...)
-	return newFakeClient(newDomainMappingScheme(), objs...)
+	return newFakeClient(newDomainMappingScheme(), objects...)
 }
 
 func newDomainMapping(mutate func(*knativev1beta1.DomainMapping)) *knativev1beta1.DomainMapping {
@@ -164,13 +164,6 @@ func TestDomainMappingManagerCreateOrUpdate(t *testing.T) {
 		require.Equal(t, beforeRV, after.ResourceVersion)
 	})
 
-	t.Run("returns error when CappConfig missing", func(t *testing.T) {
-		mgr := newDomainMappingManager(newFakeClient(newDomainMappingScheme()))
-		capp := newCappWithHostname(hostnameBare)
-
-		err := mgr.createOrUpdate(ctx, capp)
-		require.Error(t, err)
-	})
 }
 
 func TestDomainMappingManagerManage(t *testing.T) {

--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -45,6 +45,7 @@ var kpaMetrics = []string{"rps", "concurrency"}
 type KnativeServiceManager struct {
 	rclient.ResourceManagerClient
 	EventRecorder events.EventRecorder
+	CappConfig    *cappv1alpha1.CappConfig
 }
 
 // prepareResource generates a Knative Service definition from a given Capp resource.
@@ -94,12 +95,7 @@ func (k KnativeServiceManager) prepareResource(capp cappv1alpha1.Capp, ctx conte
 		})
 	}
 
-	cappConfig, err := GetCappConfig(ctx, k.K8sClient)
-	if err != nil {
-		k.Log.Error(err, fmt.Sprintf("could not fetch cappConfig from namespace %q", cappmeta.CappNS))
-	}
-
-	knativeService.Spec.Template.Annotations = cappmeta.MergeMaps(knativeServiceAnnotations, setAutoScaler(capp, cappConfig.Spec.AutoscaleConfig))
+	knativeService.Spec.Template.Annotations = cappmeta.MergeMaps(knativeServiceAnnotations, setAutoScaler(capp, k.CappConfig.Spec.AutoscaleConfig))
 	knativeService.Spec.Template.Labels = knativeServiceLabels
 
 	return knativeService

--- a/internal/kinds/capp/resourcemanagers/ksvc_test.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc_test.go
@@ -36,6 +36,7 @@ func newKsvcManager(k8sClient client.Client) (KnativeServiceManager, *events.Fak
 	return KnativeServiceManager{
 		ResourceManagerClient: rclient.ResourceManagerClient{K8sClient: k8sClient, Log: logr.Discard()},
 		EventRecorder:         recorder,
+		CappConfig:            newCappConfig(),
 	}, recorder
 }
 
@@ -69,7 +70,7 @@ func TestKnativeServiceManagerPrepareResource(t *testing.T) {
 		)
 		internalAnnotationKey := cappmeta.CappAPIGroup + "/internal"
 
-		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme()))
 		capp := newKsvcCapp()
 		capp.Annotations = map[string]string{
 			allowedAnnotationKey:  allowedAnnotationValue,
@@ -91,7 +92,7 @@ func TestKnativeServiceManagerPrepareResource(t *testing.T) {
 			userLabelValue = "platform"
 		)
 
-		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme()))
 		capp := newKsvcCapp()
 		capp.Labels = map[string]string{
 			userLabelKey:             userLabelValue,
@@ -107,7 +108,7 @@ func TestKnativeServiceManagerPrepareResource(t *testing.T) {
 	})
 
 	t.Run("sets route timeout on template", func(t *testing.T) {
-		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme()))
 		capp := newKsvcCapp()
 		routeTimeout := int64(30)
 		capp.Spec.RouteSpec.RouteTimeoutSeconds = &routeTimeout
@@ -121,7 +122,7 @@ func TestKnativeServiceManagerPrepareResource(t *testing.T) {
 	t.Run("appends nfs volumes as pvc volume sources", func(t *testing.T) {
 		const nfsVolumeName = "data-vol"
 
-		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme()))
 		capp := newKsvcCapp()
 		capp.Spec.VolumesSpec.NFSVolumes = []cappv1alpha1.NFSVolume{{
 			Name:     nfsVolumeName,
@@ -138,17 +139,15 @@ func TestKnativeServiceManagerPrepareResource(t *testing.T) {
 	})
 
 	t.Run("merges autoscale annotations from capp and cappConfig", func(t *testing.T) {
-		cappConfig := newCappConfig()
-
-		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), cappConfig))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme()))
 		capp := newKsvcCapp()
 
 		got := km.prepareResource(capp, ctx)
 
 		require.Equal(t, kautoscaling.HPA, got.Spec.Template.Annotations[kautoscaling.ClassAnnotationKey])
 		require.Equal(t, kautoscaling.CPU, got.Spec.Template.Annotations[kautoscaling.MetricAnnotationKey])
-		require.Equal(t, strconv.Itoa(cappConfig.Spec.AutoscaleConfig.CPU), got.Spec.Template.Annotations[kautoscaling.TargetAnnotationKey])
-		require.Equal(t, strconv.Itoa(cappConfig.Spec.AutoscaleConfig.ActivationScale), got.Spec.Template.Annotations[kautoscaling.ActivationScaleKey])
+		require.Equal(t, strconv.Itoa(km.CappConfig.Spec.AutoscaleConfig.CPU), got.Spec.Template.Annotations[kautoscaling.TargetAnnotationKey])
+		require.Equal(t, strconv.Itoa(km.CappConfig.Spec.AutoscaleConfig.ActivationScale), got.Spec.Template.Annotations[kautoscaling.ActivationScaleKey])
 	})
 }
 
@@ -156,7 +155,7 @@ func TestKnativeServiceManagerManage(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates ksvc with owner reference when enabled", func(t *testing.T) {
-		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme()))
 		capp := newKsvcCapp()
 
 		require.NoError(t, km.Manage(ctx, capp))
@@ -171,7 +170,7 @@ func TestKnativeServiceManagerManage(t *testing.T) {
 	t.Run("updates ksvc when spec changes", func(t *testing.T) {
 		const updatedContainerImage = "example.com/app:v2"
 
-		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme()))
 		capp := newKsvcCapp()
 		require.NoError(t, km.Manage(ctx, capp))
 
@@ -184,7 +183,7 @@ func TestKnativeServiceManagerManage(t *testing.T) {
 	})
 
 	t.Run("skips update when unchanged", func(t *testing.T) {
-		km, _ := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
+		km, _ := newKsvcManager(newFakeClient(newKsvcScheme()))
 		capp := newKsvcCapp()
 		require.NoError(t, km.Manage(ctx, capp))
 
@@ -200,7 +199,7 @@ func TestKnativeServiceManagerManage(t *testing.T) {
 	})
 
 	t.Run("deletes ksvc and emits disabled event when state is disabled", func(t *testing.T) {
-		km, recorder := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
+		km, recorder := newKsvcManager(newFakeClient(newKsvcScheme()))
 		capp := newKsvcCapp()
 		require.NoError(t, km.Manage(ctx, capp))
 		require.Contains(t, <-recorder.Events, eventCappKnativeServiceCreated)
@@ -217,7 +216,7 @@ func TestKnativeServiceManagerManage(t *testing.T) {
 	})
 
 	t.Run("recreates ksvc and emits enabled event when resuming from disabled", func(t *testing.T) {
-		km, recorder := newKsvcManager(newFakeClient(newKsvcScheme(), newCappConfig()))
+		km, recorder := newKsvcManager(newFakeClient(newKsvcScheme()))
 		capp := newKsvcCapp()
 		capp.Status.StateStatus = cappv1alpha1.StateStatus{
 			State:      cappv1alpha1.CappStateDisabled,

--- a/internal/kinds/capp/status/capp.go
+++ b/internal/kinds/capp/status/capp.go
@@ -27,7 +27,7 @@ func CreateStateStatus(stateStatus *cappv1alpha1.StateStatus, cappStateFromSpec 
 }
 
 // SyncStatus updates the Capp status subresource from the observed state of its managed resources.
-func SyncStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Logger, r client.Client, resourceManagers map[string]rmanagers.ResourceManager) error {
+func SyncStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Logger, r client.Client, resourceManagers map[string]rmanagers.ResourceManager, cappConfig *cappv1alpha1.CappConfig) error {
 	cappObject := cappv1alpha1.Capp{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, &cappObject); err != nil {
 		return err
@@ -56,7 +56,7 @@ func SyncStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Logger, r 
 		rmanagers.DNSRecord:     resourceManagers[rmanagers.DNSRecord].IsRequired(capp),
 		rmanagers.Certificate:   resourceManagers[rmanagers.Certificate].IsRequired(capp),
 	}
-	routeStatus, err := buildRouteStatus(ctx, r, capp, routeRequired)
+	routeStatus, err := buildRouteStatus(ctx, r, capp, routeRequired, cappConfig)
 	if err != nil {
 		return err
 	}

--- a/internal/kinds/capp/status/route.go
+++ b/internal/kinds/capp/status/route.go
@@ -17,13 +17,8 @@ import (
 
 // buildRouteStatus constructs the Route Status of the Capp object in accordance to the
 // status of the corresponding DomainMapping, DNSRecord and Certificate objects if such exist.
-func buildRouteStatus(ctx context.Context, kubeClient client.Client, capp cappv1alpha1.Capp, isRequired map[string]bool) (cappv1alpha1.RouteStatus, error) {
+func buildRouteStatus(ctx context.Context, kubeClient client.Client, capp cappv1alpha1.Capp, isRequired map[string]bool, cappConfig *cappv1alpha1.CappConfig) (cappv1alpha1.RouteStatus, error) {
 	routeStatus := cappv1alpha1.RouteStatus{}
-
-	cappConfig, err := rmanagers.GetCappConfig(ctx, kubeClient)
-	if err != nil {
-		return routeStatus, err
-	}
 	dnsConfig := cappConfig.Spec.DNSConfig
 
 	domainMappingStatus, err := buildDomainMappingStatus(ctx, kubeClient, capp, isRequired[rmanagers.DomainMapping], dnsConfig.Zone)

--- a/internal/kinds/capp/status/route_test.go
+++ b/internal/kinds/capp/status/route_test.go
@@ -59,24 +59,15 @@ func TestBuildRouteStatus(t *testing.T) {
 	ctx := context.Background()
 	capp := routeCapp()
 
-	t.Run("returns error when capp config missing", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newRouteScheme()).Build()
-		isRequired := map[string]bool{}
-
-		_, err := buildRouteStatus(ctx, fakeClient, capp, isRequired)
-		require.Error(t, err)
-	})
-
 	t.Run("returns empty statuses when no sub-resources required", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(newRouteScheme()).
-			WithObjects(newCappConfig()).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(newRouteScheme()).Build()
 		isRequired := map[string]bool{
 			rmanagers.DomainMapping: false,
 			rmanagers.DNSRecord:     false,
 			rmanagers.Certificate:   false,
 		}
 
-		result, err := buildRouteStatus(ctx, fakeClient, capp, isRequired)
+		result, err := buildRouteStatus(ctx, fakeClient, capp, isRequired, newCappConfig())
 		require.NoError(t, err)
 		assert.Empty(t, result.DomainMappingObjectStatus.Conditions)
 		assert.Empty(t, result.DNSRecordObjectStatus.CNAMERecordObjectStatus.Conditions)
@@ -118,14 +109,14 @@ func TestBuildRouteStatus(t *testing.T) {
 		}
 
 		fakeClient := fake.NewClientBuilder().WithScheme(newRouteScheme()).
-			WithObjects(newCappConfig(), dm, cert, cname).Build()
+			WithObjects(dm, cert, cname).Build()
 		isRequired := map[string]bool{
 			rmanagers.DomainMapping: true,
 			rmanagers.DNSRecord:     true,
 			rmanagers.Certificate:   true,
 		}
 
-		result, err := buildRouteStatus(ctx, fakeClient, capp, isRequired)
+		result, err := buildRouteStatus(ctx, fakeClient, capp, isRequired, newCappConfig())
 		require.NoError(t, err)
 		require.NotNil(t, result.DomainMappingObjectStatus.URL)
 		assert.Equal(t, resourceName, result.DomainMappingObjectStatus.URL.Host)


### PR DESCRIPTION
Fetch CappConfig once at the top of Reconcile and inject it into the four managers and the status path, eliminating 5+ redundant API-server GETs per reconcile. All consumers within a single reconcile now see a consistent snapshot.

Also fixes a latent nil-dereference in ksvc prepareResource, where a GetCappConfig error was logged but execution continued into a nil pointer access.