### PR TITLE
test(webhook): add unit tests for CappMutator

### DIFF
--- a/internal/webhook/rcs/v1alpha1/fixtures_test.go
+++ b/internal/webhook/rcs/v1alpha1/fixtures_test.go
@@ -1,0 +1,109 @@
+package webhooks
+
+import (
+	"encoding/json"
+	"testing"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/dana-team/container-app-operator/internal/kinds/capp/cappmeta"
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	"github.com/stretchr/testify/require"
+	gomodulesjsonpatch "gomodules.xyz/jsonpatch/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+const (
+	cappName             = "test-capp"
+	nsName               = "test-ns"
+	testUsername         = "developer@example.com"
+	testContainerName    = "app"
+	cappCleanupFinalizer = "dana.io/capp-cleanup"
+
+	mountedNFSVolumeName      = "mounted"
+	unmountedNFSVolumeName    = "a-data"
+	eventSourceName           = "ping-a"
+	unchangedHostname         = "same.example.com"
+	oldHostname               = "old.example.com"
+	newHostname               = "new.example.com"
+	elasticHost               = "https://elastic.example.com"
+	elasticIndex              = "my-index"
+	missingSecretName         = "missing-secret"
+	missingRequiredKeyMessage = "missing required key"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(cappv1alpha1.AddToScheme(scheme))
+
+	return scheme
+}
+
+func newCappConfig() *cappv1alpha1.CappConfig {
+	return &cappv1alpha1.CappConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cappmeta.CappConfigName,
+			Namespace: cappmeta.CappNS,
+		},
+		Spec: cappv1alpha1.CappConfigSpec{
+			AllowedHostnamePatterns: []cappv1alpha1.HostnamePattern{{Match: ".*"}},
+			MaxKafkaConsumers:       5,
+			AutoscaleConfig: cappv1alpha1.AutoscaleConfig{
+				MinReplicasLimit: 10,
+				MaxScaleDelay:    100,
+				MaxReplicasLimit: 10,
+			},
+		},
+	}
+}
+
+func newCapp(hostname string) *cappv1alpha1.Capp {
+	return &cappv1alpha1.Capp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cappName,
+			Namespace: nsName,
+		},
+		Spec: cappv1alpha1.CappSpec{
+			RouteSpec: cappv1alpha1.RouteSpec{
+				Hostname: hostname,
+			},
+		},
+	}
+}
+
+func newDefaultResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+}
+
+func patchedCapp(t *testing.T, raw []byte, patches []gomodulesjsonpatch.JsonPatchOperation) cappv1alpha1.Capp {
+	t.Helper()
+
+	patchBytes, err := json.Marshal(patches)
+	require.NoError(t, err)
+
+	patch, err := jsonpatch.DecodePatch(patchBytes)
+	require.NoError(t, err)
+
+	modified, err := patch.Apply(raw)
+	require.NoError(t, err)
+
+	var capp cappv1alpha1.Capp
+	require.NoError(t, json.Unmarshal(modified, &capp))
+	return capp
+}

--- a/internal/webhook/rcs/v1alpha1/mutator_test.go
+++ b/internal/webhook/rcs/v1alpha1/mutator_test.go
@@ -1,0 +1,277 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func newCappMutator(t *testing.T, scheme *runtime.Scheme) *CappMutator {
+	t.Helper()
+
+	cfg := newCappConfig()
+	cfg.Spec.DefaultResources = newDefaultResources()
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cfg).
+		Build()
+
+	return &CappMutator{
+		Client:  fakeClient,
+		Decoder: admission.NewDecoder(scheme),
+	}
+}
+
+func TestCappMutatorHandle(t *testing.T) {
+	scheme := newScheme(t)
+	mutator := newCappMutator(t, scheme)
+
+	t.Run("skips mutation for status subresource", func(t *testing.T) {
+		capp := newCapp("")
+		raw, err := json.Marshal(capp)
+		require.NoError(t, err)
+
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				SubResource: "status",
+				Object:      runtime.RawExtension{Raw: raw},
+				Name:        cappName,
+				Namespace:   nsName,
+			},
+		}
+
+		resp := mutator.Handle(context.Background(), req)
+		require.True(t, resp.Allowed)
+		require.Empty(t, resp.Patches)
+	})
+
+	t.Run("returns error when CappConfig is missing", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		m := &CappMutator{
+			Client:  fakeClient,
+			Decoder: admission.NewDecoder(scheme),
+		}
+
+		capp := newCapp("")
+		raw, err := json.Marshal(capp)
+		require.NoError(t, err)
+
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Object:    runtime.RawExtension{Raw: raw},
+				Name:      cappName,
+				Namespace: nsName,
+			},
+		}
+
+		resp := m.Handle(context.Background(), req)
+		require.Equal(t, int32(http.StatusInternalServerError), resp.Result.Code)
+	})
+
+	t.Run("returns error on invalid object", func(t *testing.T) {
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Object: runtime.RawExtension{Raw: []byte(`{invalid`)},
+				Name:   cappName,
+			},
+		}
+
+		resp := mutator.Handle(context.Background(), req)
+		require.Equal(t, int32(http.StatusBadRequest), resp.Result.Code)
+	})
+
+	t.Run("patches annotation and default resources", func(t *testing.T) {
+		capp := &cappv1alpha1.Capp{}
+		capp.Name = cappName
+		capp.Namespace = nsName
+		capp.Spec.ConfigurationSpec.Template.Spec.Containers = []corev1.Container{
+			{Name: testContainerName},
+		}
+
+		raw, err := json.Marshal(capp)
+		require.NoError(t, err)
+
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Object:    runtime.RawExtension{Raw: raw},
+				Name:      cappName,
+				Namespace: nsName,
+				UserInfo:  authenticationv1.UserInfo{Username: testUsername},
+			},
+		}
+
+		resp := mutator.Handle(context.Background(), req)
+		require.True(t, resp.Allowed)
+		require.NotEmpty(t, resp.Patches)
+
+		patched := patchedCapp(t, raw, resp.Patches)
+		require.Equal(t, testUsername, patched.Annotations[lastUpdatedByAnnotationKey])
+
+		container := patched.Spec.ConfigurationSpec.Template.Spec.Containers[0]
+		require.Equal(t, resource.MustParse("100m"), container.Resources.Requests[corev1.ResourceCPU])
+		require.Equal(t, resource.MustParse("128Mi"), container.Resources.Requests[corev1.ResourceMemory])
+		require.Equal(t, resource.MustParse("500m"), container.Resources.Limits[corev1.ResourceCPU])
+		require.Equal(t, resource.MustParse("512Mi"), container.Resources.Limits[corev1.ResourceMemory])
+	})
+
+	t.Run("preserves existing container resources", func(t *testing.T) {
+		capp := &cappv1alpha1.Capp{}
+		capp.Name = cappName
+		capp.Namespace = nsName
+		capp.Spec.ConfigurationSpec.Template.Spec.Containers = []corev1.Container{
+			{
+				Name: testContainerName,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("200m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		raw, err := json.Marshal(capp)
+		require.NoError(t, err)
+
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Object:    runtime.RawExtension{Raw: raw},
+				Name:      cappName,
+				Namespace: nsName,
+				UserInfo:  authenticationv1.UserInfo{Username: testUsername},
+			},
+		}
+
+		resp := mutator.Handle(context.Background(), req)
+		require.True(t, resp.Allowed)
+
+		patched := patchedCapp(t, raw, resp.Patches)
+		container := patched.Spec.ConfigurationSpec.Template.Spec.Containers[0]
+		require.Equal(t, resource.MustParse("200m"), container.Resources.Requests[corev1.ResourceCPU])
+		require.Equal(t, resource.MustParse("128Mi"), container.Resources.Requests[corev1.ResourceMemory])
+		require.Equal(t, resource.MustParse("500m"), container.Resources.Limits[corev1.ResourceCPU])
+		require.Equal(t, resource.MustParse("1Gi"), container.Resources.Limits[corev1.ResourceMemory])
+	})
+}
+
+func TestMutateAnnotations(t *testing.T) {
+	t.Run("sets annotation on nil annotations map", func(t *testing.T) {
+		capp := &cappv1alpha1.Capp{}
+		mutateAnnotations(capp, testUsername)
+
+		require.Equal(t, testUsername, capp.Annotations[lastUpdatedByAnnotationKey])
+	})
+
+	t.Run("appends annotation without clobbering existing keys", func(t *testing.T) {
+		capp := &cappv1alpha1.Capp{}
+		capp.Annotations = map[string]string{"existing-key": "existing-value"}
+		mutateAnnotations(capp, testUsername)
+
+		require.Equal(t, testUsername, capp.Annotations[lastUpdatedByAnnotationKey])
+		require.Equal(t, "existing-value", capp.Annotations["existing-key"])
+	})
+}
+
+func TestMutateResources(t *testing.T) {
+	defaults := newDefaultResources()
+
+	t.Run("skips mutation when default resources are zero-valued", func(t *testing.T) {
+		capp := &cappv1alpha1.Capp{}
+		capp.Spec.ConfigurationSpec.Template.Spec.Containers = []corev1.Container{
+			{Name: testContainerName},
+		}
+
+		mutateResources(capp, corev1.ResourceRequirements{})
+
+		container := capp.Spec.ConfigurationSpec.Template.Spec.Containers[0]
+		require.Nil(t, container.Resources.Requests)
+		require.Nil(t, container.Resources.Limits)
+	})
+
+	t.Run("injects defaults when container has nil resource lists", func(t *testing.T) {
+		capp := &cappv1alpha1.Capp{}
+		capp.Spec.ConfigurationSpec.Template.Spec.Containers = []corev1.Container{
+			{Name: testContainerName},
+		}
+
+		mutateResources(capp, defaults)
+
+		container := capp.Spec.ConfigurationSpec.Template.Spec.Containers[0]
+		require.Equal(t, resource.MustParse("100m"), container.Resources.Requests[corev1.ResourceCPU])
+		require.Equal(t, resource.MustParse("128Mi"), container.Resources.Requests[corev1.ResourceMemory])
+		require.Equal(t, resource.MustParse("500m"), container.Resources.Limits[corev1.ResourceCPU])
+		require.Equal(t, resource.MustParse("512Mi"), container.Resources.Limits[corev1.ResourceMemory])
+	})
+
+	t.Run("preserves existing values and fills missing ones", func(t *testing.T) {
+		capp := &cappv1alpha1.Capp{}
+		capp.Spec.ConfigurationSpec.Template.Spec.Containers = []corev1.Container{
+			{
+				Name: testContainerName,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("250m"),
+					},
+				},
+			},
+		}
+
+		mutateResources(capp, defaults)
+
+		container := capp.Spec.ConfigurationSpec.Template.Spec.Containers[0]
+		require.Equal(t, resource.MustParse("250m"), container.Resources.Requests[corev1.ResourceCPU])
+		require.Equal(t, resource.MustParse("128Mi"), container.Resources.Requests[corev1.ResourceMemory])
+		require.Equal(t, resource.MustParse("500m"), container.Resources.Limits[corev1.ResourceCPU])
+		require.Equal(t, resource.MustParse("512Mi"), container.Resources.Limits[corev1.ResourceMemory])
+	})
+
+	t.Run("handles multiple containers independently", func(t *testing.T) {
+		capp := &cappv1alpha1.Capp{}
+		capp.Spec.ConfigurationSpec.Template.Spec.Containers = []corev1.Container{
+			{
+				Name: "first",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+			},
+			{Name: "second"},
+		}
+
+		mutateResources(capp, defaults)
+
+		first := capp.Spec.ConfigurationSpec.Template.Spec.Containers[0]
+		require.Equal(t, resource.MustParse("1"), first.Resources.Requests[corev1.ResourceCPU])
+		require.Equal(t, resource.MustParse("2Gi"), first.Resources.Limits[corev1.ResourceMemory])
+
+		second := capp.Spec.ConfigurationSpec.Template.Spec.Containers[1]
+		require.Equal(t, resource.MustParse("100m"), second.Resources.Requests[corev1.ResourceCPU])
+		require.Equal(t, resource.MustParse("512Mi"), second.Resources.Limits[corev1.ResourceMemory])
+	})
+}

--- a/internal/webhook/rcs/v1alpha1/validator_test.go
+++ b/internal/webhook/rcs/v1alpha1/validator_test.go
@@ -6,36 +6,17 @@ import (
 	"testing"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
-	"github.com/dana-team/container-app-operator/internal/kinds/capp/cappmeta"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	knativeautoscaling "knative.dev/serving/pkg/apis/autoscaling"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-)
-
-const (
-	cappCleanupFinalizer      = "dana.io/capp-cleanup"
-	cappName                  = "test-capp"
-	nsName                    = "test-ns"
-	mountedNFSVolumeName      = "mounted"
-	unmountedNFSVolumeName    = "a-data"
-	eventSourceName           = "ping-a"
-	unchangedHostname         = "same.example.com"
-	oldHostname               = "old.example.com"
-	newHostname               = "new.example.com"
-	elasticHost               = "https://elastic.example.com"
-	elasticIndex              = "my-index"
-	missingSecretName         = "missing-secret"
-	missingRequiredKeyMessage = "missing required key"
 )
 
 func TestCappValidatorHandle(t *testing.T) {
@@ -516,12 +497,12 @@ func TestValidateKafkaSourceConsumers(t *testing.T) {
 	}{
 		{
 			name:         "allows consumers within capacity",
-			cfg:          &cappv1alpha1.KafkaSourceConfiguration{Consumers: ptrInt32(3)},
+			cfg:          &cappv1alpha1.KafkaSourceConfiguration{Consumers: ptr.To(int32(3))},
 			maxConsumers: 5,
 		},
 		{
 			name:         "rejects consumers above capacity",
-			cfg:          &cappv1alpha1.KafkaSourceConfiguration{Consumers: ptrInt32(6)},
+			cfg:          &cappv1alpha1.KafkaSourceConfiguration{Consumers: ptr.To(int32(6))},
 			maxConsumers: 5,
 			wantErrContains: []string{
 				"consumers",
@@ -718,16 +699,6 @@ func TestValidateScaleSpec(t *testing.T) {
 	}
 }
 
-func newScheme(t *testing.T) *runtime.Scheme {
-	t.Helper()
-
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(cappv1alpha1.AddToScheme(scheme))
-
-	return scheme
-}
-
 func newCappValidator(t *testing.T, scheme *runtime.Scheme, decoder admission.Decoder) *CappValidator {
 	t.Helper()
 
@@ -739,41 +710,5 @@ func newCappValidator(t *testing.T, scheme *runtime.Scheme, decoder admission.De
 	return &CappValidator{
 		Client:  fakeClient,
 		Decoder: decoder,
-	}
-}
-
-func newCappConfig() *cappv1alpha1.CappConfig {
-	return &cappv1alpha1.CappConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cappmeta.CappConfigName,
-			Namespace: cappmeta.CappNS,
-		},
-		Spec: cappv1alpha1.CappConfigSpec{
-			AllowedHostnamePatterns: []cappv1alpha1.HostnamePattern{{Match: ".*"}},
-			MaxKafkaConsumers:       5,
-			AutoscaleConfig: cappv1alpha1.AutoscaleConfig{
-				MinReplicasLimit: 10,
-				MaxScaleDelay:    100,
-				MaxReplicasLimit: 10,
-			},
-		},
-	}
-}
-
-func ptrInt32(v int32) *int32 {
-	return &v
-}
-
-func newCapp(hostname string) *cappv1alpha1.Capp {
-	return &cappv1alpha1.Capp{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cappName,
-			Namespace: nsName,
-		},
-		Spec: cappv1alpha1.CappSpec{
-			RouteSpec: cappv1alpha1.RouteSpec{
-				Hostname: hostname,
-			},
-		},
 	}
 }


### PR DESCRIPTION
Covers mutation, annotation injection, and default resource assignment including edge cases. Shared test fixtures extracted to a single file used by both validator and mutator suites.

#691 