### PR TITLE
refactor(status): colocate readiness checks with their domain files

### DIFF
--- a/internal/kinds/capp/status/capp.go
+++ b/internal/kinds/capp/status/capp.go
@@ -8,13 +8,11 @@ import (
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kapis "knative.dev/pkg/apis"
-	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -81,7 +79,8 @@ func SyncStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Logger, r 
 
 	CreateStateStatus(&cappObject.Status.StateStatus, capp.Spec.State)
 
-	buildCappConditions(&cappObject.Status, capp, resourceManagers, syncErrors)
+	condition := computeReadyCondition(&cappObject.Status, capp, resourceManagers, syncErrors)
+	meta.SetStatusCondition(&cappObject.Status.Conditions, condition)
 
 	if equality.Semantic.DeepEqual(
 		stripVolatileStatusFields(*oldStatus),
@@ -97,12 +96,6 @@ func SyncStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Logger, r 
 	}
 
 	return nil
-}
-
-// buildCappConditions derives top-level Capp conditions from the collected sub-statuses.
-func buildCappConditions(status *cappv1alpha1.CappStatus, capp cappv1alpha1.Capp, resourceManagers map[string]rmanagers.ResourceManager, syncErrors []error) {
-	condition := computeReadyCondition(status, capp, resourceManagers, syncErrors)
-	meta.SetStatusCondition(&status.Conditions, condition)
 }
 
 // computeReadyCondition determines the Ready condition by checking sync errors first,
@@ -172,76 +165,6 @@ func readyFalse(reason, message string) metav1.Condition {
 		Reason:  reason,
 		Message: message,
 	}
-}
-
-func loggingNotReady(ls cappv1alpha1.LoggingStatus) (string, string, bool) {
-	for _, c := range ls.Conditions {
-		if c.Status == metav1.ConditionFalse {
-			return cappv1alpha1.CappReadyReasonLoggingNotReady, c.Message, false
-		}
-	}
-	return "", "", true
-}
-
-func domainMappingNotReady(rs cappv1alpha1.RouteStatus) (string, string, bool) {
-	for _, c := range rs.DomainMappingObjectStatus.Conditions {
-		if c.Type == kapis.ConditionReady && c.Status != corev1.ConditionTrue {
-			return cappv1alpha1.CappReadyReasonDomainMappingNotReady, c.Message, false
-		}
-	}
-	return "", "", true
-}
-
-func certificateNotReady(rs cappv1alpha1.RouteStatus) (string, string, bool) {
-	for _, c := range rs.CertificateObjectStatus.Conditions {
-		if string(c.Type) == "Ready" && c.Status != "True" {
-			return cappv1alpha1.CappReadyReasonCertificateNotReady, c.Message, false
-		}
-	}
-	return "", "", true
-}
-
-func volumesNotReady(vs cappv1alpha1.VolumesStatus) (string, string, bool) {
-	for _, v := range vs.NFSVolumesStatus {
-		if v.NFSPVCStatus.PvPhase != string(corev1.VolumeBound) ||
-			v.NFSPVCStatus.PvcPhase != string(corev1.ClaimBound) {
-			return cappv1alpha1.CappReadyReasonVolumesNotReady,
-				"NFS volume " + v.VolumeName + " is not bound", false
-		}
-	}
-	return "", "", true
-}
-
-func eventingNotReady(es cappv1alpha1.EventingStatus) (string, string, bool) {
-	for _, src := range es.EventSources {
-		if src.Condition.Status != corev1.ConditionTrue {
-			return cappv1alpha1.CappReadyReasonEventingNotReady,
-				"event source " + src.Name + " is not ready", false
-		}
-	}
-	return "", "", true
-}
-
-func knativeNotReady(ks knativev1.ServiceStatus) (string, string, bool) {
-	if len(ks.Conditions) == 0 {
-		return cappv1alpha1.CappReadyReasonKnativeNotReady, "Knative Service has no status yet", false
-	}
-
-	if ks.LatestCreatedRevisionName != "" &&
-		ks.LatestCreatedRevisionName != ks.LatestReadyRevisionName {
-		return cappv1alpha1.CappReadyReasonKnativeNotReady,
-			"latest revision " + ks.LatestCreatedRevisionName + " is not ready", false
-	}
-
-	for _, c := range ks.Conditions {
-		if c.Type == kapis.ConditionReady {
-			if c.Status == corev1.ConditionTrue {
-				return "", "", true
-			}
-			return cappv1alpha1.CappReadyReasonKnativeNotReady, c.Message, false
-		}
-	}
-	return cappv1alpha1.CappReadyReasonKnativeNotReady, "Knative Service Ready condition not found", false
 }
 
 // stripVolatileStatusFields clears condition transition timestamps for status comparison.

--- a/internal/kinds/capp/status/capp_test.go
+++ b/internal/kinds/capp/status/capp_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -422,7 +423,8 @@ func TestBuildCappConditions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			status := tt.status
 			managers := buildManagers(tt.enabled)
-			buildCappConditions(&status, capp, managers, tt.syncErrors)
+			condition := computeReadyCondition(&status, capp, managers, tt.syncErrors)
+			meta.SetStatusCondition(&status.Conditions, condition)
 
 			cond := readyCondition(&status)
 			require.NotNil(t, cond, "Ready condition should be set")
@@ -453,7 +455,8 @@ func TestBuildCappConditionsPreservesExistingConditions(t *testing.T) {
 	}
 
 	managers := buildManagers(map[string]bool{})
-	buildCappConditions(&status, cappv1alpha1.Capp{}, managers, nil)
+	condition := computeReadyCondition(&status, cappv1alpha1.Capp{}, managers, nil)
+	meta.SetStatusCondition(&status.Conditions, condition)
 
 	assert.Len(t, status.Conditions, 2)
 	cond := readyCondition(&status)

--- a/internal/kinds/capp/status/eventing.go
+++ b/internal/kinds/capp/status/eventing.go
@@ -74,3 +74,13 @@ func newEventSourceStatus(name string, ready *kapis.Condition) cappv1alpha1.Even
 		Condition: condition,
 	}
 }
+
+func eventingNotReady(es cappv1alpha1.EventingStatus) (string, string, bool) {
+	for _, src := range es.EventSources {
+		if src.Condition.Status != corev1.ConditionTrue {
+			return cappv1alpha1.CappReadyReasonEventingNotReady,
+				"event source " + src.Name + " is not ready", false
+		}
+	}
+	return "", "", true
+}

--- a/internal/kinds/capp/status/logging.go
+++ b/internal/kinds/capp/status/logging.go
@@ -71,3 +71,12 @@ func buildLoggingStatus(ctx context.Context, capp cappv1alpha1.Capp, log logr.Lo
 
 	return loggingStatus, nil
 }
+
+func loggingNotReady(ls cappv1alpha1.LoggingStatus) (string, string, bool) {
+	for _, c := range ls.Conditions {
+		if c.Status == metav1.ConditionFalse {
+			return cappv1alpha1.CappReadyReasonLoggingNotReady, c.Message, false
+		}
+	}
+	return "", "", true
+}

--- a/internal/kinds/capp/status/route.go
+++ b/internal/kinds/capp/status/route.go
@@ -4,13 +4,16 @@ import (
 	"context"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 
 	rmanagers "github.com/dana-team/container-app-operator/internal/kinds/capp/resourcemanagers"
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	kapis "knative.dev/pkg/apis"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -113,4 +116,22 @@ func buildCNAMERecordStatus(ctx context.Context, kubeClient client.Client, capp 
 	}
 
 	return cnameRecord.Status, nil
+}
+
+func domainMappingNotReady(rs cappv1alpha1.RouteStatus) (string, string, bool) {
+	for _, c := range rs.DomainMappingObjectStatus.Conditions {
+		if c.Type == kapis.ConditionReady && c.Status != corev1.ConditionTrue {
+			return cappv1alpha1.CappReadyReasonDomainMappingNotReady, c.Message, false
+		}
+	}
+	return "", "", true
+}
+
+func certificateNotReady(rs cappv1alpha1.RouteStatus) (string, string, bool) {
+	for _, c := range rs.CertificateObjectStatus.Conditions {
+		if c.Type == cmapi.CertificateConditionReady && c.Status != cmmeta.ConditionTrue {
+			return cappv1alpha1.CappReadyReasonCertificateNotReady, c.Message, false
+		}
+	}
+	return "", "", true
 }

--- a/internal/kinds/capp/status/serving.go
+++ b/internal/kinds/capp/status/serving.go
@@ -5,10 +5,12 @@ import (
 	"sort"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	kapis "knative.dev/pkg/apis"
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -84,4 +86,26 @@ func buildKnativeStatus(ctx context.Context, kubeClient client.Client, capp capp
 	}
 
 	return knativeObjectStatus, revisionInfo, nil
+}
+
+func knativeNotReady(ks knativev1.ServiceStatus) (string, string, bool) {
+	if len(ks.Conditions) == 0 {
+		return cappv1alpha1.CappReadyReasonKnativeNotReady, "Knative Service has no status yet", false
+	}
+
+	if ks.LatestCreatedRevisionName != "" &&
+		ks.LatestCreatedRevisionName != ks.LatestReadyRevisionName {
+		return cappv1alpha1.CappReadyReasonKnativeNotReady,
+			"latest revision " + ks.LatestCreatedRevisionName + " is not ready", false
+	}
+
+	for _, c := range ks.Conditions {
+		if c.Type == kapis.ConditionReady {
+			if c.Status == corev1.ConditionTrue {
+				return "", "", true
+			}
+			return cappv1alpha1.CappReadyReasonKnativeNotReady, c.Message, false
+		}
+	}
+	return cappv1alpha1.CappReadyReasonKnativeNotReady, "Knative Service Ready condition not found", false
 }

--- a/internal/kinds/capp/status/volumes.go
+++ b/internal/kinds/capp/status/volumes.go
@@ -5,6 +5,7 @@ import (
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	nfspvcv1alpha1 "github.com/dana-team/nfspvc-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -40,4 +41,15 @@ func buildVolumesStatus(ctx context.Context, kubeClient client.Client, capp capp
 	}
 
 	return volumesStatus, nil
+}
+
+func volumesNotReady(vs cappv1alpha1.VolumesStatus) (string, string, bool) {
+	for _, v := range vs.NFSVolumesStatus {
+		if v.NFSPVCStatus.PvPhase != string(corev1.VolumeBound) ||
+			v.NFSPVCStatus.PvcPhase != string(corev1.ClaimBound) {
+			return cappv1alpha1.CappReadyReasonVolumesNotReady,
+				"NFS volume " + v.VolumeName + " is not bound", false
+		}
+	}
+	return "", "", true
 }


### PR DESCRIPTION
Each sub-resource readiness function (knative, logging, route, eventing, volumes) now lives next to the status builder it relates to instead of in the central capp.go. Inlines the single-use buildCappConditions wrapper and replaces hardcoded condition strings with library constants.