### PR TITLE
test(status): split readiness detection tests into domain files

### DIFF
--- a/internal/kinds/capp/status/capp_test.go
+++ b/internal/kinds/capp/status/capp_test.go
@@ -26,10 +26,9 @@ import (
 )
 
 const (
-	readyRevision    = "rev-1"
-	pendingRevision  = "rev-2"
-	pingEventSource  = "ping-src"
-	kafkaEventSource = "kafka-src"
+	readyRevision   = "rev-1"
+	pendingRevision = "rev-2"
+	pingEventSource = "ping-src"
 )
 
 type stubManager struct {
@@ -128,7 +127,7 @@ func nfsVolumesUnbound(name string) cappv1alpha1.VolumesStatus {
 	}
 }
 
-func TestBuildCappConditions(t *testing.T) {
+func TestComputeReadyCondition(t *testing.T) {
 	capp := cappv1alpha1.Capp{}
 
 	tests := []struct {
@@ -150,37 +149,9 @@ func TestBuildCappConditions(t *testing.T) {
 			expectedReason: cappv1alpha1.CappReadyReasonReady,
 		},
 		{
-			name: "not ready when knative has no conditions",
-			status: cappv1alpha1.CappStatus{
-				KnativeObjectStatus: knativev1.ServiceStatus{},
-			},
-			enabled:        map[string]bool{},
-			expectedStatus: metav1.ConditionFalse,
-			expectedReason: cappv1alpha1.CappReadyReasonKnativeNotReady,
-		},
-		{
 			name: "not ready when knative is not ready",
 			status: cappv1alpha1.CappStatus{
 				KnativeObjectStatus: knativeServiceReady(corev1.ConditionFalse),
-			},
-			enabled:        map[string]bool{},
-			expectedStatus: metav1.ConditionFalse,
-			expectedReason: cappv1alpha1.CappReadyReasonKnativeNotReady,
-		},
-		{
-			name: "not ready when latest revision differs from latest ready",
-			status: cappv1alpha1.CappStatus{
-				KnativeObjectStatus: knativev1.ServiceStatus{
-					Status: duckv1.Status{
-						Conditions: duckv1.Conditions{
-							{Type: kapis.ConditionReady, Status: corev1.ConditionTrue},
-						},
-					},
-					ConfigurationStatusFields: knativev1.ConfigurationStatusFields{
-						LatestCreatedRevisionName: pendingRevision,
-						LatestReadyRevisionName:   readyRevision,
-					},
-				},
 			},
 			enabled:        map[string]bool{},
 			expectedStatus: metav1.ConditionFalse,
@@ -305,52 +276,6 @@ func TestBuildCappConditions(t *testing.T) {
 			enabled:        map[string]bool{rmanagers.PingSource: true},
 			expectedStatus: metav1.ConditionFalse,
 			expectedReason: cappv1alpha1.CappReadyReasonEventingNotReady,
-		},
-		{
-			name: "ready when PingSource enabled and all event sources ready",
-			status: cappv1alpha1.CappStatus{
-				KnativeObjectStatus: knativeServiceReady(corev1.ConditionTrue),
-				EventingStatus: cappv1alpha1.EventingStatus{
-					EventSources: []cappv1alpha1.EventSourceStatus{
-						{Name: pingEventSource, Condition: kapis.Condition{Status: corev1.ConditionTrue}},
-					},
-				},
-			},
-			enabled:        map[string]bool{rmanagers.PingSource: true},
-			expectedStatus: metav1.ConditionTrue,
-			expectedReason: cappv1alpha1.CappReadyReasonReady,
-		},
-		{
-			name: "not ready when KafkaSource enabled and event source not ready",
-			status: cappv1alpha1.CappStatus{
-				KnativeObjectStatus: knativeServiceReady(corev1.ConditionTrue),
-				EventingStatus: cappv1alpha1.EventingStatus{
-					EventSources: []cappv1alpha1.EventSourceStatus{
-						{Name: kafkaEventSource, Condition: kapis.Condition{Status: corev1.ConditionFalse}},
-					},
-				},
-			},
-			enabled:        map[string]bool{rmanagers.KafkaSource: true},
-			expectedStatus: metav1.ConditionFalse,
-			expectedReason: cappv1alpha1.CappReadyReasonEventingNotReady,
-		},
-		{
-			name: "ready when mixed event sources enabled and all ready",
-			status: cappv1alpha1.CappStatus{
-				KnativeObjectStatus: knativeServiceReady(corev1.ConditionTrue),
-				EventingStatus: cappv1alpha1.EventingStatus{
-					EventSources: []cappv1alpha1.EventSourceStatus{
-						{Name: pingEventSource, Condition: kapis.Condition{Status: corev1.ConditionTrue}},
-						{Name: kafkaEventSource, Condition: kapis.Condition{Status: corev1.ConditionTrue}},
-					},
-				},
-			},
-			enabled: map[string]bool{
-				rmanagers.PingSource:  true,
-				rmanagers.KafkaSource: true,
-			},
-			expectedStatus: metav1.ConditionTrue,
-			expectedReason: cappv1alpha1.CappReadyReasonReady,
 		},
 
 		// --- Cascade order: logging before knative ---

--- a/internal/kinds/capp/status/eventing_test.go
+++ b/internal/kinds/capp/status/eventing_test.go
@@ -7,6 +7,7 @@ import (
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/container-app-operator/internal/kinds/capp/cappmeta"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,6 +166,54 @@ func TestNewEventSourceStatus(t *testing.T) {
 			require.Equal(t, tt.wantMessage, result.Condition.Message)
 			if tt.wantReason != "" {
 				require.Equal(t, tt.wantReason, result.Condition.Reason)
+			}
+		})
+	}
+}
+
+func TestEventingNotReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     cappv1alpha1.EventingStatus
+		wantReason string
+		wantMsg    string
+		wantOK     bool
+	}{
+		{
+			name:   "ready when no event sources exist",
+			status: cappv1alpha1.EventingStatus{},
+			wantOK: true,
+		},
+		{
+			name: "ready when all event sources are ready",
+			status: cappv1alpha1.EventingStatus{
+				EventSources: []cappv1alpha1.EventSourceStatus{
+					{Name: "src-a", Condition: kapis.Condition{Status: corev1.ConditionTrue}},
+					{Name: "src-b", Condition: kapis.Condition{Status: corev1.ConditionTrue}},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "not ready when an event source is not ready",
+			status: cappv1alpha1.EventingStatus{
+				EventSources: []cappv1alpha1.EventSourceStatus{
+					{Name: "src-a", Condition: kapis.Condition{Status: corev1.ConditionTrue}},
+					{Name: "src-b", Condition: kapis.Condition{Status: corev1.ConditionFalse}},
+				},
+			},
+			wantReason: cappv1alpha1.CappReadyReasonEventingNotReady,
+			wantMsg:    "event source src-b is not ready",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, msg, ok := eventingNotReady(tt.status)
+			assert.Equal(t, tt.wantOK, ok)
+			if !ok {
+				assert.Equal(t, tt.wantReason, reason)
+				assert.Equal(t, tt.wantMsg, msg)
 			}
 		})
 	}

--- a/internal/kinds/capp/status/logging_test.go
+++ b/internal/kinds/capp/status/logging_test.go
@@ -112,3 +112,49 @@ func TestBuildLoggingStatus(t *testing.T) {
 		assert.Equal(t, loggingResourceInvalid, result.Conditions[0].Reason)
 	})
 }
+
+func TestLoggingNotReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     cappv1alpha1.LoggingStatus
+		wantReason string
+		wantMsg    string
+		wantOK     bool
+	}{
+		{
+			name:   "ready when logging has no conditions",
+			status: cappv1alpha1.LoggingStatus{},
+			wantOK: true,
+		},
+		{
+			name: "ready when all conditions are true",
+			status: cappv1alpha1.LoggingStatus{
+				Conditions: []metav1.Condition{
+					{Type: loggingReady, Status: metav1.ConditionTrue, Reason: conditionReady},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "not ready when a condition is false",
+			status: cappv1alpha1.LoggingStatus{
+				Conditions: []metav1.Condition{
+					{Type: loggingReady, Status: metav1.ConditionFalse, Reason: loggingResourceInvalid, Message: "syslogng flow invalid"},
+				},
+			},
+			wantReason: cappv1alpha1.CappReadyReasonLoggingNotReady,
+			wantMsg:    "syslogng flow invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, msg, ok := loggingNotReady(tt.status)
+			assert.Equal(t, tt.wantOK, ok)
+			if !ok {
+				assert.Equal(t, tt.wantReason, reason)
+				assert.Equal(t, tt.wantMsg, msg)
+			}
+		})
+	}
+}

--- a/internal/kinds/capp/status/route_test.go
+++ b/internal/kinds/capp/status/route_test.go
@@ -12,10 +12,12 @@ import (
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns-v2/apis/namespaced/record/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -255,4 +257,108 @@ func TestBuildCNAMERecordStatus(t *testing.T) {
 		require.NotNil(t, result.AtProvider.Cname)
 		assert.Equal(t, target, *result.AtProvider.Cname)
 	})
+}
+
+func TestDomainMappingNotReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     cappv1alpha1.RouteStatus
+		wantReason string
+		wantMsg    string
+		wantOK     bool
+	}{
+		{
+			name:   "ready when domain mapping has no conditions",
+			status: cappv1alpha1.RouteStatus{},
+			wantOK: true,
+		},
+		{
+			name: "ready when domain mapping Ready condition is true",
+			status: cappv1alpha1.RouteStatus{
+				DomainMappingObjectStatus: knativev1beta1.DomainMappingStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{Type: apis.ConditionReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "not ready when domain mapping Ready condition is false",
+			status: cappv1alpha1.RouteStatus{
+				DomainMappingObjectStatus: knativev1beta1.DomainMappingStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{Type: apis.ConditionReady, Status: corev1.ConditionFalse, Message: "DNS not propagated"},
+						},
+					},
+				},
+			},
+			wantReason: cappv1alpha1.CappReadyReasonDomainMappingNotReady,
+			wantMsg:    "DNS not propagated",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, msg, ok := domainMappingNotReady(tt.status)
+			assert.Equal(t, tt.wantOK, ok)
+			if !ok {
+				assert.Equal(t, tt.wantReason, reason)
+				assert.Equal(t, tt.wantMsg, msg)
+			}
+		})
+	}
+}
+
+func TestCertificateNotReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     cappv1alpha1.RouteStatus
+		wantReason string
+		wantMsg    string
+		wantOK     bool
+	}{
+		{
+			name:   "ready when certificate has no conditions",
+			status: cappv1alpha1.RouteStatus{},
+			wantOK: true,
+		},
+		{
+			name: "ready when certificate Ready condition is true",
+			status: cappv1alpha1.RouteStatus{
+				CertificateObjectStatus: cmapi.CertificateStatus{
+					Conditions: []cmapi.CertificateCondition{
+						{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue},
+					},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "not ready when certificate Ready condition is false",
+			status: cappv1alpha1.RouteStatus{
+				CertificateObjectStatus: cmapi.CertificateStatus{
+					Conditions: []cmapi.CertificateCondition{
+						{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionFalse, Message: "issuer not found"},
+					},
+				},
+			},
+			wantReason: cappv1alpha1.CappReadyReasonCertificateNotReady,
+			wantMsg:    "issuer not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, msg, ok := certificateNotReady(tt.status)
+			assert.Equal(t, tt.wantOK, ok)
+			if !ok {
+				assert.Equal(t, tt.wantReason, reason)
+				assert.Equal(t, tt.wantMsg, msg)
+			}
+		})
+	}
 }

--- a/internal/kinds/capp/status/serving_test.go
+++ b/internal/kinds/capp/status/serving_test.go
@@ -8,9 +8,12 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	kapis "knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -120,4 +123,95 @@ func TestBuildRevisionsStatus(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, revisions)
 	})
+}
+
+func TestKnativeNotReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     knativev1.ServiceStatus
+		wantReason string
+		wantMsg    string
+		wantOK     bool
+	}{
+		{
+			name:       "not ready when no conditions exist",
+			status:     knativev1.ServiceStatus{},
+			wantReason: cappv1alpha1.CappReadyReasonKnativeNotReady,
+			wantMsg:    "Knative Service has no status yet",
+		},
+		{
+			name: "not ready when knative Ready condition is false",
+			status: knativev1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{Type: kapis.ConditionReady, Status: corev1.ConditionFalse, Message: "image pull failed"},
+					},
+				},
+				ConfigurationStatusFields: knativev1.ConfigurationStatusFields{
+					LatestCreatedRevisionName: readyRevision,
+					LatestReadyRevisionName:   readyRevision,
+				},
+			},
+			wantReason: cappv1alpha1.CappReadyReasonKnativeNotReady,
+			wantMsg:    "image pull failed",
+		},
+		{
+			name: "not ready when latest revision differs from latest ready",
+			status: knativev1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{Type: kapis.ConditionReady, Status: corev1.ConditionTrue},
+					},
+				},
+				ConfigurationStatusFields: knativev1.ConfigurationStatusFields{
+					LatestCreatedRevisionName: pendingRevision,
+					LatestReadyRevisionName:   readyRevision,
+				},
+			},
+			wantReason: cappv1alpha1.CappReadyReasonKnativeNotReady,
+			wantMsg:    "latest revision " + pendingRevision + " is not ready",
+		},
+		{
+			name: "not ready when Ready condition is missing from non-empty conditions",
+			status: knativev1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{Type: "ConfigurationsReady", Status: corev1.ConditionTrue},
+					},
+				},
+				ConfigurationStatusFields: knativev1.ConfigurationStatusFields{
+					LatestCreatedRevisionName: readyRevision,
+					LatestReadyRevisionName:   readyRevision,
+				},
+			},
+			wantReason: cappv1alpha1.CappReadyReasonKnativeNotReady,
+			wantMsg:    "Knative Service Ready condition not found",
+		},
+		{
+			name: "ready when Ready condition is true and revisions match",
+			status: knativev1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{Type: kapis.ConditionReady, Status: corev1.ConditionTrue},
+					},
+				},
+				ConfigurationStatusFields: knativev1.ConfigurationStatusFields{
+					LatestCreatedRevisionName: readyRevision,
+					LatestReadyRevisionName:   readyRevision,
+				},
+			},
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, msg, ok := knativeNotReady(tt.status)
+			assert.Equal(t, tt.wantOK, ok)
+			if !ok {
+				assert.Equal(t, tt.wantReason, reason)
+				assert.Equal(t, tt.wantMsg, msg)
+			}
+		})
+	}
 }

--- a/internal/kinds/capp/status/volumes_test.go
+++ b/internal/kinds/capp/status/volumes_test.go
@@ -102,3 +102,41 @@ func TestBuildVolumesStatus(t *testing.T) {
 		assert.Equal(t, nfspvcv1alpha1.NfsPvcStatus{}, result.NFSVolumesStatus[1].NFSPVCStatus)
 	})
 }
+
+func TestVolumesNotReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     cappv1alpha1.VolumesStatus
+		wantReason string
+		wantMsg    string
+		wantOK     bool
+	}{
+		{
+			name:   "ready when no volumes exist",
+			status: cappv1alpha1.VolumesStatus{},
+			wantOK: true,
+		},
+		{
+			name:   "ready when all volumes are bound",
+			status: nfsVolumesBound("vol-a", "vol-b"),
+			wantOK: true,
+		},
+		{
+			name:       "not ready when PV is not bound",
+			status:     nfsVolumesUnbound("shared-data"),
+			wantReason: cappv1alpha1.CappReadyReasonVolumesNotReady,
+			wantMsg:    "NFS volume shared-data is not bound",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, msg, ok := volumesNotReady(tt.status)
+			assert.Equal(t, tt.wantOK, ok)
+			if !ok {
+				assert.Equal(t, tt.wantReason, reason)
+				assert.Equal(t, tt.wantMsg, msg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Move detection-focused test cases out of the monolithic composition test into dedicated unit tests (knative, logging, route, volumes, eventing) co-located with the code under test. The composition test is renamed and trimmed to cover only wiring, IsRequired guards, cascade priority, and sync errors.