### PR TITLE
fix(reconcile): enforce deterministic resource manager execution order

### DIFF
--- a/internal/kinds/capp/controllers/controller.go
+++ b/internal/kinds/capp/controllers/controller.go
@@ -363,16 +363,16 @@ func (r *CappReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, fmt.Errorf("failed to get CappConfig: %w", err)
 	}
 
-	resourceManagers := map[string]rmanagers.ResourceManager{
-		rmanagers.KnativeService: rmanagers.KnativeServiceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder, CappConfig: cappConfig},
-		rmanagers.DNSRecord:      rmanagers.DNSRecordManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder, CappConfig: cappConfig},
-		rmanagers.Certificate:    rmanagers.CertificateManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder, CappConfig: cappConfig},
-		rmanagers.DomainMapping:  rmanagers.DomainMappingManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder, CappConfig: cappConfig},
-		rmanagers.SyslogNGFlow:   rmanagers.SyslogNGFlowManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
-		rmanagers.SyslogNGOutput: rmanagers.SyslogNGOutputManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
-		rmanagers.NfsPvc:         rmanagers.NFSPVCManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
-		rmanagers.PingSource:     rmanagers.PingSourceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
-		rmanagers.KafkaSource:    rmanagers.KafkaSourceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder},
+	resourceManagers := []rmanagers.ResourceManagerEntry{
+		{Name: rmanagers.KnativeService, Manager: rmanagers.KnativeServiceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder, CappConfig: cappConfig}},
+		{Name: rmanagers.NfsPvc, Manager: rmanagers.NFSPVCManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder}},
+		{Name: rmanagers.SyslogNGOutput, Manager: rmanagers.SyslogNGOutputManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder}},
+		{Name: rmanagers.SyslogNGFlow, Manager: rmanagers.SyslogNGFlowManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder}},
+		{Name: rmanagers.Certificate, Manager: rmanagers.CertificateManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder, CappConfig: cappConfig}},
+		{Name: rmanagers.DomainMapping, Manager: rmanagers.DomainMappingManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder, CappConfig: cappConfig}},
+		{Name: rmanagers.DNSRecord, Manager: rmanagers.DNSRecordManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder, CappConfig: cappConfig}},
+		{Name: rmanagers.PingSource, Manager: rmanagers.PingSourceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder}},
+		{Name: rmanagers.KafkaSource, Manager: rmanagers.KafkaSourceManager{ResourceManagerClient: rmClient, EventRecorder: r.EventRecorder}},
 	}
 
 	deleted, err := handleResourceDeletion(ctx, capp, rmClient, resourceManagers)
@@ -400,12 +400,12 @@ func (r *CappReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 // SyncApplication manages the lifecycle of Capp.
 // It ensures all manifests are applied according to the specification and synchronizes the status accordingly.
-func (r *CappReconciler) SyncApplication(ctx context.Context, capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.ResourceManager, cappConfig *cappv1alpha1.CappConfig, logger logr.Logger) error {
-	for _, manager := range resourceManagers {
-		if err := manager.Manage(ctx, capp); err != nil {
+func (r *CappReconciler) SyncApplication(ctx context.Context, capp cappv1alpha1.Capp, resourceManagers []rmanagers.ResourceManagerEntry, cappConfig *cappv1alpha1.CappConfig, logger logr.Logger) error {
+	for _, entry := range resourceManagers {
+		if err := entry.Manager.Manage(ctx, capp); err != nil {
 			return err
 		}
 	}
 
-	return status.SyncStatus(ctx, capp, logger, r.Client, resourceManagers, cappConfig)
+	return status.SyncStatus(ctx, capp, logger, r.Client, rmanagers.ManagerMap(resourceManagers), cappConfig)
 }

--- a/internal/kinds/capp/controllers/finalizer.go
+++ b/internal/kinds/capp/controllers/finalizer.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"slices"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	rclient "github.com/dana-team/container-app-operator/internal/kinds/capp/resourceclient"
@@ -11,7 +12,7 @@ import (
 
 const cappCleanupFinalizer = "dana.io/capp-cleanup"
 
-func handleResourceDeletion(ctx context.Context, capp cappv1alpha1.Capp, rmClient rclient.ResourceManagerClient, resourceManagers map[string]rmanagers.ResourceManager) (bool, error) {
+func handleResourceDeletion(ctx context.Context, capp cappv1alpha1.Capp, rmClient rclient.ResourceManagerClient, resourceManagers []rmanagers.ResourceManagerEntry) (bool, error) {
 	if capp.DeletionTimestamp != nil {
 		if controllerutil.ContainsFinalizer(&capp, cappCleanupFinalizer) {
 			if err := finalizeCapp(ctx, capp, resourceManagers); err != nil {
@@ -28,9 +29,9 @@ func removeFinalizer(ctx context.Context, capp cappv1alpha1.Capp, rmClient rclie
 	return rmClient.UpdateResource(ctx, &capp)
 }
 
-func finalizeCapp(ctx context.Context, capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.ResourceManager) error {
-	for _, manager := range resourceManagers {
-		if err := manager.CleanUp(ctx, capp); err != nil {
+func finalizeCapp(ctx context.Context, capp cappv1alpha1.Capp, resourceManagers []rmanagers.ResourceManagerEntry) error {
+	for _, entry := range slices.Backward(resourceManagers) {
+		if err := entry.Manager.CleanUp(ctx, capp); err != nil {
 			return err
 		}
 	}

--- a/internal/kinds/capp/controllers/finalizer_test.go
+++ b/internal/kinds/capp/controllers/finalizer_test.go
@@ -134,7 +134,7 @@ func TestHandleResourceDeletion(t *testing.T) {
 		assert.NoError(t, fakeClient.Create(ctx, capp))
 
 		rmClient := rclient.ResourceManagerClient{K8sClient: fakeClient, Log: logr.Discard()}
-		managers := map[string]rmanagers.ResourceManager{stubKey: stubResourceManager{}}
+		managers := []rmanagers.ResourceManagerEntry{{Name: stubKey, Manager: stubResourceManager{}}}
 
 		deleted, err := handleResourceDeletion(ctx, *capp, rmClient, managers)
 
@@ -152,7 +152,7 @@ func TestHandleResourceDeletion(t *testing.T) {
 		assert.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: nsName}, capp))
 
 		rmClient := rclient.ResourceManagerClient{K8sClient: fakeClient, Log: logr.Discard()}
-		managers := map[string]rmanagers.ResourceManager{stubKey: stubResourceManager{}}
+		managers := []rmanagers.ResourceManagerEntry{{Name: stubKey, Manager: stubResourceManager{}}}
 
 		deleted, err := handleResourceDeletion(ctx, *capp, rmClient, managers)
 
@@ -169,7 +169,7 @@ func TestHandleResourceDeletion(t *testing.T) {
 		assert.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: nsName}, capp))
 
 		rmClient := rclient.ResourceManagerClient{K8sClient: fakeClient, Log: logr.Discard()}
-		managers := map[string]rmanagers.ResourceManager{stubKey: stubResourceManager{cleanUpErr: cleanUpErr}}
+		managers := []rmanagers.ResourceManagerEntry{{Name: stubKey, Manager: stubResourceManager{cleanUpErr: cleanUpErr}}}
 
 		deleted, err := handleResourceDeletion(ctx, *capp, rmClient, managers)
 
@@ -187,7 +187,7 @@ func TestHandleResourceDeletion(t *testing.T) {
 		assert.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: cappName, Namespace: nsName}, capp))
 
 		rmClient := rclient.ResourceManagerClient{K8sClient: fakeClient, Log: logr.Discard()}
-		managers := map[string]rmanagers.ResourceManager{stubKey: stubResourceManager{}}
+		managers := []rmanagers.ResourceManagerEntry{{Name: stubKey, Manager: stubResourceManager{}}}
 
 		deleted, err := handleResourceDeletion(ctx, *capp, rmClient, managers)
 

--- a/internal/kinds/capp/resourcemanagers/resourcemanagers.go
+++ b/internal/kinds/capp/resourcemanagers/resourcemanagers.go
@@ -12,3 +12,20 @@ type ResourceManager interface {
 	CleanUp(ctx context.Context, capp cappv1alpha1.Capp) error
 	IsRequired(capp cappv1alpha1.Capp) bool
 }
+
+// ResourceManagerEntry pairs a name with its ResourceManager so that
+// a slice can enforce deterministic execution order.
+type ResourceManagerEntry struct {
+	Name    string
+	Manager ResourceManager
+}
+
+// ManagerMap converts an ordered slice of entries into a map keyed by name,
+// for call sites that need keyed lookup (e.g. status).
+func ManagerMap(entries []ResourceManagerEntry) map[string]ResourceManager {
+	m := make(map[string]ResourceManager, len(entries))
+	for _, e := range entries {
+		m[e.Name] = e.Manager
+	}
+	return m
+}


### PR DESCRIPTION
Map iteration gave non-deterministic reconcile/finalize ordering, causing intermittent failures when resources have dependencies (e.g. Certificate before DomainMapping). An ordered slice now guarantees correct creation sequence and reverse cleanup order.

#500 