### PR TITLE
refactor(webhook): remove dead URI validation from event sources

### DIFF
--- a/internal/webhook/rcs/common/utils.go
+++ b/internal/webhook/rcs/common/utils.go
@@ -72,13 +72,3 @@ func IsDomainNameTaken(ctx context.Context, domainName string) (bool, error) {
 	}
 	return true, nil
 }
-
-// ValidateURI checks if the provided URI is valid and is a relative path.
-func ValidateURI(uri *apis.URL) error {
-
-	_, err := apis.ParseURL(uri.String())
-	if err != nil {
-		return err
-	}
-	return nil
-}

--- a/internal/webhook/rcs/v1alpha1/validator.go
+++ b/internal/webhook/rcs/v1alpha1/validator.go
@@ -211,12 +211,6 @@ func validateEventSources(ctx context.Context, r client.Reader, capp cappv1alpha
 				return fmt.Errorf("%s[%d]: %w", eventSourcePath, i, err)
 			}
 		}
-
-		if src.URI != nil {
-			if err := common.ValidateURI(src.URI); err != nil {
-				return fmt.Errorf("%s[%d].uri: %w", eventSourcePath, i, err)
-			}
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
The URI field is typed as *apis.URL (invalid strings fail JSON deserialization) and guarded by a CRD-level CEL rule enforcing relative paths. By the time the webhook runs, both gates have already passed — the re-parse was guaranteed to succeed.