### PR TITLE
fix: expose managed-resource webhook errors in Capp status

### DIFF
--- a/api/v1alpha1/capp_types.go
+++ b/api/v1alpha1/capp_types.go
@@ -47,6 +47,10 @@ const (
 	CappReadyReasonCertificateNotReady   = "CertificateNotReady"
 	CappReadyReasonVolumesNotReady       = "VolumesNotReady"
 	CappReadyReasonEventingNotReady      = "EventingNotReady"
+
+	// CappReadyReasonManagedResourceError indicates a child resource managed by
+	// Capp could not be created or updated (e.g. rejected by an admission webhook).
+	CappReadyReasonManagedResourceError = "ManagedResourceError"
 )
 
 // CappSpec defines the desired state of Capp.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -207,6 +207,15 @@ kubectl describe capp my-app -n my-namespace         # detailed status
 
 The status section includes: `knativeObjectStatus`, `routeStatus`, `loggingStatus`, `volumesStatus`, `eventingStatus`, and `conditions`.
 
+**Diagnose failures**: the `Ready` condition in `status.conditions` reflects why a Capp isn't
+progressing. A `reason` of `ManagedResourceError` means a child resource (e.g. the Knative
+Service or DomainMapping) was rejected on create/update — often by an admission webhook — and
+the `message` includes which resource and the underlying error:
+
+```bash
+kubectl get capp my-app -n my-namespace -o jsonpath='{.status.conditions[?(@.type=="Ready")]}'
+```
+
 ## Practical Examples
 
 ### Example 1: Web Application with Custom Domain

--- a/internal/kinds/capp/controllers/controller.go
+++ b/internal/kinds/capp/controllers/controller.go
@@ -401,11 +401,33 @@ func (r *CappReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 // SyncApplication manages the lifecycle of Capp.
 // It ensures all manifests are applied according to the specification and synchronizes the status accordingly.
 func (r *CappReconciler) SyncApplication(ctx context.Context, capp cappv1alpha1.Capp, resourceManagers []rmanagers.ResourceManagerEntry, cappConfig *cappv1alpha1.CappConfig, logger logr.Logger) error {
+	var manageErrors []rmanagers.ManageError
+	var conflictErr error
+
 	for _, entry := range resourceManagers {
-		if err := entry.Manager.Manage(ctx, capp); err != nil {
-			return err
+		err := entry.Manager.Manage(ctx, capp)
+		if err == nil {
+			continue
 		}
+		// Conflicts are transient and are retried quickly by Reconcile;
+		// they are not surfaced to users in the Capp status.
+		if errors.IsConflict(err) {
+			if conflictErr == nil {
+				conflictErr = err
+			}
+			continue
+		}
+		logger.Error(err, "failed to manage resource", "resourceManager", entry.Name)
+		manageErrors = append(manageErrors, rmanagers.ManageError{Name: entry.Name, Err: err})
 	}
 
-	return status.SyncStatus(ctx, capp, logger, r.Client, rmanagers.ManagerMap(resourceManagers), cappConfig)
+	if len(manageErrors) == 0 && conflictErr != nil {
+		return conflictErr
+	}
+
+	if err := status.SyncStatus(ctx, capp, logger, r.Client, rmanagers.ManagerMap(resourceManagers), cappConfig, manageErrors); err != nil {
+		return err
+	}
+
+	return rmanagers.JoinManageErrors(manageErrors)
 }

--- a/internal/kinds/capp/controllers/controller_test.go
+++ b/internal/kinds/capp/controllers/controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -9,10 +10,15 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/cappmeta"
+	rmanagers "github.com/dana-team/container-app-operator/internal/kinds/capp/resourcemanagers"
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	knativeapis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -534,4 +540,180 @@ func TestFindCappFromLabels(t *testing.T) {
 			assert.Equal(t, tt.expected, r.findCappFromLabels(ctx, tt.object))
 		})
 	}
+}
+
+// syncStubManager is a configurable rmanagers.ResourceManager used to exercise
+// SyncApplication's error-collection behavior without a real managed resource.
+type syncStubManager struct {
+	manageErr error
+	calls     *int
+}
+
+func (s syncStubManager) Manage(_ context.Context, _ cappv1alpha1.Capp) error {
+	*s.calls++
+	return s.manageErr
+}
+func (s syncStubManager) CleanUp(_ context.Context, _ cappv1alpha1.Capp) error { return nil }
+func (s syncStubManager) IsRequired(_ cappv1alpha1.Capp) bool                  { return false }
+
+// allManagerNames mirrors the manager set registered in Reconcile; SyncStatus
+// map-indexes by name so every one of these must be present in the test's managers slice.
+var allManagerNames = []string{
+	rmanagers.KnativeService,
+	rmanagers.NfsPvc,
+	rmanagers.SyslogNGOutput,
+	rmanagers.SyslogNGFlow,
+	rmanagers.Certificate,
+	rmanagers.DomainMapping,
+	rmanagers.DNSRecord,
+	rmanagers.PingSource,
+	rmanagers.KafkaSource,
+}
+
+// newSyncManagers builds one syncStubManager per registered manager name, failing
+// with manageErrs[name] where set, and returns the entries plus a per-name call counter.
+func newSyncManagers(manageErrs map[string]error) ([]rmanagers.ResourceManagerEntry, map[string]*int) {
+	entries := make([]rmanagers.ResourceManagerEntry, 0, len(allManagerNames))
+	calls := make(map[string]*int, len(allManagerNames))
+	for _, name := range allManagerNames {
+		count := 0
+		calls[name] = &count
+		entries = append(entries, rmanagers.ResourceManagerEntry{
+			Name:    name,
+			Manager: syncStubManager{manageErr: manageErrs[name], calls: &count},
+		})
+	}
+	return entries, calls
+}
+
+func readyConditionFromCapp(capp *cappv1alpha1.Capp) *metav1.Condition {
+	for i := range capp.Status.Conditions {
+		if capp.Status.Conditions[i].Type == conditionTypeReady {
+			return &capp.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+func TestSyncApplication(t *testing.T) {
+	ctx := context.Background()
+
+	newReconciler := func(capp *cappv1alpha1.Capp) (*CappReconciler, *cappv1alpha1.CappConfig) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(newScheme()).
+			WithObjects(capp).
+			WithStatusSubresource(&cappv1alpha1.Capp{}).
+			Build()
+		return &CappReconciler{Client: fakeClient}, &cappv1alpha1.CappConfig{}
+	}
+
+	getCapp := func(t *testing.T, r *CappReconciler) *cappv1alpha1.Capp {
+		t.Helper()
+		got := &cappv1alpha1.Capp{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Namespace: nsName, Name: cappName}, got))
+		return got
+	}
+
+	t.Run("all managers succeed", func(t *testing.T) {
+		capp := newCapp()
+		r, cappConfig := newReconciler(capp)
+		entries, calls := newSyncManagers(nil)
+
+		err := r.SyncApplication(ctx, *capp, entries, cappConfig, logr.Discard())
+		require.NoError(t, err)
+
+		for _, name := range allManagerNames {
+			assert.Equal(t, 1, *calls[name], "manager %s should have been called", name)
+		}
+
+		got := getCapp(t, r)
+		cond := readyConditionFromCapp(got)
+		require.NotNil(t, cond, "Ready condition should be set")
+		// KnativeService.IsRequired() is false here, but computeReadyCondition checks
+		// knativeNotReady unconditionally, so the cascade lands on KnativeServiceNotReady.
+		assert.Equal(t, cappv1alpha1.CappReadyReasonKnativeNotReady, cond.Reason)
+	})
+
+	t.Run("one manager fails with a non-conflict error", func(t *testing.T) {
+		capp := newCapp()
+		r, cappConfig := newReconciler(capp)
+		manageErr := errors.New("admission webhook denied the request")
+		entries, calls := newSyncManagers(map[string]error{rmanagers.KnativeService: manageErr})
+
+		err := r.SyncApplication(ctx, *capp, entries, cappConfig, logr.Discard())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, manageErr)
+
+		for _, name := range allManagerNames {
+			assert.Equal(t, 1, *calls[name], "manager %s should still have been called", name)
+		}
+
+		got := getCapp(t, r)
+		cond := readyConditionFromCapp(got)
+		require.NotNil(t, cond)
+		assert.Equal(t, metav1.ConditionFalse, cond.Status)
+		assert.Equal(t, cappv1alpha1.CappReadyReasonManagedResourceError, cond.Reason)
+		assert.Contains(t, cond.Message, rmanagers.KnativeService)
+		assert.Contains(t, cond.Message, "admission webhook denied the request")
+	})
+
+	t.Run("two managers fail", func(t *testing.T) {
+		capp := newCapp()
+		r, cappConfig := newReconciler(capp)
+		ksvcErr := errors.New("ksvc denied")
+		dmErr := errors.New("domain mapping denied")
+		entries, _ := newSyncManagers(map[string]error{
+			rmanagers.KnativeService: ksvcErr,
+			rmanagers.DomainMapping:  dmErr,
+		})
+
+		err := r.SyncApplication(ctx, *capp, entries, cappConfig, logr.Discard())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ksvcErr)
+		assert.ErrorIs(t, err, dmErr)
+
+		got := getCapp(t, r)
+		cond := readyConditionFromCapp(got)
+		require.NotNil(t, cond)
+		assert.Equal(t, cappv1alpha1.CappReadyReasonManagedResourceError, cond.Reason)
+		assert.Contains(t, cond.Message, rmanagers.KnativeService)
+		assert.Contains(t, cond.Message, rmanagers.DomainMapping)
+	})
+
+	t.Run("conflict error is quietly propagated without touching status", func(t *testing.T) {
+		capp := newCapp()
+		r, cappConfig := newReconciler(capp)
+		conflictErr := apierrors.NewConflict(schema.GroupResource{Resource: "services"}, cappName, errors.New("resourceVersion mismatch"))
+		entries, _ := newSyncManagers(map[string]error{rmanagers.KnativeService: conflictErr})
+
+		err := r.SyncApplication(ctx, *capp, entries, cappConfig, logr.Discard())
+		require.Error(t, err)
+		assert.True(t, apierrors.IsConflict(err))
+
+		got := getCapp(t, r)
+		assert.Nil(t, readyConditionFromCapp(got), "status should not be touched on a conflict-only failure")
+	})
+
+	t.Run("conflict plus real failure surfaces only the real failure", func(t *testing.T) {
+		capp := newCapp()
+		r, cappConfig := newReconciler(capp)
+		conflictErr := apierrors.NewConflict(schema.GroupResource{Resource: "services"}, cappName, errors.New("resourceVersion mismatch"))
+		realErr := errors.New("admission webhook denied the request")
+		entries, _ := newSyncManagers(map[string]error{
+			rmanagers.KnativeService: conflictErr,
+			rmanagers.DomainMapping:  realErr,
+		})
+
+		err := r.SyncApplication(ctx, *capp, entries, cappConfig, logr.Discard())
+		require.Error(t, err)
+		assert.False(t, apierrors.IsConflict(err))
+		assert.ErrorIs(t, err, realErr)
+
+		got := getCapp(t, r)
+		cond := readyConditionFromCapp(got)
+		require.NotNil(t, cond)
+		assert.Equal(t, cappv1alpha1.CappReadyReasonManagedResourceError, cond.Reason)
+		assert.Contains(t, cond.Message, rmanagers.DomainMapping)
+		assert.NotContains(t, cond.Message, rmanagers.KnativeService+":")
+	})
 }

--- a/internal/kinds/capp/controllers/finalizer_test.go
+++ b/internal/kinds/capp/controllers/finalizer_test.go
@@ -15,6 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	kafkasourcev1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/sources/v1"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,6 +45,8 @@ func newScheme() *runtime.Scheme {
 	utilruntime.Must(cappv1alpha1.AddToScheme(s))
 	utilruntime.Must(knativev1beta1.AddToScheme(s))
 	utilruntime.Must(knativev1.AddToScheme(s))
+	utilruntime.Must(sourcesv1.AddToScheme(s))
+	utilruntime.Must(kafkasourcev1.AddToScheme(s))
 	return s
 }
 

--- a/internal/kinds/capp/resourcemanagers/certificate.go
+++ b/internal/kinds/capp/resourcemanagers/certificate.go
@@ -20,6 +20,7 @@ const (
 	Certificate                        = "Certificate"
 	eventCappCertificateCreationFailed = "CertificateCreationFailed"
 	eventCappCertificateCreated        = "CertificateCreated"
+	eventCappCertificateUpdateFailed   = "CertificateUpdateFailed"
 	PrivateKeySize                     = 4096
 	maxCommonNameLength                = 64
 	certificateUIDSecretLabelKey       = "networking.internal.knative.dev/certificate-uid"
@@ -117,7 +118,8 @@ func (c CertificateManager) createOrUpdate(ctx context.Context, capp cappv1alpha
 	if err := ensureOwnerReference(c.K8sClient, &capp, &certificate, Certificate); err != nil {
 		return err
 	}
-	if err := updateManagedResourceIfNeeded(ctx, c.UpdateResource, &certificate, orig.Spec, certificate.Spec, orig.OwnerReferences); err != nil {
+	if err := updateManagedResourceIfNeeded(ctx, c.UpdateResource, &certificate, orig.Spec, certificate.Spec, orig.OwnerReferences,
+		c.EventRecorder, &capp, Certificate, eventCappCertificateUpdateFailed); err != nil {
 		return fmt.Errorf("update Certificate %q: %w", certificate.Name, err)
 	}
 

--- a/internal/kinds/capp/resourcemanagers/domainmapping.go
+++ b/internal/kinds/capp/resourcemanagers/domainmapping.go
@@ -25,6 +25,7 @@ const (
 	DomainMapping                        = "DomainMapping"
 	eventCappDomainMappingCreationFailed = "DomainMappingCreationFailed"
 	eventCappDomainMappingCreated        = "DomainMappingCreated"
+	eventCappDomainMappingUpdateFailed   = "DomainMappingUpdateFailed"
 )
 
 type DomainMappingManager struct {
@@ -148,7 +149,8 @@ func (k DomainMappingManager) createOrUpdate(ctx context.Context, capp cappv1alp
 	if err := ensureOwnerReference(k.K8sClient, &capp, &domainMapping, DomainMapping); err != nil {
 		return err
 	}
-	return updateManagedResourceIfNeeded(ctx, k.UpdateResource, &domainMapping, orig.Spec, domainMapping.Spec, orig.OwnerReferences)
+	return updateManagedResourceIfNeeded(ctx, k.UpdateResource, &domainMapping, orig.Spec, domainMapping.Spec, orig.OwnerReferences,
+		k.EventRecorder, &capp, DomainMapping, eventCappDomainMappingUpdateFailed)
 }
 
 // getPreviousDomainMappings returns a list of all DomainMapping objects that are related to the given Capp.

--- a/internal/kinds/capp/resourcemanagers/helpers.go
+++ b/internal/kinds/capp/resourcemanagers/helpers.go
@@ -50,11 +50,25 @@ func managedResourceNeedsUpdate(origSpec, newSpec any, origOwners, newOwners []m
 		!equality.Semantic.DeepEqual(origOwners, newOwners)
 }
 
-func updateManagedResourceIfNeeded(ctx context.Context, update func(context.Context, client.Object) error, obj client.Object, origSpec, newSpec any, origOwners []metav1.OwnerReference) error {
+func updateManagedResourceIfNeeded(
+	ctx context.Context,
+	update func(context.Context, client.Object) error,
+	obj client.Object,
+	origSpec, newSpec any,
+	origOwners []metav1.OwnerReference,
+	recorder events.EventRecorder,
+	capp *cappv1alpha1.Capp,
+	kind, eventFailed string,
+) error {
 	if !managedResourceNeedsUpdate(origSpec, newSpec, origOwners, obj.GetOwnerReferences()) {
 		return nil
 	}
-	return update(ctx, obj)
+	if err := update(ctx, obj); err != nil {
+		recorder.Eventf(capp, nil, corev1.EventTypeWarning, eventFailed, eventFailed,
+			fmt.Sprintf("Failed to update %s %s", kind, obj.GetName()))
+		return err
+	}
+	return nil
 }
 
 func deleteOwnedResources[T client.Object](ctx context.Context, c client.Client, capp *cappv1alpha1.Capp, resources []T) error {

--- a/internal/kinds/capp/resourcemanagers/kafkasource.go
+++ b/internal/kinds/capp/resourcemanagers/kafkasource.go
@@ -25,6 +25,7 @@ const (
 	KafkaSource                    = "KafkaSource"
 	eventKafkaSourceCreationFailed = "KafkaSourceCreationFailed"
 	eventKafkaSourceCreated        = "KafkaSourceCreated"
+	eventKafkaSourceUpdateFailed   = "KafkaSourceUpdateFailed"
 )
 
 type KafkaSourceManager struct {
@@ -90,7 +91,8 @@ func (k KafkaSourceManager) createOrUpdate(ctx context.Context, capp cappv1alpha
 	if managedResourceNeedsUpdate(orig.Spec, existing.Spec, orig.OwnerReferences, existing.OwnerReferences) {
 		k.Log.Info("Updating KafkaSource", "Name", existing.Name)
 	}
-	return updateManagedResourceIfNeeded(ctx, k.UpdateResource, existing, orig.Spec, existing.Spec, orig.OwnerReferences)
+	return updateManagedResourceIfNeeded(ctx, k.UpdateResource, existing, orig.Spec, existing.Spec, orig.OwnerReferences,
+		k.EventRecorder, &capp, KafkaSource, eventKafkaSourceUpdateFailed)
 }
 
 // prepareResource prepares a KafkaSource resource based on the provided Capp and source entry.

--- a/internal/kinds/capp/resourcemanagers/ksvc.go
+++ b/internal/kinds/capp/resourcemanagers/ksvc.go
@@ -28,6 +28,7 @@ const (
 	KnativeService                        = "KnativeService"
 	eventCappKnativeServiceCreationFailed = "KnativeServiceCreationFailed"
 	eventCappKnativeServiceCreated        = "KnativeServiceCreated"
+	eventCappKnativeServiceUpdateFailed   = "KnativeServiceUpdateFailed"
 	eventCappDisabled                     = "CappDisabled"
 	eventCappEnabled                      = "CappEnabled"
 	knativeServiceKind                    = "Service"
@@ -172,7 +173,8 @@ func (k KnativeServiceManager) createOrUpdate(ctx context.Context, capp cappv1al
 			"resourceVersion", knativeService.ResourceVersion,
 			"generation", knativeService.Generation)
 	}
-	return updateManagedResourceIfNeeded(ctx, k.UpdateResource, &knativeService, orig.Spec, knativeService.Spec, orig.OwnerReferences)
+	return updateManagedResourceIfNeeded(ctx, k.UpdateResource, &knativeService, orig.Spec, knativeService.Spec, orig.OwnerReferences,
+		k.EventRecorder, &capp, KnativeService, eventCappKnativeServiceUpdateFailed)
 }
 
 // setAutoScaler takes a Capp and returns autoscaler annotations based on the Capp's ScaleSpec.Metric value.

--- a/internal/kinds/capp/resourcemanagers/nfspvc.go
+++ b/internal/kinds/capp/resourcemanagers/nfspvc.go
@@ -22,6 +22,7 @@ const (
 	NfsPvc                    = "NfsPvc"
 	eventNFSPVCCreationFailed = "NfsPvcCreationFailed"
 	eventNFSPVCCreated        = "NfsPvcCreated"
+	eventNFSPVCUpdateFailed   = "NfsPvcUpdateFailed"
 )
 
 type NFSPVCManager struct {
@@ -116,7 +117,8 @@ func (n NFSPVCManager) createOrUpdate(ctx context.Context, capp cappv1alpha1.Cap
 			if err := ensureOwnerReference(n.K8sClient, &capp, &existingNFSPVC, NfsPvc); err != nil {
 				return err
 			}
-			if err := updateManagedResourceIfNeeded(ctx, n.UpdateResource, &existingNFSPVC, orig.Spec, existingNFSPVC.Spec, orig.OwnerReferences); err != nil {
+			if err := updateManagedResourceIfNeeded(ctx, n.UpdateResource, &existingNFSPVC, orig.Spec, existingNFSPVC.Spec, orig.OwnerReferences,
+				n.EventRecorder, &capp, NfsPvc, eventNFSPVCUpdateFailed); err != nil {
 				return err
 			}
 		}

--- a/internal/kinds/capp/resourcemanagers/pingsource.go
+++ b/internal/kinds/capp/resourcemanagers/pingsource.go
@@ -22,6 +22,7 @@ const (
 	PingSource                    = "PingSource"
 	eventPingSourceCreationFailed = "PingSourceCreationFailed"
 	eventPingSourceCreated        = "PingSourceCreated"
+	eventPingSourceUpdateFailed   = "PingSourceUpdateFailed"
 )
 
 type PingSourceManager struct {
@@ -86,7 +87,8 @@ func (p PingSourceManager) createOrUpdate(ctx context.Context, capp cappv1alpha1
 	if managedResourceNeedsUpdate(orig.Spec, existing.Spec, orig.OwnerReferences, existing.OwnerReferences) {
 		p.Log.Info("Updating PingSource", "Name", existing.Name)
 	}
-	return updateManagedResourceIfNeeded(ctx, p.UpdateResource, existing, orig.Spec, existing.Spec, orig.OwnerReferences)
+	return updateManagedResourceIfNeeded(ctx, p.UpdateResource, existing, orig.Spec, existing.Spec, orig.OwnerReferences,
+		p.EventRecorder, &capp, PingSource, eventPingSourceUpdateFailed)
 }
 
 // prepareResource prepares a PingSource resource based on the provided Capp and source entry.

--- a/internal/kinds/capp/resourcemanagers/resourcemanagers.go
+++ b/internal/kinds/capp/resourcemanagers/resourcemanagers.go
@@ -2,6 +2,8 @@ package resourcemanagers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 )
@@ -28,4 +30,25 @@ func ManagerMap(entries []ResourceManagerEntry) map[string]ResourceManager {
 		m[e.Name] = e.Manager
 	}
 	return m
+}
+
+// ManageError associates a resource manager with the failure it returned.
+type ManageError struct {
+	Name string
+	Err  error
+}
+
+func (e ManageError) Error() string { return fmt.Sprintf("%s: %v", e.Name, e.Err) }
+func (e ManageError) Unwrap() error { return e.Err }
+
+// JoinManageErrors aggregates manager failures into a single error.
+func JoinManageErrors(manageErrors []ManageError) error {
+	if len(manageErrors) == 0 {
+		return nil
+	}
+	errs := make([]error, 0, len(manageErrors))
+	for _, e := range manageErrors {
+		errs = append(errs, e)
+	}
+	return errors.Join(errs...)
 }

--- a/internal/kinds/capp/resourcemanagers/syslogngflow.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngflow.go
@@ -23,6 +23,7 @@ const (
 	SyslogNGFlow                        = "SyslogNGFlow"
 	eventCappSyslogNGFlowCreationFailed = "SyslogNGFlowCreationFailed"
 	eventCappSyslogNGFlowCreated        = "SyslogNGFlowCreated"
+	eventCappSyslogNGFlowUpdateFailed   = "SyslogNGFlowUpdateFailed"
 	knativeConfiguration                = "serving.knative.dev/configuration"
 )
 
@@ -103,5 +104,6 @@ func (f SyslogNGFlowManager) createOrUpdate(ctx context.Context, capp cappv1alph
 	if err := ensureOwnerReference(f.K8sClient, &capp, &syslogNGFlow, SyslogNGFlow); err != nil {
 		return err
 	}
-	return updateManagedResourceIfNeeded(ctx, f.UpdateResource, &syslogNGFlow, orig.Spec, syslogNGFlow.Spec, orig.OwnerReferences)
+	return updateManagedResourceIfNeeded(ctx, f.UpdateResource, &syslogNGFlow, orig.Spec, syslogNGFlow.Spec, orig.OwnerReferences,
+		f.EventRecorder, &capp, SyslogNGFlow, eventCappSyslogNGFlowUpdateFailed)
 }

--- a/internal/kinds/capp/resourcemanagers/syslogngoutput.go
+++ b/internal/kinds/capp/resourcemanagers/syslogngoutput.go
@@ -26,6 +26,7 @@ const (
 	SyslogNGOutput                        = "SyslogNGOutput"
 	eventCappSyslogNGOutputCreationFailed = "SyslogNGOutputCreationFailed"
 	eventCappSyslogNGOutputCreated        = "SyslogNGOutputCreated"
+	eventCappSyslogNGOutputUpdateFailed   = "SyslogNGOutputUpdateFailed"
 	elasticSSLVersion                     = "tlsv1_2"
 	elasticTemplate                       = "$(format-json --subkeys json# --key-delimiter #)"
 	elasticDataStreamTemplate             = "--subkeys json# --key-delimiter # --exclude DATE --key ISODATE @timestamp=${ISODATE}"
@@ -169,5 +170,6 @@ func (o SyslogNGOutputManager) createOrUpdate(ctx context.Context, capp cappv1al
 	if err := ensureOwnerReference(o.K8sClient, &capp, &syslogNGOutput, SyslogNGOutput); err != nil {
 		return err
 	}
-	return updateManagedResourceIfNeeded(ctx, o.UpdateResource, &syslogNGOutput, orig.Spec, syslogNGOutput.Spec, orig.OwnerReferences)
+	return updateManagedResourceIfNeeded(ctx, o.UpdateResource, &syslogNGOutput, orig.Spec, syslogNGOutput.Spec, orig.OwnerReferences,
+		o.EventRecorder, &capp, SyslogNGOutput, eventCappSyslogNGOutputUpdateFailed)
 }

--- a/internal/kinds/capp/status/capp.go
+++ b/internal/kinds/capp/status/capp.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"context"
+	"strings"
 
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/cappmeta"
 	rmanagers "github.com/dana-team/container-app-operator/internal/kinds/capp/resourcemanagers"
@@ -27,7 +28,7 @@ func CreateStateStatus(stateStatus *cappv1alpha1.StateStatus, cappStateFromSpec 
 }
 
 // SyncStatus updates the Capp status subresource from the observed state of its managed resources.
-func SyncStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Logger, r client.Client, resourceManagers map[string]rmanagers.ResourceManager, cappConfig *cappv1alpha1.CappConfig) error {
+func SyncStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Logger, r client.Client, resourceManagers map[string]rmanagers.ResourceManager, cappConfig *cappv1alpha1.CappConfig, manageErrors []rmanagers.ManageError) error {
 	cappObject := cappv1alpha1.Capp{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: capp.Namespace, Name: capp.Name}, &cappObject); err != nil {
 		return err
@@ -77,7 +78,7 @@ func SyncStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Logger, r 
 
 	CreateStateStatus(&cappObject.Status.StateStatus, capp.Spec.State)
 
-	buildCappConditions(&cappObject.Status, capp, resourceManagers)
+	buildCappConditions(&cappObject.Status, capp, resourceManagers, manageErrors)
 
 	if equality.Semantic.DeepEqual(
 		stripVolatileStatusFields(*oldStatus),
@@ -96,14 +97,18 @@ func SyncStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Logger, r 
 }
 
 // buildCappConditions derives top-level Capp conditions from the collected sub-statuses.
-func buildCappConditions(status *cappv1alpha1.CappStatus, capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.ResourceManager) {
-	condition := computeReadyCondition(status, capp, resourceManagers)
+func buildCappConditions(status *cappv1alpha1.CappStatus, capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.ResourceManager, manageErrors []rmanagers.ManageError) {
+	condition := computeReadyCondition(status, capp, resourceManagers, manageErrors)
 	meta.SetStatusCondition(&status.Conditions, condition)
 }
 
 // computeReadyCondition determines the Ready condition by cascading through
 // each configured sub-resource, broadcasting its own Ready status.
-func computeReadyCondition(status *cappv1alpha1.CappStatus, capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.ResourceManager) metav1.Condition {
+func computeReadyCondition(status *cappv1alpha1.CappStatus, capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.ResourceManager, manageErrors []rmanagers.ManageError) metav1.Condition {
+	if len(manageErrors) > 0 {
+		return readyFalse(cappv1alpha1.CappReadyReasonManagedResourceError, formatManageErrors(manageErrors))
+	}
+
 	if resourceManagers[rmanagers.SyslogNGFlow].IsRequired(capp) {
 		if reason, msg, ok := loggingNotReady(status.LoggingStatus); !ok {
 			return readyFalse(reason, msg)
@@ -145,6 +150,23 @@ func computeReadyCondition(status *cappv1alpha1.CappStatus, capp cappv1alpha1.Ca
 		Reason:  cappv1alpha1.CappReadyReasonReady,
 		Message: "Capp is ready",
 	}
+}
+
+const maxConditionMessageLength = 4096
+const conditionMessageTruncationSuffix = "... (truncated)"
+
+// formatManageErrors renders manager failures into a single condition message,
+// bounded to respect the CRD's condition-message size limit.
+func formatManageErrors(manageErrors []rmanagers.ManageError) string {
+	parts := make([]string, 0, len(manageErrors))
+	for _, e := range manageErrors {
+		parts = append(parts, e.Error())
+	}
+	msg := strings.Join(parts, "; ")
+	if len(msg) > maxConditionMessageLength {
+		msg = msg[:maxConditionMessageLength-len(conditionMessageTruncationSuffix)] + conditionMessageTruncationSuffix
+	}
+	return msg
 }
 
 func readyFalse(reason, message string) metav1.Condition {

--- a/internal/kinds/capp/status/capp_test.go
+++ b/internal/kinds/capp/status/capp_test.go
@@ -2,6 +2,8 @@ package status
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -129,11 +131,13 @@ func TestBuildCappConditions(t *testing.T) {
 	capp := cappv1alpha1.Capp{}
 
 	tests := []struct {
-		name           string
-		status         cappv1alpha1.CappStatus
-		enabled        map[string]bool
-		expectedStatus metav1.ConditionStatus
-		expectedReason string
+		name                    string
+		status                  cappv1alpha1.CappStatus
+		enabled                 map[string]bool
+		manageErrors            []rmanagers.ManageError
+		expectedStatus          metav1.ConditionStatus
+		expectedReason          string
+		expectedMessageContains []string
 	}{
 		{
 			name: "ready when knative is ready and no optional features enabled",
@@ -363,20 +367,120 @@ func TestBuildCappConditions(t *testing.T) {
 			expectedStatus: metav1.ConditionFalse,
 			expectedReason: cappv1alpha1.CappReadyReasonLoggingNotReady,
 		},
+
+		// --- Managed resource sync errors ---
+		{
+			name: "not ready when a managed resource failed to sync",
+			status: cappv1alpha1.CappStatus{
+				KnativeObjectStatus: knativeServiceReady(corev1.ConditionTrue),
+			},
+			enabled: map[string]bool{},
+			manageErrors: []rmanagers.ManageError{
+				{Name: rmanagers.KnativeService, Err: errors.New("admission webhook denied the request")},
+			},
+			expectedStatus:          metav1.ConditionFalse,
+			expectedReason:          cappv1alpha1.CappReadyReasonManagedResourceError,
+			expectedMessageContains: []string{rmanagers.KnativeService, "admission webhook denied the request"},
+		},
+		{
+			name: "sync error takes precedence over a not-ready sub-resource",
+			status: cappv1alpha1.CappStatus{
+				KnativeObjectStatus: knativeServiceReady(corev1.ConditionFalse),
+			},
+			enabled: map[string]bool{},
+			manageErrors: []rmanagers.ManageError{
+				{Name: rmanagers.KnativeService, Err: errors.New("admission webhook denied the request")},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: cappv1alpha1.CappReadyReasonManagedResourceError,
+		},
+		{
+			name: "sync error takes precedence over logging failure",
+			status: cappv1alpha1.CappStatus{
+				KnativeObjectStatus: knativeServiceReady(corev1.ConditionTrue),
+				LoggingStatus: cappv1alpha1.LoggingStatus{
+					Conditions: []metav1.Condition{
+						{Type: loggingReady, Status: metav1.ConditionFalse, Reason: loggingResourceInvalid, Message: "flow err"},
+					},
+				},
+			},
+			enabled: map[string]bool{rmanagers.SyslogNGFlow: true},
+			manageErrors: []rmanagers.ManageError{
+				{Name: rmanagers.DomainMapping, Err: errors.New("invalid hostname")},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: cappv1alpha1.CappReadyReasonManagedResourceError,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			status := tt.status
 			managers := buildManagers(tt.enabled)
-			buildCappConditions(&status, capp, managers)
+			buildCappConditions(&status, capp, managers, tt.manageErrors)
 
 			cond := readyCondition(&status)
 			require.NotNil(t, cond, "Ready condition should be set")
 			assert.Equal(t, tt.expectedStatus, cond.Status)
 			assert.Equal(t, tt.expectedReason, cond.Reason)
+			for _, substr := range tt.expectedMessageContains {
+				assert.Contains(t, cond.Message, substr)
+			}
 		})
 	}
+}
+
+func TestBuildCappConditionsClearsManagedResourceError(t *testing.T) {
+	capp := cappv1alpha1.Capp{}
+	managers := buildManagers(map[string]bool{})
+
+	status := cappv1alpha1.CappStatus{
+		KnativeObjectStatus: knativeServiceReady(corev1.ConditionTrue),
+	}
+	buildCappConditions(&status, capp, managers, []rmanagers.ManageError{
+		{Name: rmanagers.KnativeService, Err: errors.New("admission webhook denied the request")},
+	})
+
+	cond := readyCondition(&status)
+	require.NotNil(t, cond)
+	assert.Equal(t, cappv1alpha1.CappReadyReasonManagedResourceError, cond.Reason)
+
+	buildCappConditions(&status, capp, managers, nil)
+
+	cond = readyCondition(&status)
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, cappv1alpha1.CappReadyReasonReady, cond.Reason)
+
+	readyCount := 0
+	for _, c := range status.Conditions {
+		if c.Type == cappv1alpha1.CappConditionReady {
+			readyCount++
+		}
+	}
+	assert.Equal(t, 1, readyCount)
+}
+
+func TestFormatManageErrors(t *testing.T) {
+	t.Run("empty slice returns empty string", func(t *testing.T) {
+		assert.Equal(t, "", formatManageErrors(nil))
+	})
+
+	t.Run("joins multiple errors preserving order", func(t *testing.T) {
+		msg := formatManageErrors([]rmanagers.ManageError{
+			{Name: rmanagers.KnativeService, Err: errors.New("a")},
+			{Name: rmanagers.DomainMapping, Err: errors.New("b")},
+		})
+		assert.Equal(t, "KnativeService: a; DomainMapping: b", msg)
+	})
+
+	t.Run("truncates overly long messages", func(t *testing.T) {
+		msg := formatManageErrors([]rmanagers.ManageError{
+			{Name: rmanagers.KnativeService, Err: errors.New(strings.Repeat("x", maxConditionMessageLength*2))},
+		})
+		assert.Len(t, msg, maxConditionMessageLength)
+		assert.True(t, strings.HasSuffix(msg, conditionMessageTruncationSuffix))
+	})
 }
 
 func TestBuildCappConditionsPreservesExistingConditions(t *testing.T) {
@@ -388,7 +492,7 @@ func TestBuildCappConditionsPreservesExistingConditions(t *testing.T) {
 	}
 
 	managers := buildManagers(map[string]bool{})
-	buildCappConditions(&status, cappv1alpha1.Capp{}, managers)
+	buildCappConditions(&status, cappv1alpha1.Capp{}, managers, nil)
 
 	assert.Len(t, status.Conditions, 2)
 	cond := readyCondition(&status)


### PR DESCRIPTION
## Summary
- `SyncApplication` no longer bails on the first managed-resource error — it now runs every manager, collects failures (separating transient `IsConflict` errors, which stay silently fast-requeued as before), and always syncs status.
- New `Ready` condition reason `ManagedResourceError` surfaces child-resource create/update failures (e.g. admission webhook rejections on ksvc/DomainMapping) in `capp.status.conditions`, with a message naming the resource and the underlying error (truncated to respect the CRD's condition-message size limit).
- `updateManagedResourceIfNeeded` now emits a Warning event on update failures too (previously only create failures fired an event).
- Docs: short note in `docs/user-guide.md` on diagnosing failures via the `Ready` condition.

Closes #676

## Test plan
- [x] `make test` (go vet + full unit suite, manifest regen — no CRD/chart diff)
- [x] `make lint` (golangci-lint v2, 0 issues)
- [x] New unit tests: `status.TestBuildCappConditions` (managed-resource-error cases + precedence over sub-resource reasons), `status.TestBuildCappConditionsClearsManagedResourceError` (self-heals), `status.TestFormatManageErrors` (join + truncation), `controllers.TestSyncApplication` (all-succeed, one/two failures, conflict-only, conflict+real-failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)